### PR TITLE
Document getting audio devices

### DIFF
--- a/packages/js/examples/react-audio/stories/Utilities.stories.js
+++ b/packages/js/examples/react-audio/stories/Utilities.stories.js
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import { withKnobs, text, boolean } from '@storybook/addon-knobs/react';
+
+import Utilities from './components/Utilities';
+
+export default {
+  title: 'Utilities',
+  decorators: [withKnobs],
+};
+
+export const Example = () => {
+  const production = boolean('Production', true);
+  const username = text('Connection Username', 'username');
+  const password = text('Connection Password', 'password');
+
+  return (
+    <Utilities
+      environment={production ? 'production' : 'development'}
+      username={username}
+      password={password}
+    />
+  );
+};

--- a/packages/js/examples/react-audio/stories/components/Utilities.jsx
+++ b/packages/js/examples/react-audio/stories/components/Utilities.jsx
@@ -34,9 +34,7 @@ function Utilities({ environment, username, password }) {
         setMessage('Received error attempting to connect');
       });
 
-      await clientRef.current.connect();
-
-      clientRef.current = clientRef.current;
+      clientRef.current.connect();
     } else {
       setMessage('Username and Password are required');
     }

--- a/packages/js/examples/react-audio/stories/components/Utilities.jsx
+++ b/packages/js/examples/react-audio/stories/components/Utilities.jsx
@@ -52,6 +52,16 @@ function Utilities({ environment, username, password }) {
     );
   };
 
+  const getAudioOutDevices = async () => {
+    const results = await clientRef.current.getAudioOutDevices();
+
+    setMessage(
+      `Audio output devices: ${
+        results.length ? results.map(({ label }) => label).join(', ') : 'None'
+      }`
+    );
+  };
+
   if (!clientRef.current && environment && username && password) {
     initClient();
   }
