### PR TITLE
Add transitionary Chrome RTCConfiguration interface

### DIFF
--- a/packages/js/src/Modules/Verto/webrtc/Peer.ts
+++ b/packages/js/src/Modules/Verto/webrtc/Peer.ts
@@ -15,7 +15,7 @@ import {
   streamIsValid,
 } from '../util/webrtc';
 import { isFunction } from '../util/helpers';
-import { CallOptions, IDeprecatedRTCConfiguration } from './interfaces';
+import { CallOptions, IChromeRTCConfiguration } from './interfaces';
 import { trigger } from '../services/Handler';
 
 export default class Peer {
@@ -179,9 +179,9 @@ export default class Peer {
     return this.type === PeerType.Answer;
   }
 
-  private _config(): IDeprecatedRTCConfiguration {
+  private _config(): IChromeRTCConfiguration {
     const { iceServers = [] } = this.options;
-    const config: IDeprecatedRTCConfiguration = {
+    const config: IChromeRTCConfiguration = {
       sdpSemantics: 'plan-b',
       bundlePolicy: 'max-compat',
       iceServers,

--- a/packages/js/src/Modules/Verto/webrtc/Peer.ts
+++ b/packages/js/src/Modules/Verto/webrtc/Peer.ts
@@ -15,7 +15,7 @@ import {
   streamIsValid,
 } from '../util/webrtc';
 import { isFunction } from '../util/helpers';
-import { CallOptions } from './interfaces';
+import { CallOptions, IDeprecatedRTCConfiguration } from './interfaces';
 import { trigger } from '../services/Handler';
 
 export default class Peer {
@@ -179,10 +179,9 @@ export default class Peer {
     return this.type === PeerType.Answer;
   }
 
-  private _config(): RTCConfiguration {
+  private _config(): IDeprecatedRTCConfiguration {
     const { iceServers = [] } = this.options;
-    const config: RTCConfiguration = {
-      // @ts-ignore
+    const config: IDeprecatedRTCConfiguration = {
       sdpSemantics: 'plan-b',
       bundlePolicy: 'max-compat',
       iceServers,

--- a/packages/js/src/Modules/Verto/webrtc/interfaces.ts
+++ b/packages/js/src/Modules/Verto/webrtc/interfaces.ts
@@ -99,3 +99,8 @@ export interface ICantinaUser {
   scopes: string[];
   config?: object;
 }
+
+// https://webrtc.org/getting-started/unified-plan-transition-guide
+export interface IDeprecatedRTCConfiguration extends RTCConfiguration {
+  sdpSemantics: 'plan-b' | 'unified-plan';
+}

--- a/packages/js/src/Modules/Verto/webrtc/interfaces.ts
+++ b/packages/js/src/Modules/Verto/webrtc/interfaces.ts
@@ -101,6 +101,6 @@ export interface ICantinaUser {
 }
 
 // https://webrtc.org/getting-started/unified-plan-transition-guide
-export interface IDeprecatedRTCConfiguration extends RTCConfiguration {
-  sdpSemantics: 'plan-b' | 'unified-plan';
+export interface IChromeRTCConfiguration extends RTCConfiguration {
+  sdpSemantics?: 'plan-b' | 'unified-plan';
 }


### PR DESCRIPTION
Extends interface of `RTCConfiguration` to use during the [Unified Plan SDP format transition](https://webrtc.org/getting-started/unified-plan-transition-guide) instead of ignoring the TypeScript error.

## 📝 To Do

- [x] All linters pass
- [x] All tests pass
- [x] Change documentation based on my changes