### PR TITLE
fix link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ Screenshot:
 ### React Native
 
 We've included a few [examples in React Native](https://github.com/team-telnyx/webrtc/tree/master/examples/react-native) to help you get started.\
-You can access the documentation [here](https://www.npmjs.com/package/@telnyx) about `@telnyx/react-native` to have more information.
+You can access the documentation [here](https://www.npmjs.com/package/@telnyx/react-native) about `@telnyx/react-native` to have more information.
 
 ```
 cd examples/react-native


### PR DESCRIPTION
Fixes incorrect link to `react-native` package documentation in the README.