@@ -66,7 +76,13 @@ function Utilities({ environment, username, password }) {
         <section>
           <div>
             <button type='button' onClick={() => getAudioInDevices()}>
-              Get Audio In Devices
+              Get Audio Input Devices
+            </button>
+          </div>
+
+          <div>
+            <button type='button' onClick={() => getAudioOutDevices()}>
+              Get Audio Output Devices
             </button>
           </div>
 

--- a/packages/js/examples/react-audio/stories/components/Utilities.jsx
+++ b/packages/js/examples/react-audio/stories/components/Utilities.jsx
@@ -1,0 +1,61 @@
+import React, { useRef, useState } from 'react';
+import { TelnyxRTC } from '@telnyx/webrtc';
+
+function Utilities({ environment, username, password }) {
+  const clientRef = useRef();
+  const [isConnected, setIsConnected] = useState(false);
+  const [message, setMessage] = useState('');
+
+  if (!clientRef.current && environment && username && password) {
+    clientRef.current = new TelnyxRTC({
+      env: environment,
+      login: username,
+      password,
+    });
+  }
+
+  const connect = async () => {
+    if (environment && username && password) {
+      if (isConnected) {
+        setIsConnected(false);
+        setMessage('Reconnecting...');
+
+        await clientRef.current.disconnect();
+      }
+
+      const session = new TelnyxRTC({
+        env: environment,
+        login: username,
+        password,
+      });
+
+      session.on('telnyx.ready', () => {
+        setIsConnected(true);
+        setMessage('Connected');
+      });
+
+      session.on('telnyx.error', () => {
+        setMessage('Received error attempting to connect');
+      });
+
+      await session.connect();
+
+      clientRef.current = session;
+    } else {
+      setMessage('Username and Password are required');
+    }
+  };
+
+  return (
+    <div>
+      <section>
+        <div>{message && <p>{message}</p>}</div>
+        <button type='button' onClick={() => connect()}>
+          {isConnected ? 'Reconnect' : 'Connect'}
+        </button>
+      </section>
+    </div>
+  );
+}
+
+export default Utilities;

--- a/packages/js/src/Modules/Verto/BrowserSession.ts
+++ b/packages/js/src/Modules/Verto/BrowserSession.ts
@@ -220,7 +220,7 @@ export default abstract class BrowserSession extends BaseSession {
   }
 
   /**
-   * Return the device list supported by the browser
+   * Return the audio input device list supported by the browser
    */
   getAudioInDevices(): Promise<MediaDeviceInfo[]> {
     return getDevices(DeviceType.AudioIn).catch((error) => {

--- a/packages/js/src/Modules/Verto/BrowserSession.ts
+++ b/packages/js/src/Modules/Verto/BrowserSession.ts
@@ -221,6 +221,28 @@ export default abstract class BrowserSession extends BaseSession {
 
   /**
    * Return the audio input device list supported by the browser
+   *
+   * ## Examples
+   *
+   * Using async/await:
+   *
+   * ```js
+   * async function() {
+   *   const client = new TelnyxRTC(options);
+   *
+   *   let result = await client.getAudioInDevices();
+   *
+   *   console.log(result);
+   * }
+   * ```
+   *
+   * Using ES6 `Promises`:
+   *
+   * ```js
+   * client.getAudioInDevices().then((result) => {
+   *   console.log(result);
+   * });
+   * ```
    */
   getAudioInDevices(): Promise<MediaDeviceInfo[]> {
     return getDevices(DeviceType.AudioIn).catch((error) => {

--- a/packages/js/src/Modules/Verto/BrowserSession.ts
+++ b/packages/js/src/Modules/Verto/BrowserSession.ts
@@ -220,7 +220,7 @@ export default abstract class BrowserSession extends BaseSession {
   }
 
   /**
-   * Return the audio input device list supported by the browser
+   * Return the audio output devices supported by the browser.
    *
    * ## Examples
    *
@@ -252,7 +252,34 @@ export default abstract class BrowserSession extends BaseSession {
   }
 
   /**
-   * Return the device list supported by the browser
+   * Returns the audio output devices supported by the browser.
+   *
+   * Browser Compatibility Note: Firefox has yet to fully implement
+   * audio output devices. As of v63, this feature is behind the
+   * user preference `media.setsinkid.enabled`.
+   * See: https://bugzilla.mozilla.org/show_bug.cgi?id=1152401#c98
+   *
+   * ## Examples
+   *
+   * Using async/await:
+   *
+   * ```js
+   * async function() {
+   *   const client = new TelnyxRTC(options);
+   *
+   *   let result = await client.getAudioOutDevices();
+   *
+   *   console.log(result);
+   * }
+   * ```
+   *
+   * Using ES6 `Promises`:
+   *
+   * ```js
+   * client.getAudioOutDevices().then((result) => {
+   *   console.log(result);
+   * });
+   * ```
    */
   getAudioOutDevices(): Promise<MediaDeviceInfo[]> {
     return getDevices(DeviceType.AudioOut).catch((error) => {

--- a/packages/js/src/Modules/Verto/webrtc/helpers.ts
+++ b/packages/js/src/Modules/Verto/webrtc/helpers.ts
@@ -33,9 +33,13 @@ const _constraintsByKind = (
  * Retrieve device list using the browser APIs
  * If 'deviceId' or 'label' are missing it means we are on Safari (macOS or iOS)
  * so we must request permissions to the user and then refresh the device list.
+ *
+ * @NOTE Firefox has yet to fully implement audio output devices. As of v63,
+ * this feature is behind the user preference `media.setsinkid.enabled`.
+ * See: https://bugzilla.mozilla.org/show_bug.cgi?id=1152401#c98
  */
 const getDevices = async (
-  kind: string = null,
+  kind: MediaDeviceKind | undefined = null,
   fullList: boolean = false
 ): Promise<MediaDeviceInfo[]> => {
   let devices = await WebRTC.enumerateDevices().catch((error) => []);

--- a/packages/js/src/Modules/Verto/webrtc/helpers.ts
+++ b/packages/js/src/Modules/Verto/webrtc/helpers.ts
@@ -34,8 +34,9 @@ const _constraintsByKind = (
  * If 'deviceId' or 'label' are missing it means we are on Safari (macOS or iOS)
  * so we must request permissions to the user and then refresh the device list.
  *
- * @NOTE Firefox has yet to fully implement audio output devices. As of v63,
- * this feature is behind the user preference `media.setsinkid.enabled`.
+ * Browser Compatibility Note: Firefox has yet to fully implement
+ * audio output devices. As of v63, this feature is behind the
+ * user preference `media.setsinkid.enabled`.
  * See: https://bugzilla.mozilla.org/show_bug.cgi?id=1152401#c98
  */
 const getDevices = async (


### PR DESCRIPTION
Documents getting audio input and output devices.

## 📝 To Do

- [x] All linters pass
- [x] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

1. Run `npm run build` in `packages/js`
2. Run `npm start` in `packages/js/examples/react-audio`
3. Navigate to http://localhost:6006/?path=/story/utilities--example
4. Click "Get Audio Input Devices". Verify your input devices are displayed
5. Click "Get Audio Output Devices". Verify your input devices are displayed (see note about browser compatibility below)

## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [x] Chrome
- [x] Firefox
- [ ] Safari

Firefox doesn't return an audio output device list. I've documented this in the comments.

## 📸 Screenshots

Firefox:
<img width="521" alt="Screen Shot 2020-11-18 at 2 19 45 PM" src="https://user-images.githubusercontent.com/4672952/99595224-375d3800-29a9-11eb-8396-bd7215a9827a.png">
<img width="239" alt="Screen Shot 2020-11-18 at 2 19 49 PM" src="https://user-images.githubusercontent.com/4672952/99595228-388e6500-29a9-11eb-9a88-71d0eca6c324.png">

Chrome:
<img width="732" alt="Screen Shot 2020-11-18 at 2 19 59 PM" src="https://user-images.githubusercontent.com/4672952/99595236-3c21ec00-29a9-11eb-9ce9-1b701374a29e.png">
<img width="885" alt="Screen Shot 2020-11-18 at 2 20 06 PM" src="https://user-images.githubusercontent.com/4672952/99595237-3cba8280-29a9-11eb-9455-bcde7f4660f9.png">
