### PR TITLE
feat(WEBRTC-108): Added helper function to handle inside Telnyx the call state

### DIFF
--- a/src/Modules/Verto/BrowserSession.ts
+++ b/src/Modules/Verto/BrowserSession.ts
@@ -4,12 +4,13 @@ import { ICacheDevices, IAudioSettings, IVideoSettings, BroadcastParams, Subscri
 import { registerOnce, trigger } from './services/Handler'
 import { SwEvent, SESSION_ID, TURN_SERVER, STUN_SERVER } from './util/constants'
 import { State, DeviceType } from './webrtc/constants'
-import { changeStateTelnyx, getDevices, scanResolutions, removeUnsupportedConstraints, checkDeviceIdConstraints, destructSubscribeResponse, getUserMedia, assureDeviceId } from './webrtc/helpers'
+import { getDevices, scanResolutions, removeUnsupportedConstraints, checkDeviceIdConstraints, destructSubscribeResponse, getUserMedia, assureDeviceId } from './webrtc/helpers'
 import { findElementByType } from './util/helpers'
 import { Unsubscribe, Subscribe, Broadcast } from './messages/Verto'
 import { localStorage } from './util/storage/'
 import { stopStream } from './util/webrtc'
 import { IWebRTCCall } from './webrtc/interfaces'
+import Call from './webrtc/Call'
 
 export default abstract class BrowserSession extends BaseSession {
   public calls: { [callId: string]: IWebRTCCall } = {}
@@ -334,7 +335,7 @@ export default abstract class BrowserSession extends BaseSession {
     return response
   }
 
-  static telnyxStateCall(call) {
-    return changeStateTelnyx(call);
+  static telnyxStateCall(call: Call) {
+    return Call.setStateTelnyx(call);
   }
 }

--- a/src/Modules/Verto/BrowserSession.ts
+++ b/src/Modules/Verto/BrowserSession.ts
@@ -4,7 +4,7 @@ import { ICacheDevices, IAudioSettings, IVideoSettings, BroadcastParams, Subscri
 import { registerOnce, trigger } from './services/Handler'
 import { SwEvent, SESSION_ID, TURN_SERVER, STUN_SERVER } from './util/constants'
 import { State, DeviceType } from './webrtc/constants'
-import { getDevices, scanResolutions, removeUnsupportedConstraints, checkDeviceIdConstraints, destructSubscribeResponse, getUserMedia, assureDeviceId } from './webrtc/helpers'
+import { changeStateTelnyx, getDevices, scanResolutions, removeUnsupportedConstraints, checkDeviceIdConstraints, destructSubscribeResponse, getUserMedia, assureDeviceId } from './webrtc/helpers'
 import { findElementByType } from './util/helpers'
 import { Unsubscribe, Subscribe, Broadcast } from './messages/Verto'
 import { localStorage } from './util/storage/'
@@ -332,5 +332,9 @@ export default abstract class BrowserSession extends BaseSession {
     unsubscribed.forEach(channel => this._removeSubscription(this.relayProtocol, channel))
     notSubscribed.forEach(channel => this._removeSubscription(this.relayProtocol, channel))
     return response
+  }
+
+  static telnyxStateCall(call) {
+    return changeStateTelnyx(call);
   }
 }

--- a/src/Modules/Verto/tests/Verto.test.ts
+++ b/src/Modules/Verto/tests/Verto.test.ts
@@ -7,8 +7,8 @@ import Verto, { VERTO_PROTOCOL } from '..'
 const Connection = require('../services/Connection')
 
 describe('Verto', () => {
-  const _buildInstance = (): Verto => {
-    const instance: Verto = new Verto({ host: 'example.telnyx.com', login: 'login', password: 'password' })
+  const _buildInstance = (props): Verto => {
+    const instance: Verto = new Verto(props)
     // @ts-ignore
     instance.connection = Connection.default()
     return instance
@@ -18,13 +18,13 @@ describe('Verto', () => {
   const noop = (): void => { }
 
   beforeAll(() => {
-    behaveLikeBaseSession.call(this, _buildInstance())
+    behaveLikeBaseSession.call(this, _buildInstance({ host: 'example.telnyx.com', login: 'login', password: 'password' }))
     VertoHandler.call(this, Verto)
     LayoutHandler.call(this, Verto)
   })
 
   beforeEach(() => {
-    instance = _buildInstance()
+    instance = _buildInstance({ host: 'example.telnyx.com', login: 'login', password: 'password' })
     instance.subscriptions = {}
     Connection.mockSend.mockClear()
     Connection.default.mockClear()
@@ -33,6 +33,44 @@ describe('Verto', () => {
 
   it('should instantiate Verto with default methods', () => {
     expect(instance).toBeInstanceOf(Verto)
+  })
+
+  it('should set env equal production ', () => {
+    const telnyxRTC = _buildInstance({ env: 'production', login: 'login', password: 'password' })
+    expect(telnyxRTC.options.env).toEqual("production")
+  })
+
+  it('should set env equal development', () => {
+    const telnyxRTC = _buildInstance({ env: 'development', login: 'login', password: 'password' })
+    expect(telnyxRTC.options.env).toEqual("development")
+  })
+
+  it('should set host equal wss://test.telnyx.com', () => {
+    const telnyxRTC = _buildInstance({ host: 'wss://test.telnyx.com', login: 'login', password: 'password' })
+    expect(telnyxRTC.options.host).toEqual("wss://test.telnyx.com")
+  })
+
+  it('should return iceServers with google servers when is true', () => {
+    const telnyxRTC = _buildInstance({ iceServers: true, login: 'login', password: 'password' })
+    expect(telnyxRTC.iceServers[0]).toEqual({ "urls": ["stun:stun.l.google.com:19302"] })
+  })
+
+  it('should return iceServers with empty [] when is false', () => {
+    const telnyxRTC = _buildInstance({ iceServers: false, login: 'login', password: 'password' })
+    expect(telnyxRTC.iceServers).toEqual([])
+  })
+
+  it('should return production iceServers when not pass iceServers', () => {
+    const telnyxRTC = _buildInstance({ login: 'login', password: 'password' })
+    expect(telnyxRTC.iceServers[0]).toEqual({ "credential": "testpassword", "urls": "turn:turn.telnyx.com:3478?transport=tcp", "username": "testuser" })
+    expect(telnyxRTC.iceServers[1]).toEqual({
+      "urls": "stun:stun.telnyx.com:3843",
+    })
+  })
+
+  it('should set iceServers equal stun.test.telnyx.com', () => {
+    const telnyxRTC = _buildInstance({ iceServers: ['stun.test.telnyx.com'], login: 'login', password: 'password' })
+    expect(telnyxRTC.iceServers[0]).toEqual('stun.test.telnyx.com')
   })
 
   describe('.validateOptions()', () => {

--- a/src/Modules/Verto/tests/webrtc/Call.test.ts
+++ b/src/Modules/Verto/tests/webrtc/Call.test.ts
@@ -17,7 +17,7 @@ describe('Call', () => {
   const noop = (): void => { }
 
   beforeEach(async done => {
-    session = new Verto({ host: 'example.fs.edo', login: 'login', passwd: 'passwd' })
+    session = new Verto({ host: 'example.fs.telnyx', login: 'login', passwd: 'passwd' })
     await session.connect().catch(console.error)
     call = new Call(session, defaultParams)
     done()

--- a/src/Modules/Verto/tests/webrtc/Call.test.ts
+++ b/src/Modules/Verto/tests/webrtc/Call.test.ts
@@ -342,4 +342,41 @@ describe('Call', () => {
       done()
     })
   })
+
+  describe('setStateTelnyx', () => {
+    it('should return null if call is null', () => {
+      const localCall = Call.setStateTelnyx(undefined);
+      expect(localCall).toEqual(undefined)
+    })
+
+    it('should return call without change', () => {
+      const localCall = Call.setStateTelnyx(call);
+      expect(localCall).toEqual(call)
+    })
+    it('set telnyx state call', () => {
+      call.setState(State.Recovering)
+      Call.setStateTelnyx(call);
+      expect(call.state).toEqual('connecting')
+
+      call.setState(State.Trying)
+      Call.setStateTelnyx(call);
+      expect(call.state).toEqual('connecting')
+
+      call.setState(State.Early)
+      Call.setStateTelnyx(call);
+      expect(call.state).toEqual('connecting')
+
+      call.setState(State.Hangup)
+      Call.setStateTelnyx(call);
+      expect(call.state).toEqual('done')
+
+      call.setState(State.Destroy)
+      Call.setStateTelnyx(call);
+      expect(call.state).toEqual('done')
+
+      call.setState(State.Answering)
+      Call.setStateTelnyx(call);
+      expect(call.state).toEqual('ringing')
+    })
+  })
 })

--- a/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/src/Modules/Verto/webrtc/BaseCall.ts
@@ -12,6 +12,7 @@ import { objEmpty, mutateLiveArrayData, isFunction } from '../util/helpers'
 import { CallOptions, IWebRTCCall } from './interfaces'
 import { attachMediaStream, detachMediaStream, sdpToJsonHack, stopStream, getUserMedia, setMediaElementSinkId } from '../util/webrtc'
 import { MCULayoutEventHandler } from './LayoutHandler'
+import Call from './Call'
 
 export default abstract class BaseCall implements IWebRTCCall {
   public id: string = ''
@@ -774,5 +775,39 @@ export default abstract class BaseCall implements IWebRTCCall {
     this.peer = null
     this.session.calls[this.id] = null
     delete this.session.calls[this.id]
+  }
+
+  static setStateTelnyx = (call: Call) => {
+    if (!call) {
+      return;
+    }
+    switch (call._state) {
+      case State.Requesting:
+      case State.Recovering:
+      case State.Trying:
+      case State.Early:
+        call.state = 'connecting';
+        break;
+      case State.Active:
+        call.state = 'active';
+        break;
+      case State.Held:
+        call.state = 'held';
+        break;
+      case State.Hangup:
+      case State.Destroy:
+        call.state = 'done';
+        break;
+      case State.Answering:
+        call.state = 'ringing';
+        break;
+      case State.New:
+        call.state = 'new';
+        break;
+      default:
+        break;
+    }
+
+    return call;
   }
 }

--- a/src/Modules/Verto/webrtc/helpers.ts
+++ b/src/Modules/Verto/webrtc/helpers.ts
@@ -1,7 +1,7 @@
 import logger from '../util/logger'
 import * as WebRTC from '../util/webrtc'
 import { isDefined } from '../util/helpers'
-import { DeviceType } from './constants'
+import { DeviceType, State } from './constants'
 import { CallOptions } from './interfaces'
 
 const getUserMedia = async (constraints: MediaStreamConstraints): Promise<MediaStream | null> => {
@@ -290,6 +290,40 @@ const sdpBitrateHack = (sdp: string, max: number, min: number, start: number) =>
   return lines.join(endOfLine)
 }
 
+const changeStateTelnyx = (call) => {
+  if (!call) {
+    return;
+  }
+  switch (call._state) {
+    case State.Requesting:
+    case State.Recovering:
+    case State.Trying:
+    case State.Early:
+      call.state = 'connecting';
+      break;
+    case State.Active:
+      call.state = 'active';
+      break;
+    case State.Held:
+      call.state = 'held';
+      break;
+    case State.Hangup:
+    case State.Destroy:
+      call.state = 'done';
+      break;
+    case State.Answering:
+      call.state = 'ringing';
+      break;
+    case State.New:
+      call.state = 'new';
+      break;
+    default:
+      break;
+  }
+
+  return call;
+}
+
 export {
   getUserMedia,
   getDevices,
@@ -309,4 +343,5 @@ export {
   enableVideoTracks,
   disableVideoTracks,
   toggleVideoTracks,
+  changeStateTelnyx
 }

--- a/src/Modules/Verto/webrtc/helpers.ts
+++ b/src/Modules/Verto/webrtc/helpers.ts
@@ -290,8 +290,6 @@ const sdpBitrateHack = (sdp: string, max: number, min: number, start: number) =>
   return lines.join(endOfLine)
 }
 
-
-
 export {
   getUserMedia,
   getDevices,

--- a/src/Modules/Verto/webrtc/helpers.ts
+++ b/src/Modules/Verto/webrtc/helpers.ts
@@ -290,39 +290,7 @@ const sdpBitrateHack = (sdp: string, max: number, min: number, start: number) =>
   return lines.join(endOfLine)
 }
 
-const changeStateTelnyx = (call) => {
-  if (!call) {
-    return;
-  }
-  switch (call._state) {
-    case State.Requesting:
-    case State.Recovering:
-    case State.Trying:
-    case State.Early:
-      call.state = 'connecting';
-      break;
-    case State.Active:
-      call.state = 'active';
-      break;
-    case State.Held:
-      call.state = 'held';
-      break;
-    case State.Hangup:
-    case State.Destroy:
-      call.state = 'done';
-      break;
-    case State.Answering:
-      call.state = 'ringing';
-      break;
-    case State.New:
-      call.state = 'new';
-      break;
-    default:
-      break;
-  }
 
-  return call;
-}
 
 export {
   getUserMedia,
@@ -343,5 +311,4 @@ export {
   enableVideoTracks,
   disableVideoTracks,
   toggleVideoTracks,
-  changeStateTelnyx
 }


### PR DESCRIPTION
Added helper function to handle inside Telnyx the call state. this function `setStateTelnyx` will be used at Telnyx inside projects, this way is easier to handle call's.

For example instead of using all these states 

```
 switch (notification.type) {
      case 'callUpdate':
        // Call is over and can be removed
        if (
          notification.call.state === 'hangup' ||
          notification.call.state === 'destroy'
        ) {
          activeCall = null;
        }
        // An established and active call
        if (notification.call.state === 'active') {
          return;
        }
        // New calls that haven't started connecting yet
        if (notification.call.state === 'new') {
          return;
        }
        // Receiving an inbound call
        if (notification.call.state === 'ringing') {
          return;
        }
        // Call is active but on hold
        if (notification.call.state === 'held') {
          return;
        }
        break;
    }
```

At Telnyx we only need to use these

```
 static setStateTelnyx = (call: Call) => {
    if (!call) {
      return;
    }
    switch (call._state) {
      case State.Requesting:
      case State.Recovering:
      case State.Trying:
      case State.Early:
        call.state = 'connecting';
        break;
      case State.Active:
        call.state = 'active';
        break;
      case State.Held:
        call.state = 'held';
        break;
      case State.Hangup:
      case State.Destroy:
        call.state = 'done';
        break;
      case State.Answering:
        call.state = 'ringing';
        break;
      case State.New:
        call.state = 'new';
        break;
      default:
        break;
    }

    return call;
  }
```


## 📝 To Do

- [x] All linters pass
- [x] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

1. `npm run build` at root folder
2. Navigate into `examples/react`
3. npm run storybook
4. Change in 2-WebDialer.stories line 300

From:
```
session.on('telnyx.notification', (notification) => {
      console.log('telnyx.notification', notification);
````

To: 
```
session.on('telnyx.notification', (notification) => {
    //console.log('telnyx.notification', notification);
     if (notification.call) {
        console.log(
          'telnyx.notification',
          TelnyxRTC.telnyxStateCall(notification.call).state
        );
      }
```

And see if notification.call.state changed to be like setStateTelnyx states

## 🦊 Browser testing

### Desktop

- [x] Edge (latest)
- [x] Chrome
- [x] Firefox
- [x] Safari

## 📸 Screenshots

| Description | Screenshot |
| ----------- | ---------- |
| Desktop     |![image](https://user-images.githubusercontent.com/16343871/84033295-0515cc00-a96f-11ea-8e1d-ddef6554dab2.png)|
