### PR TITLE
fix(ENGDESK-7173): change the STUN_SERVER port from 3843 to 3478

### DIFF
--- a/packages/js/src/Modules/Verto/tests/Verto.test.ts
+++ b/packages/js/src/Modules/Verto/tests/Verto.test.ts
@@ -100,7 +100,7 @@ describe('Verto', () => {
       username: 'testuser',
     });
     expect(telnyxRTC.iceServers[1]).toEqual({
-      urls: 'stun:stun.telnyx.com:3843',
+      urls: 'stun:stun.telnyx.com:3478',
     });
   });
 

--- a/packages/js/src/Modules/Verto/util/constants/index.ts
+++ b/packages/js/src/Modules/Verto/util/constants/index.ts
@@ -5,7 +5,7 @@ export const SESSION_ID = 'sessId';
 
 export const PROD_HOST = 'wss://rtc.telnyx.com:14938';
 export const DEV_HOST = 'wss://rtcdev.telnyx.com:14938';
-export const STUN_SERVER = { urls: 'stun:stun.telnyx.com:3843' };
+export const STUN_SERVER = { urls: 'stun:stun.telnyx.com:3478' };
 export const TURN_SERVER = {
   urls: 'turn:turn.telnyx.com:3478?transport=tcp',
   username: 'testuser',


### PR DESCRIPTION
Error:
 - When it tries to make a video call using vanilla example, the code was returning `Codec ERROR`

Solution:
- We checked the port from STUN/TURN server and figure out that the port was wrong for the STUN server, so we change the STUN_SERVER port from 3843 to 3478.

## 📝 To Do

- [x] All linters pass
- [x] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

1. Access the `package/js/example/vanilla`
2. fill your credentials and try to make a video call using Chrome Browser
3. You should see your local video and the remote video.

## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [x] Chrome
- [x] Firefox
- [ ] Safari
