### PR TITLE
add type doc for disable and enable webcam methods

### DIFF
--- a/packages/js/src/Modules/Verto/BrowserSession.ts
+++ b/packages/js/src/Modules/Verto/BrowserSession.ts
@@ -364,7 +364,7 @@ export default abstract class BrowserSession extends BaseSession {
   /**
    * Disables use of the webcam in subsequent calls.
    *
-   * Note: The method will disable the video even though `video: true` is specified.
+   * Note: This method will disable the video even if `video: true` is specified.
    *
    * ## Examples
    *

--- a/packages/js/src/Modules/Verto/BrowserSession.ts
+++ b/packages/js/src/Modules/Verto/BrowserSession.ts
@@ -361,10 +361,46 @@ export default abstract class BrowserSession extends BaseSession {
     return this._videoConstraints;
   }
 
+  /**
+   * Disables use of the webcam in subsequent calls.
+   *
+   * Note: The method will disable the video even though `video: true` is specified.
+   *
+   * ## Examples
+   *
+   * ```js
+   * const client = new TelnyxRTC(options);
+   *
+   * client.disableWebcam();
+   * ```
+   *
+   * ```js
+   * const client = new TelnyxRTC({
+   *   ...options,
+   *   video: true
+   * });
+   *
+   * client.disableWebcam();
+   * ```
+   */
   disableWebcam() {
     this._videoConstraints = false;
   }
 
+  /**
+   * Enables use of the webcam in subsequent calls.
+   *
+   * Note: This setting will be ignored if `video: false` is
+   * specified when creating a new call.
+   *
+   * ## Examples
+   *
+   * ```js
+   * const client = new TelnyxRTC(options);
+   *
+   * client.enableWebcam();
+   * ```
+   */
   enableWebcam() {
     this._videoConstraints = true;
   }


### PR DESCRIPTION
Add type doc for disable and enable webcam methods

## 📝 To Do

- [x] All linters pass
- [x] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

### Test 1 - **disableWebCam**
1. cd `package/js/example/vanilla`
2. open the index.html file
3. disable checkbox video and make a call
4. you should **not see** the local videos.

### Test 2 - **enableWebCam**
1. enable checkbox video and make a call
2. you should **see** the videos.

### Test 2 - **enableWebCam**
1. access `newCall` and set `video: false`
2. enable checkbox video and make a call
3. you should **not see** the local video.

## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [x] Chrome
- [ ] Firefox
- [ ] Safari

### Test 1 - **disableWebCam**
![image](https://user-images.githubusercontent.com/16343871/99596489-1d394f00-29d5-11eb-8970-55f201c66060.png)


