### PR TITLE
feat(WEBRTC-227): add typedoc on getDevices method and create  a utility method to test

### DIFF
--- a/packages/js/examples/react-audio/stories/components/Utilities.js
+++ b/packages/js/examples/react-audio/stories/components/Utilities.js
@@ -4,7 +4,15 @@ import { TelnyxRTC } from '@telnyx/webrtc';
 function Utilities({ environment, username, password }) {
   const clientRef = useRef();
   const [isConnected, setIsConnected] = useState(false);
-  const [message, setMessage] = useState('');
+  const [log, setLog] = useState({ title: '', message: '' });
+
+  function getListFormat(label) {
+    return (
+      <ul>
+        <li>{label}</li>
+      </ul>
+    );
+  }
 
   const initClient = () => {
     clientRef.current = new TelnyxRTC({
@@ -15,10 +23,10 @@ function Utilities({ environment, username, password }) {
   };
 
   const connect = async () => {
-    if (environment && username && password) {
+    if (environment && username && password && clientRef.current) {
       if (isConnected) {
         setIsConnected(false);
-        setMessage('Reconnecting...');
+        setLog({ message: 'Reconnecting...' });
 
         await clientRef.current.disconnect();
       }
@@ -27,37 +35,52 @@ function Utilities({ environment, username, password }) {
 
       clientRef.current.on('telnyx.ready', () => {
         setIsConnected(true);
-        setMessage('Connected');
+        setLog({ message: 'Connected' });
       });
 
       clientRef.current.on('telnyx.error', () => {
-        setMessage('Received error attempting to connect');
+        setLog({ message: 'Received error attempting to connect' });
       });
 
       clientRef.current.connect();
     } else {
-      setMessage('Username and Password are required');
+      setLog({ message: 'Username and Password are required' });
     }
   };
 
   const getAudioInDevices = async () => {
     const results = await clientRef.current.getAudioInDevices();
 
-    setMessage(
-      `Audio input devices: ${
+    setLog({
+      title: 'Audio input devices:',
+      message: `${
         results.length ? results.map(({ label }) => label).join(', ') : 'None'
-      }`
-    );
+      }`,
+    });
   };
 
   const getAudioOutDevices = async () => {
     const results = await clientRef.current.getAudioOutDevices();
 
-    setMessage(
-      `Audio output devices: ${
+    setLog({
+      title: 'Audio output devices:',
+      message: `${
         results.length ? results.map(({ label }) => label).join(', ') : 'None'
-      }`
-    );
+      }`,
+    });
+  };
+
+  const getDevices = async () => {
+    const results = await clientRef.current.getDevices();
+
+    const devicelist = results.length
+      ? results.map(({ label }) => getListFormat(label))
+      : 'None';
+
+    setLog({
+      title: 'Return the device list supported by the browser',
+      message: devicelist,
+    });
   };
 
   if (!clientRef.current && environment && username && password) {
@@ -67,7 +90,9 @@ function Utilities({ environment, username, password }) {
   return (
     <div>
       <section>
-        <p>Log: {message}</p>
+        <p>
+          Log: {log.title} {log.message}
+        </p>
       </section>
 
       {clientRef.current && (
@@ -81,6 +106,12 @@ function Utilities({ environment, username, password }) {
           <div>
             <button type='button' onClick={() => getAudioOutDevices()}>
               Get Audio Output Devices
+            </button>
+          </div>
+
+          <div>
+            <button type='button' onClick={() => getDevices()}>
+              Get Device List
             </button>
           </div>
 

--- a/packages/js/src/Modules/Verto/BrowserSession.ts
+++ b/packages/js/src/Modules/Verto/BrowserSession.ts
@@ -209,9 +209,7 @@ export default abstract class BrowserSession extends BaseSession {
    * ```js
    * async function() {
    *   const client = new TelnyxRTC(options);
-   *
    *   let result = await client.getDevices();
-   *
    *   console.log(result);
    * }
    * ```

--- a/packages/js/src/Modules/Verto/BrowserSession.ts
+++ b/packages/js/src/Modules/Verto/BrowserSession.ts
@@ -200,7 +200,7 @@ export default abstract class BrowserSession extends BaseSession {
   }
 
   /**
-   * Return the device list supported by the browser
+   * Returns a list of devices supported by the browser
    *
    * ## Examples
    *

--- a/packages/js/src/Modules/Verto/BrowserSession.ts
+++ b/packages/js/src/Modules/Verto/BrowserSession.ts
@@ -201,6 +201,28 @@ export default abstract class BrowserSession extends BaseSession {
 
   /**
    * Return the device list supported by the browser
+   *
+   * ## Examples
+   *
+   * Using async/await:
+   *
+   * ```js
+   * async function() {
+   *   const client = new TelnyxRTC(options);
+   *
+   *   let result = await client.getDevices();
+   *
+   *   console.log(result);
+   * }
+   * ```
+   *
+   * Using ES6 `Promises`:
+   *
+   * ```js
+   * client.getDevices().then((result) => {
+   *   console.log(result);
+   * });
+   * ```
    */
   getDevices(): Promise<MediaDeviceInfo[]> {
     return getDevices().catch((error) => {


### PR DESCRIPTION
- Add typedoc on getDevices method
- Create a utility method to test

## 📝 To Do

- [x] All linters pass
- [x] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

1. Navigate into `package/js/examples/react-audio`
2. Run `npm i && npm start`
3. Access http://localhost:6006/?path=/story/utilities--example
4. Clinck on the button Get Device List

## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [x] Chrome
- [ ] Firefox
- [ ] Safari

## 📸 Screenshots

| Description | Screenshot |
| ----------- | ---------- |
| Desktop     |![image](https://user-images.githubusercontent.com/16343871/100238169-a63d1280-2f0e-11eb-9d9b-bb9ea0301a72.png)|
