### PR TITLE
fix(WEBRTC-54):  add support to make and receive call in Safari  

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+Describe your changes
+
+## 📝 To Do
+
+- [ ] All linters pass
+- [ ] All tests pass
+- [ ] Change documentation based on my changes
+
+## ✋ Manual testing
+
+1. Provide manual testing instructions
+
+## 🦊 Browser testing
+
+### Desktop
+
+- [ ] Edge (latest)
+- [ ] Chrome
+- [ ] Firefox
+- [ ] Safari
+
+## 📸 Screenshots
+
+| Description | Screenshot |
+| ----------- | ---------- |
+| Desktop     |            |
+| usage.gif   |            |

--- a/examples/react/stories/2-WebDialer.stories.js
+++ b/examples/react/stories/2-WebDialer.stories.js
@@ -76,6 +76,24 @@ const DialPadContainer = styled.div`
   }
 `;
 
+const ButtonAnswer = styled.button`
+  color: #fff !important;
+  border-radius: 50%;
+  width: 80px !important;
+  height: 80px !important;
+  background-color: #1ea7fd;
+  cursor: pointer;
+`;
+
+const ButtonEnd = styled.button`
+  cursor: pointer;
+  color: #fff !important;
+  border-radius: 50%;
+  width: 80px !important;
+  height: 80px !important;
+  background-color: #ff6666;
+`;
+
 const DialPad = ({
   call,
   onDigit,
@@ -90,88 +108,117 @@ const DialPad = ({
   const muted = call && call.isMuted;
   const makeSendDigit = (x) => () => onDigit(x);
 
+  const isInbound = call && call.call.direction === 'inbound';
+  const isIncomingCall = isInbound && call.state === 'new';
+
+  const answerCall = () => {
+    if (call) {
+      call.answer();
+    }
+  };
+
+  const hangup = () => {
+    call.hangup();
+  };
+
   return (
     <DialPadContainer>
-      <button type='button' onClick={makeSendDigit('1')}>
-        1
-      </button>
-      <button type='button' onClick={makeSendDigit('2')}>
-        2<span>ABC</span>
-      </button>
-      <button type='button' onClick={makeSendDigit('3')}>
-        3<span>DEF</span>
-      </button>
-      <button type='button' onClick={makeSendDigit('4')}>
-        4<span>GHI</span>
-      </button>
-      <button type='button' onClick={makeSendDigit('5')}>
-        5<span>JKL</span>
-      </button>
-      <button type='button' onClick={makeSendDigit('6')}>
-        6<span>MNO</span>
-      </button>
-      <button type='button' onClick={makeSendDigit('7')}>
-        7<span>PQRS</span>
-      </button>
-      <button type='button' onClick={makeSendDigit('8')}>
-        8<span>TUV</span>
-      </button>
-      <button type='button' onClick={makeSendDigit('9')}>
-        9<span>WXYZ</span>
-      </button>
-      <button type='button' onClick={makeSendDigit('*')}>
-        *
-      </button>
-      <button type='button' onClick={makeSendDigit('0')}>
-        0
-      </button>
-      <button type='button' onClick={makeSendDigit('#')}>
-        #
-      </button>
+      {isIncomingCall ? (
+        <React.Fragment>
+          <ButtonAnswer type='button' onClick={answerCall}>
+            Answer
+          </ButtonAnswer>
 
-      {call ? (
-        <button
-          type='button'
-          onClick={toggleMute}
-          className={muted ? 'active' : ''}
-        >
-          <span role='img' aria-label={muted ? 'Unmute' : 'Mute'}>
-            🔇
-          </span>
-        </button>
-      ) : (
-        <div />
-      )}
+          <div />
 
-      {call ? (
-        <button type='button' onClick={onEndCall} className='EndButton'>
-          End
-        </button>
+          <ButtonEnd type='button' onClick={hangup}>
+            Reject
+          </ButtonEnd>
+        </React.Fragment>
       ) : (
-        <button
-          type='button'
-          onClick={onStartCall}
-          className='CallButton'
-          disabled={disabled}
-        >
-          Call
-        </button>
-      )}
+        <React.Fragment>
+          <button type='button' onClick={makeSendDigit('1')}>
+            1
+          </button>
+          <button type='button' onClick={makeSendDigit('2')}>
+            2<span>ABC</span>
+          </button>
+          <button type='button' onClick={makeSendDigit('3')}>
+            3<span>DEF</span>
+          </button>
+          <button type='button' onClick={makeSendDigit('4')}>
+            4<span>GHI</span>
+          </button>
+          <button type='button' onClick={makeSendDigit('5')}>
+            5<span>JKL</span>
+          </button>
+          <button type='button' onClick={makeSendDigit('6')}>
+            6<span>MNO</span>
+          </button>
+          <button type='button' onClick={makeSendDigit('7')}>
+            7<span>PQRS</span>
+          </button>
+          <button type='button' onClick={makeSendDigit('8')}>
+            8<span>TUV</span>
+          </button>
+          <button type='button' onClick={makeSendDigit('9')}>
+            9<span>WXYZ</span>
+          </button>
+          <button type='button' onClick={makeSendDigit('*')}>
+            *
+          </button>
+          <button type='button' onClick={makeSendDigit('0')}>
+            0
+          </button>
+          <button type='button' onClick={makeSendDigit('#')}>
+            #
+          </button>
 
-      {call ? (
-        <button
-          type='button'
-          onClick={toggleHold}
-          className={held ? 'active' : ''}
-        >
-          <span role='img' aria-label={held ? 'Unhold' : 'Hold'}>
-            ⏸
-          </span>
-        </button>
-      ) : (
-        <button type='button' onClick={onBackspace}>
-          ⌫
-        </button>
+          {call ? (
+            <button
+              type='button'
+              onClick={toggleMute}
+              className={muted ? 'active' : ''}
+            >
+              <span role='img' aria-label={muted ? 'Unmute' : 'Mute'}>
+                🔇
+              </span>
+            </button>
+          ) : (
+            <div />
+          )}
+
+          {call ? (
+            <button type='button' onClick={onEndCall} className='EndButton'>
+              End
+            </button>
+          ) : (
+            <button
+              type='button'
+              onClick={onStartCall}
+              className='CallButton'
+              disabled={disabled}
+            >
+              Call
+            </button>
+          )}
+
+          {call ? (
+            <button
+              type='button'
+              onClick={toggleHold}
+              className={held ? 'active' : ''}
+            >
+              <span role='img' aria-label={held ? 'Unhold' : 'Hold'}>
+                ⏸
+              </span>
+            </button>
+          ) : (
+            <button type='button' onClick={onBackspace}>
+              ⌫
+            </button>
+          )}
+        </React.Fragment>
       )}
     </DialPadContainer>
   );

--- a/src/TelnyxRTC/RTC.ts
+++ b/src/TelnyxRTC/RTC.ts
@@ -75,7 +75,7 @@ function setDefaultCodec(mLine, payload) {
   return newLine.join(' ');
 }
 
-function setCompat() {}
+function setCompat() { }
 
 function checkCompat() {
   return true;
@@ -239,23 +239,20 @@ function FSRTCPeerConnection(options: any) {
 
   // @TODO Migrate to `addTrack`
   // https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/addStream
-  if (options.attachStream) (<any>peer).addStream(options.attachStream);
 
-  // attachStreams[0] = audio-stream;
-  // attachStreams[1] = video-stream;
-  // attachStreams[2] = screen-capturing-stream;
-  if (options.attachStreams && options.attachStream.length) {
-    const streams = options.attachStreams;
-    streams.forEach((stream) => {
-      (<any>peer).addStream(stream);
-    });
+
+  if (options.attachStream && options.attachStream.getTracks().length) {
+    for (const track of options.attachStream.getTracks()) {
+      console.log("TYPE+++++=====>", track);
+      (<any>peer).addTrack(track);
+    }
   }
 
-  peer.ontrack = function(event) {
+  peer.ontrack = function (event) {
     const remoteMediaStream = event.streams[0];
 
     // onRemoteStreamEnded(MediaStream)
-    (<any>remoteMediaStream).oninactive = function() {
+    (<any>remoteMediaStream).oninactive = function () {
       if (options.onRemoteStreamEnded)
         options.onRemoteStreamEnded(remoteMediaStream);
     };
@@ -300,7 +297,7 @@ function FSRTCPeerConnection(options: any) {
       onSdpSuccess,
       onSdpError
     );
-    (<any>peer).createAnswer(function(sessionDescription) {
+    (<any>peer).createAnswer(function (sessionDescription) {
       sessionDescription.sdp = serializeSdp(sessionDescription.sdp);
       peer.setLocalDescription(sessionDescription);
       if (options.onAnswerSDP) {
@@ -346,9 +343,9 @@ function FSRTCPeerConnection(options: any) {
     sdp =
       sdp.indexOf('a=crypto') == -1
         ? sdp.replace(
-            /c=IN/g,
-            'a=crypto:1 AES_CM_128_HMAC_SHA1_80 inline:' + inline + 'c=IN'
-          )
+          /c=IN/g,
+          'a=crypto:1 AES_CM_128_HMAC_SHA1_80 inline:' + inline + 'c=IN'
+        )
         : sdp;
 
     return sdp;
@@ -383,18 +380,18 @@ function FSRTCPeerConnection(options: any) {
   }
 
   function setChannelEvents() {
-    channel.onmessage = function(event) {
+    channel.onmessage = function (event) {
       if (options.onChannelMessage) options.onChannelMessage(event);
     };
-    channel.onopen = function() {
+    channel.onopen = function () {
       if (options.onChannelOpened) options.onChannelOpened(channel);
     };
-    channel.onclose = function(event) {
+    channel.onclose = function (event) {
       if (options.onChannelClosed) options.onChannelClosed(event);
 
       console.warn('WebRTC DataChannel closed', event);
     };
-    channel.onerror = function(event) {
+    channel.onerror = function (event) {
       if (options.onChannelError) options.onChannelError(event);
 
       console.error('WebRTC DataChannel error', event);
@@ -416,7 +413,7 @@ function FSRTCPeerConnection(options: any) {
     console.log('Error in fake:true');
   }
 
-  function onSdpSuccess() {}
+  function onSdpSuccess() { }
 
   function onSdpError(e) {
     if (options.onChannelError) {
@@ -522,9 +519,9 @@ export default class VertoRTC {
         videoParams: {},
         audioParams: {},
         callbacks: {
-          onICEComplete: function() {},
-          onICE: function() {},
-          onOfferSDP: function() {},
+          onICEComplete: function () { },
+          onICE: function () { },
+          onOfferSDP: function () { },
         },
       },
       options
@@ -913,11 +910,11 @@ export default class VertoRTC {
           },
         },
         localVideo: this.options.localVideo,
-        onsuccess: function(e) {
+        onsuccess: function (e) {
           this.options.localVideoStream = e;
           // console.log('local video ready');
         },
-        onerror: function(e) {
+        onerror: function (e) {
           console.error('local video error!');
         },
       });
@@ -973,7 +970,7 @@ export default class VertoRTC {
         onICE: (candidate) => onICE(this, candidate),
         onICEComplete: () => onICEComplete(this),
         onRemoteStream: screen
-          ? (stream) => {}
+          ? (stream) => { }
           : (stream) => onRemoteStream(this, stream),
         onOfferSDP: (sdp) => onOfferSDP(this, sdp),
         onICESDP: (sdp) => onICESDP(this, sdp),
@@ -1055,7 +1052,7 @@ export default class VertoRTC {
         video: check_video,
         // video: false,
       },
-      onsuccess: function(e) {
+      onsuccess: function (e) {
         e.getTracks().forEach((track) => {
           track.stop();
         });
@@ -1123,7 +1120,7 @@ export default class VertoRTC {
         video: cam !== 'none' ? video : false,
       },
       onsuccess: (e) => {
-        e.getTracks().forEach(function(track) {
+        e.getTracks().forEach(function (track) {
           track.stop();
         });
         // console.info(w + 'x' + h + ' supported.');

--- a/src/TelnyxRTC/RTC.ts
+++ b/src/TelnyxRTC/RTC.ts
@@ -235,11 +235,6 @@ function FSRTCPeerConnection(options: any) {
   };
 
   // attachStream = MediaStream;
-
-  // @TODO Migrate to `addTrack`
-  // https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/addStream
-
-
   if (options.attachStream && options.attachStream.getTracks().length) {
     for (const track of options.attachStream.getTracks()) {
       peer.addTrack(track);

--- a/src/TelnyxRTC/RTC.ts
+++ b/src/TelnyxRTC/RTC.ts
@@ -189,7 +189,6 @@ function FSRTCPeerConnection(options: any) {
   }
 
   const peer = new RTCPeerConnection(config);
-
   openOffererChannel();
   let x = 0;
 
@@ -211,6 +210,7 @@ function FSRTCPeerConnection(options: any) {
   }
 
   peer.onicecandidate = (event) => {
+
     if (done) {
       return;
     }
@@ -218,7 +218,6 @@ function FSRTCPeerConnection(options: any) {
     if (!gathering) {
       gathering = setTimeout(ice_handler, 1000);
     }
-
     if (event) {
       if (event.candidate) {
         options.onICE(event.candidate);
@@ -243,8 +242,7 @@ function FSRTCPeerConnection(options: any) {
 
   if (options.attachStream && options.attachStream.getTracks().length) {
     for (const track of options.attachStream.getTracks()) {
-      console.log("TYPE+++++=====>", track);
-      (<any>peer).addTrack(track);
+      peer.addTrack(track);
     }
   }
 
@@ -272,17 +270,13 @@ function FSRTCPeerConnection(options: any) {
   function createOffer() {
     if (!options.onOfferSDP) return;
 
-    // @TODO Migrate to single options argument
-    // https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/createOffer
-    (<any>peer).createOffer(
-      (sessionDescription) => {
-        sessionDescription.sdp = serializeSdp(sessionDescription.sdp);
-        peer.setLocalDescription(sessionDescription);
-        options.onOfferSDP(sessionDescription);
-      },
-      onSdpError,
-      options.constraints
-    );
+    peer.createOffer().then(function (offer) {
+      return peer.setLocalDescription(offer);
+    }).then(function (success) {
+      console.log("success createOffer", success)
+    }).catch(function (reason) {
+      console.error("error createOffer", reason)
+    });
   }
 
   // onAnswerSDP(RTCSessionDescription)

--- a/src/TelnyxRTC/RTC.ts
+++ b/src/TelnyxRTC/RTC.ts
@@ -272,32 +272,25 @@ function FSRTCPeerConnection(options: any) {
 
     peer.createOffer().then(function (offer) {
       return peer.setLocalDescription(offer);
-    }).then(function (success) {
-      console.log("success createOffer", success)
     }).catch(function (reason) {
       console.error("error createOffer", reason)
     });
   }
 
   // onAnswerSDP(RTCSessionDescription)
-  function createAnswer() {
+  async function createAnswer() {
     if (options.type != 'answer') return;
 
-    //options.offerSDP.sdp = addStereo(options.offerSDP.sdp);
+    await peer.setRemoteDescription(options.offerSDP).catch(onSdpError);
 
-    // @TODO Verify `setRemoteDescription` and `createAnswer` call signature
-    (<any>peer).setRemoteDescription(
-      new window.RTCSessionDescription(options.offerSDP),
-      onSdpSuccess,
-      onSdpError
-    );
-    (<any>peer).createAnswer(function (sessionDescription) {
-      sessionDescription.sdp = serializeSdp(sessionDescription.sdp);
-      peer.setLocalDescription(sessionDescription);
-      if (options.onAnswerSDP) {
-        options.onAnswerSDP(sessionDescription);
-      }
-    }, onSdpError);
+    peer.createAnswer()
+      .then(function (answer) {
+        if (options.onAnswerSDP) {
+          options.onAnswerSDP(answer);
+        }
+        return peer.setLocalDescription(answer);
+      })
+      .catch(onSdpError);
   }
 
   if (options.onChannelMessage || !options.onChannelMessage) {


### PR DESCRIPTION
Changed method addStream deprecated to addTrack.
Changed method createOffer deprecated to createOffer new interface.
Changed method createAnswer deprecated to createAnswer new interface.
Added answer button to answer a received call.

## 📝 To Do

- [x] All linters pass
- [x] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

1. cd examples/react
2. run yarn setup
3. run yarn storybook
4. make a call and receive a call

## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [x] Chrome
- [x] Firefox
- [x] Safari

