### PR TITLE
fix(WEBRTC-124): fixed audio call on Firefox browser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8892,9 +8892,9 @@
       "dev": true
     },
     "webrtc-adapter": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-7.6.3.tgz",
-      "integrity": "sha512-DCMiS6cy29PknSuBz779twM6/VsPdoQNAU/I/q4VCEVSlCQ88xiwqGD5/osVO6UMyXCnTBiOl8kd+1cJi6Pkig==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-7.6.4.tgz",
+      "integrity": "sha512-JHbYZeJldjRDpLFcei2C1eOaVyIGGX6D43P5ImNhm1O4JFPR4kpKATrL5Yn2gEdLKBHdlReVV80cc+yK55spbQ==",
       "dev": true,
       "requires": {
         "rtcpeerconnection-shim": "^1.2.15",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "typedoc": "^0.15.0",
     "typedoc-plugin-markdown": "^2.2.6",
     "typescript": "^3.6.2",
-    "webrtc-adapter": "^7.4.0"
+    "webrtc-adapter": "^7.6.4"
   },
   "publishConfig": {
     "access": "public",

--- a/src/Modules/Verto/index.ts
+++ b/src/Modules/Verto/index.ts
@@ -8,6 +8,7 @@ import { trigger } from './services/Handler';
 import { localStorage } from './util/storage';
 import VertoHandler from './webrtc/VertoHandler';
 import { isValidOptions } from './util/helpers';
+import webrtcAdapter from 'webrtc-adapter';
 
 export const VERTO_PROTOCOL = 'verto-protocol';
 

--- a/src/Modules/Verto/webrtc/Peer.ts
+++ b/src/Modules/Verto/webrtc/Peer.ts
@@ -82,6 +82,9 @@ export default class Peer {
     if (!this._isOffer()) {
       return
     }
+    this._constraints.offerToReceiveAudio = Boolean(this.options.audio);
+    this._constraints.offerToReceiveVideo = Boolean(this.options.video);
+    logger.info('_createOffer - this._constraints', this._constraints);
     // FIXME: Use https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpTransceiver when available (M71)
     this.instance.createOffer(this._constraints)
       .then(this._setLocalDescription.bind(this))


### PR DESCRIPTION
- Fixed audio call problem on Firefox due to the **createOffer** method being called with both options of MediaStream enabled
`{ offerToReceiveAudio: true, offerToReceiveVideo: true }` even though I only use an **audio** options.

In the future, when we support `unified-plan` we will need to change this 
```
{ offerToReceiveAudio: true, offerToReceiveVideo: true }
```

To: 
```
 addTransceiver('audio')
```

These options are legacy
https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/createOffer

## 📝 To Do

- [x] All linters pass
- [x] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

1. In root folder `npm i ` && `npm run build`
2. Navigate into `examples/react`
3. Run `npm i` && `npm run setup` && `npm run start`
4. Open the example in a Firefox browser and try to make a call and answer

## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [x] Chrome
- [x] Firefox
- [x] Safari

