### PR TITLE
fix(WEBRTC-134) - Authentication required

### DIFF
--- a/examples/react/stories/components/WebDialer.jsx
+++ b/examples/react/stories/components/WebDialer.jsx
@@ -73,7 +73,9 @@ const WebDialer = ({
       startCall();
     });
     session.on('telnyx.error', (error) => {
-      console.log('telnyx.error', error);
+      console.error('telnyx.error', error);
+      setRegistered(false);
+      setRegistering(false);
     });
 
     session.on('telnyx.socket.error', (error) => {

--- a/src/Modules/Verto/index.ts
+++ b/src/Modules/Verto/index.ts
@@ -48,10 +48,6 @@ export default class Verto extends BrowserSession {
     const {
       login, password, passwd, login_token, userVariables,
     } = this.options;
-    if (this.sessionid) {
-      const sessidLogin = new Login(undefined, undefined, this.sessionid, undefined);
-      await this.execute(sessidLogin).catch(console.error);
-    }
     const msg = new Login(login, (password || passwd), login_token, this.sessionid, userVariables);
     const response = await this.execute(msg).catch(this._handleLoginError);
     if (response) {


### PR DESCRIPTION
- Removed unnecessary code that ran without user and password. 

## 📝 To Do

- [x] All linters pass
- [x] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

1. `npm i` && `npm run build`
2. Navigate into `examples/react`
3. Provide your user and password wrongly and try to make a call
4. See in the console log the message error `Authentication Failed`
5. Refresh the page and provide your user and password rightly and try to make a call
6. Check in the console log that you don't have the error about `Authentication required`


## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [x] Chrome
- [ ] Firefox
- [ ] Safari
