### PR TITLE
Fix README documentation on rejecting a call

### DIFF
--- a/packages/js/README.md
+++ b/packages/js/README.md
@@ -159,8 +159,8 @@ call.dtmf('1234');
 
 // Answer an incoming call
 call.answer();
-// Reject an incoming call
-call.reject();
+// Hangup (reject) an incoming call
+call.hangup();
 ```
 
 ---


### PR DESCRIPTION
`call.reject()` is not available in the newest version of the SDK, but the
example was never updated.