### PR TITLE
chore(deps): upgrade ts to fix type declarations

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6614,9 +6614,9 @@
       }
     },
     "typescript": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.2.tgz",
-      "integrity": "sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==",
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
+      "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "ts-jest": "^24.1.0",
     "typedoc": "^0.15.0",
     "typedoc-plugin-markdown": "^2.2.6",
-    "typescript": "^3.6.2",
+    "typescript": "^3.7.5",
     "uuid": "^3.3.2",
     "webrtc-adapter": "^7.3.0"
   },


### PR DESCRIPTION
Fixes the following build error on import in Angular projects:
```shell
ERROR in node_modules/@telnyx/webrtc/lib/BaseClient.d.ts:1:26 - error TS2307: Cannot find module './TypedEmitter'.

1 import TypedEmitter from './TypedEmitter';
                           ~~~~~~~~~~~~~~~~
node_modules/@telnyx/webrtc/lib/Verto/Verto.d.ts:1:28 - error TS2307: Cannot find module './LiveArray'.

1 import VertoLiveArray from './LiveArray';
                             ~~~~~~~~~~~~~
node_modules/@telnyx/webrtc/lib/Verto/Verto.d.ts:2:23 - error TS2307: Cannot find module './ConfMan'.

2 import VertoConf from './ConfMan';
                        ~~~~~~~~~~~
node_modules/@telnyx/webrtc/lib/Verto/Verto.d.ts:3:25 - error TS2307: Cannot find module './Dialog'.

3 import VertoDialog from './Dialog';
```

See https://github.com/microsoft/TypeScript/issues/7546#issuecomment-535699638

## Manual testing

1. Run `npm link` 
2. Outside of this repo, generate new project with [Angular CLI](https://github.com/angular/angular-cli) and install `@telnyx/webrtc`
3. From the Angular project, run `npm link @telnyx/webrtc`
4. Import `TelnyxRTC` and start app with `ng serve`. App should compile without errors