### PR TITLE
feat(ENGDESK-5656): added support to login with ephemeral token

### DIFF
--- a/examples/react/stories/1-ClickToCall.stories.js
+++ b/examples/react/stories/1-ClickToCall.stories.js
@@ -122,6 +122,10 @@ const ClickToCall = ({
     call.hangup();
   };
 
+  if (mediaRef.current && call && call.remoteStream) {
+    mediaRef.current.srcObject = call.remoteStream;
+  }
+
   return (
     <div>
       {!call && (

--- a/examples/react/stories/2-WebDialer.stories.js
+++ b/examples/react/stories/2-WebDialer.stories.js
@@ -402,7 +402,6 @@ export const Example = () => {
   const production = boolean('Production', true);
   const username = text('Connection Username', 'username');
   const password = text('Connection Password', 'password');
-  const defaultDestination = text('Default Destination', '18004377950');
   const callerName = text('Caller Name', 'Caller ID Name');
   const callerNumber = text('Caller Number', 'Caller ID Number');
 
@@ -411,7 +410,7 @@ export const Example = () => {
       environment={production ? 'production' : 'development'}
       username={username}
       password={password}
-      defaultDestination={defaultDestination}
+      defaultDestination='18004377950'
       callerName={callerName}
       callerNumber={callerNumber}
     />

--- a/examples/react/stories/2-WebDialer.stories.js
+++ b/examples/react/stories/2-WebDialer.stories.js
@@ -365,7 +365,7 @@ const WebDialer = ({
     <Container>
       <audio
         ref={mediaRef}
-        id='dialogVideo'
+        id='dialogAudio'
         autoPlay='autoplay'
         controls={false}
       ></audio>

--- a/examples/vanilla/index.html
+++ b/examples/vanilla/index.html
@@ -39,26 +39,28 @@
               <div class="card-body">
                 <h5>Connect</h5>
                 <div class="form-group">
-                  <label class="telnyx-labels" for="project">Username</label>
+                  <label class="telnyx-labels" for="username">Username</label>
                   <input
                     type="text"
                     class="form-control"
                     id="username"
                     placeholder="Enter your username"
+                    onchange="saveInLocalStorage(event)"
                   />
                 </div>
                 <div class="form-group">
-                  <label class="telnyx-labels" for="token">Password</label>
+                  <label class="telnyx-labels" for="password">Password</label>
                   <input
                     type="text"
                     class="form-control"
                     id="password"
                     placeholder="Enter your password"
+                    onchange="saveInLocalStorage(event)"
                   />
                 </div>
                 <div class="telnyx-labels">Environment Options:</div>
                 <div class="form-check">
-                  <input type="checkbox" id="env" value="0" />
+                  <input type="checkbox" id="env" value="1" />
                   <label class="form-check-label telnyx-labels" for="env">
                     Production
                   </label>
@@ -99,18 +101,29 @@
                     class="form-control"
                     id="number"
                     placeholder="Enter SIP or Number to Dial"
+                    onchange="saveInLocalStorage(event)"
                   />
                 </div>
 
                 <div class="telnyx-labels">Call Options:</div>
                 <div class="form-check">
-                  <input type="checkbox" id="audio" value="1" />
+                  <input
+                    type="checkbox"
+                    id="audio"
+                    value="1"
+                    onchange="saveInLocalStorage(event)"
+                  />
                   <label class="form-check-label telnyx-labels" for="audio">
                     Include Audio
                   </label>
                 </div>
                 <div class="form-check">
-                  <input type="checkbox" id="video" value="1" />
+                  <input
+                    type="checkbox"
+                    id="video"
+                    value="1"
+                    onchange="saveInLocalStorage(event)"
+                  />
                   <label class="form-check-label telnyx-labels" for="video">
                     Include Video
                   </label>
@@ -177,12 +190,21 @@
       var client;
       var currentCall = null;
 
+      var username = localStorage.getItem('telnyx.example.username') || '';
+      var password = localStorage.getItem('telnyx.example.password') || '';
+      var number = localStorage.getItem('telnyx.example.number') || '';
+      var audio = localStorage.getItem('telnyx.example.audio') || '1';
+      var video = localStorage.getItem('telnyx.example.video') || '1';
+
       /**
        * On document ready auto-fill the input values from the localStorage.
        */
       ready(function () {
-        document.getElementById('audio').checked = '1';
-        document.getElementById('video').checked = '1';
+        document.getElementById('username').value = username;
+        document.getElementById('password').value = password;
+        document.getElementById('number').value = number;
+        document.getElementById('audio').checked = audio === '1';
+        document.getElementById('video').checked = video === '1';
         document.getElementById('env').checked = '1';
       });
 
@@ -201,6 +223,7 @@
           ringFile: './sounds/incoming_call.mp3',
         });
 
+        // client.autoRecoverCalls = false;
         client.remoteElement = 'remoteVideo';
         client.localElement = 'localVideo';
 
@@ -256,6 +279,9 @@
             break;
           case 'userMediaError':
             // Permission denied or invalid audio/video params on `getUserMedia`
+            console.log(
+              'Permission denied or invalid audio/video params on `getUserMedia`'
+            );
             break;
         }
       }
@@ -265,7 +291,6 @@
        */
       function handleCallUpdate(call) {
         currentCall = call;
-
         switch (call.state) {
           case 'new': // Setup the UI
             break;
@@ -309,9 +334,9 @@
        */
       function makeCall() {
         const params = {
-          destinationNumber: document.getElementById('number').value, // required!
           callerName: 'Caller Name',
           callerNumber: 'Caller Number',
+          destinationNumber: document.getElementById('number').value, // required!
           audio: document.getElementById('audio').checked,
           video: document.getElementById('video').checked
             ? { aspectRatio: 16 / 9 }
@@ -328,6 +353,11 @@
         if (currentCall) {
           currentCall.hangup();
         }
+      }
+
+      function saveInLocalStorage(e) {
+        var key = e.target.name || e.target.id;
+        localStorage.setItem('telnyx.example.' + key, e.target.value);
       }
 
       // jQuery document.ready equivalent

--- a/examples/vanilla/index.html
+++ b/examples/vanilla/index.html
@@ -51,7 +51,7 @@
                 <div class="form-group">
                   <label class="telnyx-labels" for="password">Password</label>
                   <input
-                    type="text"
+                    type="password"
                     class="form-control"
                     id="password"
                     placeholder="Enter your password"

--- a/examples/vanilla/index.html
+++ b/examples/vanilla/index.html
@@ -223,7 +223,6 @@
           ringFile: './sounds/incoming_call.mp3',
         });
 
-        // client.autoRecoverCalls = false;
         client.remoteElement = 'remoteVideo';
         client.localElement = 'localVideo';
 
@@ -278,7 +277,6 @@
             handleCallUpdate(notification.call);
             break;
           case 'userMediaError':
-            // Permission denied or invalid audio/video params on `getUserMedia`
             console.log(
               'Permission denied or invalid audio/video params on `getUserMedia`'
             );

--- a/src/Modules/Verto/BaseSession.ts
+++ b/src/Modules/Verto/BaseSession.ts
@@ -12,6 +12,7 @@ import { BroadcastParams, ITelnyxRTCOptions, SubscribeParams, IBladeConnectResul
 import { Subscription, Connect, Reauthenticate, Ping } from './messages/Blade'
 import { isFunction, randomInt } from './util/helpers'
 import { sessionStorage } from './util/storage/'
+import { isValidOptions } from './util/helpers'
 
 const KEEPALIVE_INTERVAL = 10 * 1000
 
@@ -105,13 +106,12 @@ export default abstract class BaseSession {
 
   /**
    * Validates the options passed in.
-   * TelnyxRTC requires project and token
+   * TelnyxRTC requires (login and password) OR login_token 
    * Verto requires host, login, passwd OR password
    * @return boolean
    */
   validateOptions() {
-    const { project = false, token = false } = this.options
-    return Boolean(project && token)
+    return isValidOptions(this.options)
   }
 
   /**

--- a/src/Modules/Verto/index.ts
+++ b/src/Modules/Verto/index.ts
@@ -15,8 +15,8 @@ export default class Verto extends BrowserSession {
   public timeoutErrorCode = -329990 // fake verto timeout error code.
 
   validateOptions() {
-    const { login, passwd, password } = this.options
-    return Boolean(login && (passwd || password))
+    const { login, passwd, password, login_token } = this.options
+    return Boolean((login && (passwd || password)) || login_token)
   }
 
   newCall(options: CallOptions) {
@@ -43,12 +43,12 @@ export default class Verto extends BrowserSession {
 
   protected async _onSocketOpen() {
     this._idle = false
-    const { login, password, passwd, userVariables } = this.options
+    const { login, password, passwd, login_token, userVariables } = this.options
     if (this.sessionid) {
       const sessidLogin = new Login(undefined, undefined, this.sessionid, undefined)
       await this.execute(sessidLogin).catch(console.error)
     }
-    const msg = new Login(login, (password || passwd), this.sessionid, userVariables)
+    const msg = new Login(login, (password || passwd), login_token, this.sessionid, userVariables)
     const response = await this.execute(msg).catch(this._handleLoginError)
     if (response) {
       this._autoReconnect = true

--- a/src/Modules/Verto/index.ts
+++ b/src/Modules/Verto/index.ts
@@ -7,6 +7,7 @@ import { SwEvent, SESSION_ID } from './util/constants'
 import { trigger } from './services/Handler'
 import { localStorage } from './util/storage'
 import VertoHandler from './webrtc/VertoHandler'
+import { isValidOptions } from './util/helpers'
 
 export const VERTO_PROTOCOL = 'verto-protocol'
 
@@ -15,8 +16,7 @@ export default class Verto extends BrowserSession {
   public timeoutErrorCode = -329990 // fake verto timeout error code.
 
   validateOptions() {
-    const { login, passwd, password, login_token } = this.options
-    return Boolean((login && (passwd || password)) || login_token)
+    return isValidOptions(this.options);
   }
 
   newCall(options: CallOptions) {

--- a/src/Modules/Verto/messages/verto/Login.ts
+++ b/src/Modules/Verto/messages/verto/Login.ts
@@ -3,11 +3,11 @@ import BaseRequest from './BaseRequest'
 class Login extends BaseRequest {
   method: string = 'login'
 
-  constructor(login: string, passwd: string, sessionid: string, userVariables: Object = {}) {
+  constructor(login: string, passwd: string, login_token: string, sessionid: string, userVariables: Object = {}) {
     super()
 
     // TODO: handle loginParams && userVariables
-    const params: any = { login, passwd, userVariables, loginParams: {} }
+    const params: any = { login, passwd, login_token, userVariables, loginParams: {} }
     if (sessionid) {
       params.sessid = sessionid
     }

--- a/src/Modules/Verto/tests/helpers.test.ts
+++ b/src/Modules/Verto/tests/helpers.test.ts
@@ -1,4 +1,5 @@
-import { objEmpty, mutateLiveArrayData, safeParseJson, isDefined, checkWebSocketHost, destructResponse } from '../util/helpers'
+import { ITelnyxRTCOptions } from '../util/interfaces';
+import { objEmpty, mutateLiveArrayData, safeParseJson, isDefined, checkWebSocketHost, destructResponse, isValidOptions } from '../util/helpers'
 
 describe('Helpers functions', () => {
   describe('objEmpty', () => {
@@ -116,6 +117,41 @@ describe('Helpers functions', () => {
     it('should handle Verto error over Blade', () => {
       const msg = JSON.parse('{"jsonrpc":"2.0","id":"uuid","result":{"requester_nodeid":"req-id","responder_nodeid":"res-id","result":{"code":"200","node_id":"node-id","result":{"jsonrpc":"2.0","id":"123","error":{"message":"Random Error","callID":"call-id","code":"123"}}}}}')
       expect(destructResponse(msg)).toEqual({ error: { code: '123', message: 'Random Error', callID: 'call-id' } })
+    })
+  })
+  describe('isValidOptions()', () => {
+    it("should return false if is a empty object", () => {
+      const options: ITelnyxRTCOptions = {}
+      expect(isValidOptions(options)).toBeFalsy();
+    })
+    it("should return false if none of options is provided", () => {
+      const options: ITelnyxRTCOptions = {
+        login: "",
+        password: "",
+        passwd: "",
+        login_token: ""
+      }
+      expect(isValidOptions(options)).toBeFalsy();
+    })
+    it("should return true if login and password is provided", () => {
+      const options: ITelnyxRTCOptions = {
+        login: "deivid",
+        password: "test",
+      }
+      expect(isValidOptions(options)).toBeTruthy();
+    })
+    it("should return true if login and passwd is provided", () => {
+      const options: ITelnyxRTCOptions = {
+        login: "deivid",
+        passwd: "test",
+      }
+      expect(isValidOptions(options)).toBeTruthy();
+    })
+    it("should return true if only login_token is provided", () => {
+      const options: ITelnyxRTCOptions = {
+        login_token: "asdfkasdf1243123njn123oi4n"
+      }
+      expect(isValidOptions(options)).toBeTruthy();
     })
   })
 })

--- a/src/Modules/Verto/tests/messages.test.ts
+++ b/src/Modules/Verto/tests/messages.test.ts
@@ -73,14 +73,14 @@ describe('Messages', function () {
   describe('Verto', function () {
     describe('Login', function () {
       it('should match struct', function () {
-        const message = new Login('login', 'password', null).request
-        const res = JSON.parse(`{"jsonrpc":"2.0","id":"${message.id}","method":"login","params":{"login":"login","passwd":"password","loginParams":{},"userVariables":{}}}`)
+        const message = new Login('login', 'password', 'dskbksdjbfkjsdf234y67234kjrwe98', null).request
+        const res = JSON.parse(`{"jsonrpc":"2.0","id":"${message.id}","method":"login","params":{"login":"login","passwd":"password","login_token": "dskbksdjbfkjsdf234y67234kjrwe98","loginParams":{},"userVariables":{}}}`)
         expect(message).toEqual(res)
       })
 
       it('should match struct with sessid', function () {
-        const message = new Login('login', 'password', '123456789').request
-        const res = JSON.parse(`{"jsonrpc":"2.0","id":"${message.id}","method":"login","params":{"login":"login","passwd":"password","sessid":"123456789","loginParams":{},"userVariables":{}}}`)
+        const message = new Login('login', 'password', 'dskbksdjbfkjsdf234y67234kjrwe98', '123456789').request
+        const res = JSON.parse(`{"jsonrpc":"2.0","id":"${message.id}","method":"login","params":{"login":"login","passwd":"password","login_token": "dskbksdjbfkjsdf234y67234kjrwe98","sessid":"123456789","loginParams":{},"userVariables":{}}}`)
         expect(message).toEqual(res)
       })
     })

--- a/src/Modules/Verto/util/helpers.ts
+++ b/src/Modules/Verto/util/helpers.ts
@@ -1,3 +1,4 @@
+import { ITelnyxRTCOptions } from './interfaces';
 import logger from './logger'
 import { STORAGE_PREFIX } from './constants'
 
@@ -86,4 +87,16 @@ export const destructResponse = (response: any, nodeId: string = null): { [key: 
 
 export const randomInt = (min: number, max: number) => {
   return Math.floor(Math.random() * (max - min + 1) + min)
+}
+
+/**
+  * Validates the options passed in.
+  * TelnyxRTC requires (login and password) OR (login_token)
+  * Verto requires host, login, passwd OR password
+  * @return boolean
+  */
+export const isValidOptions = ({ login, passwd, password, login_token }: ITelnyxRTCOptions) => {
+  const isLogin = login && (passwd || password);
+  const isToken = login_token
+  return Boolean(isLogin || isToken)
 }

--- a/src/Modules/Verto/util/interfaces.ts
+++ b/src/Modules/Verto/util/interfaces.ts
@@ -64,6 +64,7 @@ export interface ITelnyxRTCOptions {
   login?: string
   passwd?: string
   password?: string
+  login_token?: string
   userVariables?: Object,
   ringFile?: string
   env?: Environment


### PR DESCRIPTION
 - Was added a new prop `login_token` to handle the register on FreeSWITCH using an ephemeral JWT token.
 - Updated the ClickToCall.stories.js example.

## 📝 To Do

- [x] All linters pass
- [x] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

1. yarn build
2. cd examples/react && npm i && npm run setup && npm run storybook
3. get your credentials on the customer portal
4. make a call.


## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [x] Chrome
- [x] Firefox
- [x] Safari
