### PR TITLE
fix(ENGDESK-6713): add cause and causeCode when hangup the call

### DIFF
--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -213,6 +213,8 @@ export default abstract class BaseCall implements IWebRTCCall {
       const bye = new Bye({
         sessid: this.session.sessionid,
         dialogParams: this.options,
+        cause: 'USER_BUSY',
+        causeCode: 17,
       });
       this._execute(bye)
         .catch((error) => logger.error('telnyl_rtc.bye failed!', error))


### PR DESCRIPTION
- Add **cause** and **causeCode** when hangup the call

This change was necessary to avoid the necessity of click in hang-up many times.

## 📝 To Do

- [x] All linters pass
- [x] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

1. navigate into `packages/js` and run `yarn build`
2. navigate into `packages/js/examples/react-audio` and `npm i` && `npm run setup`
3. Use the WebDialer to make a call to react-audio and when the incoming call arrives click in hang up button.
4. See if on the react-audio app the call doesn't come again automatically.

## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [x] Chrome
- [x] Firefox
- [ ] Safari

