### PR TITLE
feat(ENGDESK-3732): add support to pass host and port by url parameters

### DIFF
--- a/examples/react/stories/2-WebDialer.stories.js
+++ b/examples/react/stories/2-WebDialer.stories.js
@@ -326,7 +326,10 @@ const WebDialer = ({
 const getUrlParams = () => {
   const queryString = window.location.search;
   if (!queryString) {
-    return null;
+    return {
+      host: null,
+      port: null,
+    };
   }
 
   const urlParams = new URLSearchParams(queryString);

--- a/examples/react/stories/2-WebDialer.stories.js
+++ b/examples/react/stories/2-WebDialer.stories.js
@@ -184,8 +184,6 @@ const WebDialer = ({
   defaultDestination,
   callerName,
   callerNumber,
-  host,
-  port,
 }) => {
   const clientRef = useRef();
   const mediaRef = useRef();
@@ -219,7 +217,7 @@ const WebDialer = ({
   };
 
   const connectAndCall = () => {
-    const configsTelnyxRTC = {
+    const newClient = new TelnyxRTC({
       env: environment,
       credentials: {
         username,
@@ -229,15 +227,7 @@ const WebDialer = ({
       useMic: true,
       useSpeaker: true,
       useCamera: false,
-    };
-
-    // These parameters comes from URL Params
-    if (host && port) {
-      configsTelnyxRTC['host'] = host;
-      configsTelnyxRTC['port'] = port;
-    }
-
-    const newClient = new TelnyxRTC(configsTelnyxRTC)
+    })
       .on('registered', () => {
         setRegistered(true);
         setRegistering(false);
@@ -323,23 +313,6 @@ const WebDialer = ({
   );
 };
 
-const getUrlParams = () => {
-  const queryString = window.location.search;
-  if (!queryString) {
-    return {
-      host: null,
-      port: null,
-    };
-  }
-
-  const urlParams = new URLSearchParams(queryString);
-
-  return {
-    host: urlParams.get('host') || null,
-    port: urlParams.get('port') || null,
-  };
-};
-
 export const Example = () => {
   const production = boolean('Production', true);
   const username = text('Connection Username', 'username');
@@ -347,13 +320,6 @@ export const Example = () => {
   const defaultDestination = text('Default Destination', '18004377950');
   const callerName = text('Caller Name', 'Caller ID Name');
   const callerNumber = text('Caller Number', 'Caller ID Number');
-  let host = null;
-  let port = null;
-  const configs = getUrlParams();
-  if (configs.host && configs.port) {
-    host = text('Hostname', configs.host);
-    port = text('Port', configs.port);
-  }
 
   return (
     <WebDialer
@@ -363,8 +329,6 @@ export const Example = () => {
       defaultDestination={defaultDestination}
       callerName={callerName}
       callerNumber={callerNumber}
-      host={host}
-      port={port}
     />
   );
 };

--- a/examples/react/stories/2-WebDialer.stories.js
+++ b/examples/react/stories/2-WebDialer.stories.js
@@ -184,6 +184,8 @@ const WebDialer = ({
   defaultDestination,
   callerName,
   callerNumber,
+  host,
+  port,
 }) => {
   const clientRef = useRef();
   const mediaRef = useRef();
@@ -217,7 +219,7 @@ const WebDialer = ({
   };
 
   const connectAndCall = () => {
-    const newClient = new TelnyxRTC({
+    const configsTelnyxRTC = {
       env: environment,
       credentials: {
         username,
@@ -227,7 +229,15 @@ const WebDialer = ({
       useMic: true,
       useSpeaker: true,
       useCamera: false,
-    })
+    };
+
+    // These parameters comes from URL Params
+    if (host && port) {
+      configsTelnyxRTC['host'] = host;
+      configsTelnyxRTC['port'] = port;
+    }
+
+    const newClient = new TelnyxRTC(configsTelnyxRTC)
       .on('registered', () => {
         setRegistered(true);
         setRegistering(false);
@@ -313,6 +323,20 @@ const WebDialer = ({
   );
 };
 
+const getUrlParams = () => {
+  const queryString = window.location.search;
+  if (!queryString) {
+    return null;
+  }
+
+  const urlParams = new URLSearchParams(queryString);
+
+  return {
+    host: urlParams.get('host') || null,
+    port: urlParams.get('port') || null,
+  };
+};
+
 export const Example = () => {
   const production = boolean('Production', true);
   const username = text('Connection Username', 'username');
@@ -320,6 +344,13 @@ export const Example = () => {
   const defaultDestination = text('Default Destination', '18004377950');
   const callerName = text('Caller Name', 'Caller ID Name');
   const callerNumber = text('Caller Number', 'Caller ID Number');
+  let host = null;
+  let port = null;
+  const configs = getUrlParams();
+  if (configs.host && configs.port) {
+    host = text('Hostname', configs.host);
+    port = text('Port', configs.port);
+  }
 
   return (
     <WebDialer
@@ -329,6 +360,8 @@ export const Example = () => {
       defaultDestination={defaultDestination}
       callerName={callerName}
       callerNumber={callerNumber}
+      host={host}
+      port={port}
     />
   );
 };

--- a/src/VertoClient/VertoClient.ts
+++ b/src/VertoClient/VertoClient.ts
@@ -28,7 +28,7 @@ export default class VertoClient extends BaseClient {
 
   constructor(o?: IClientOptions) {
     super(o);
-    this.host = HOST;
+    this.host = this.host || HOST;
     this.port =
       this.port || (this.env === 'development' ? VERTO_DEV_PORT : VERTO_PORT);
   }


### PR DESCRIPTION
[ENGDESK-3732](https://telnyx.atlassian.net/browse/ENGDESK-3732)

add support to pass hostname and port by url parameters

## 📝 To Do

- [x] All linters pass
- [x] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

1. cd examples/react
2. access this url http://localhost:6006/?path=/story/webdialer--example
3. put whatever you want in query string url
     For example:
     http://localhost:6006/?path=/story/webdialer--example&host=rtc.telnyx.com&port=1500  
4. See if show more two options in layout host and port

## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [x] Chrome
- [ ] Firefox
- [ ] Safari

## 📸 Screenshots

| Description | Screenshot |
| ----------- | ---------- |
| Desktop     | ![image](https://user-images.githubusercontent.com/16343871/72352280-bcf4c500-36c0-11ea-9869-4b77421f47a1.png)|
| Desktop 2 | ![image](https://user-images.githubusercontent.com/16343871/72352176-87e87280-36c0-11ea-966f-e871ae454843.png)|