### PR TITLE
feat(WEBRTC-226): add typedoc on getDeviceResolutions method and create a utility method to test

### DIFF
--- a/packages/js/examples/react-audio/stories/components/Utilities.js
+++ b/packages/js/examples/react-audio/stories/components/Utilities.js
@@ -6,9 +6,9 @@ function Utilities({ environment, username, password }) {
   const [isConnected, setIsConnected] = useState(false);
   const [log, setLog] = useState({ title: '', message: '' });
 
-  function getListFormat(label) {
+  function getListFormat({ key, label }) {
     return (
-      <ul>
+      <ul key={key}>
         <li>{label}</li>
       </ul>
     );
@@ -74,11 +74,36 @@ function Utilities({ environment, username, password }) {
     const results = await clientRef.current.getDevices();
 
     const devicelist = results.length
-      ? results.map(({ label }) => getListFormat(label))
+      ? results.map(({ label }, index) => getListFormat({ key: index, label }))
       : 'None';
 
     setLog({
       title: 'Return the device list supported by the browser',
+      message: devicelist,
+    });
+  };
+
+  const getDeviceResolutions = async () => {
+    const webcamList = await clientRef.current.getVideoDevices();
+    const deviceId = webcamList[0] ? webcamList[0].deviceId : '';
+    const label = webcamList[0] ? webcamList[0].label : '';
+
+    const results = await clientRef.current
+      .getDeviceResolutions(deviceId)
+      .catch((error) => console.log(error));
+
+    const devicelist =
+      results && results.length
+        ? results.map(({ resolution, width, height }, index) =>
+            getListFormat({
+              key: index,
+              label: `${resolution} - ${width}x${height}`,
+            })
+          )
+        : 'None';
+
+    setLog({
+      title: `Return the device resolutions of webcam ${label}`,
       message: devicelist,
     });
   };
@@ -90,9 +115,9 @@ function Utilities({ environment, username, password }) {
   return (
     <div>
       <section>
-        <p>
+        <div style={{ margin: '10px 0px' }}>
           Log: {log.title} {log.message}
-        </p>
+        </div>
       </section>
 
       {clientRef.current && (
@@ -112,6 +137,12 @@ function Utilities({ environment, username, password }) {
           <div>
             <button type='button' onClick={() => getDevices()}>
               Get Device List
+            </button>
+          </div>
+
+          <div>
+            <button type='button' onClick={() => getDeviceResolutions()}>
+              Get Device Resolutions
             </button>
           </div>
 

--- a/packages/js/src/Modules/Verto/BrowserSession.ts
+++ b/packages/js/src/Modules/Verto/BrowserSession.ts
@@ -358,7 +358,7 @@ export default abstract class BrowserSession extends BaseSession {
    *
    * If `deviceId` is `null`
    *
-   * 1. if `deviceId` is `null` and you do not have a webcam connect to your computer,
+   * 1. if `deviceId` is `null` and you don't have a webcam connected to your computer,
    * it will throw an error **Requested device not found**.
    *
    * 2. if `deviceId` is `null` and you have one or more webcam connect to your computer,

--- a/packages/js/src/Modules/Verto/BrowserSession.ts
+++ b/packages/js/src/Modules/Verto/BrowserSession.ts
@@ -352,7 +352,7 @@ export default abstract class BrowserSession extends BaseSession {
   /**
    * Returns supported resolution for the given webcam.
    *
-   * @param deviceId this is the `deviceId` from your webcam.
+   * @param deviceId the `deviceId` from your webcam.
    *
    * ## Examples
    *

--- a/packages/js/src/Modules/Verto/BrowserSession.ts
+++ b/packages/js/src/Modules/Verto/BrowserSession.ts
@@ -382,7 +382,7 @@ export default abstract class BrowserSession extends BaseSession {
    * });
    * ```
    *
-   * Case `deviceId` is **not** `null`
+   * If `deviceId` is **not** `null`
    *
    * it will return a list of resolutions from the `deviceId` sent.
    *

--- a/packages/js/src/Modules/Verto/BrowserSession.ts
+++ b/packages/js/src/Modules/Verto/BrowserSession.ts
@@ -361,8 +361,8 @@ export default abstract class BrowserSession extends BaseSession {
    * 1. if `deviceId` is `null` and you don't have a webcam connected to your computer,
    * it will throw an error with the message `"Requested device not found"`.
    *
-   * 2. if `deviceId` is `null` and you have one or more webcam connect to your computer,
-   * it will return a list of resolutions from the default one set up in your system.
+   * 2. if `deviceId` is `null` and you have one or more webcam connected to your computer,
+   * it will return a list of resolutions from the default device set up in your operating system.
    *
    * Using async/await:
    *

--- a/packages/js/src/Modules/Verto/BrowserSession.ts
+++ b/packages/js/src/Modules/Verto/BrowserSession.ts
@@ -352,9 +352,39 @@ export default abstract class BrowserSession extends BaseSession {
   /**
    * Return supported resolution for the given webcam.
    *
-   * @param deviceId this is the deviceId from your webcam.
+   * @param deviceId this is the `deviceId` from your webcam.
    *
    * ## Examples
+   *
+   * Case `deviceId` is `null`
+   *
+   * 1. if `deviceId` is `null` and you do not have a webcam connect to your computer,
+   * it will throw an error **Requested device not found**.
+   *
+   * 2. if `deviceId` is `null` and you have one or more webcam connect to your computer,
+   * it will return a list of resolutions from the default one set up in your system.
+   *
+   * Using async/await:
+   *
+   * ```js
+   * async function() {
+   *   const client = new TelnyxRTC(options);
+   *   let result = await client.getDeviceResolutions();
+   *   console.log(result);
+   * }
+   * ```
+   *
+   * Using ES6 `Promises`:
+   *
+   * ```js
+   * client.getDeviceResolutions().then((result) => {
+   *   console.log(result);
+   * });
+   * ```
+   *
+   * Case `deviceId` is **not** `null`
+   *
+   * it will return a list of resolutions from the `deviceId` sent.
    *
    * Using async/await:
    *
@@ -372,7 +402,6 @@ export default abstract class BrowserSession extends BaseSession {
    * client.getDeviceResolutions(deviceId).then((result) => {
    *   console.log(result);
    * });
-   * ```
    */
   async getDeviceResolutions(deviceId: string) {
     try {

--- a/packages/js/src/Modules/Verto/BrowserSession.ts
+++ b/packages/js/src/Modules/Verto/BrowserSession.ts
@@ -359,7 +359,7 @@ export default abstract class BrowserSession extends BaseSession {
    * If `deviceId` is `null`
    *
    * 1. if `deviceId` is `null` and you don't have a webcam connected to your computer,
-   * it will throw an error **Requested device not found**.
+   * it will throw an error with the message `"Requested device not found"`.
    *
    * 2. if `deviceId` is `null` and you have one or more webcam connect to your computer,
    * it will return a list of resolutions from the default one set up in your system.

--- a/packages/js/src/Modules/Verto/BrowserSession.ts
+++ b/packages/js/src/Modules/Verto/BrowserSession.ts
@@ -350,7 +350,7 @@ export default abstract class BrowserSession extends BaseSession {
   }
 
   /**
-   * Return supported resolution for the given webcam.
+   * Returns supported resolution for the given webcam.
    *
    * @param deviceId this is the `deviceId` from your webcam.
    *

--- a/packages/js/src/Modules/Verto/BrowserSession.ts
+++ b/packages/js/src/Modules/Verto/BrowserSession.ts
@@ -356,7 +356,7 @@ export default abstract class BrowserSession extends BaseSession {
    *
    * ## Examples
    *
-   * Case `deviceId` is `null`
+   * If `deviceId` is `null`
    *
    * 1. if `deviceId` is `null` and you do not have a webcam connect to your computer,
    * it will throw an error **Requested device not found**.

--- a/packages/js/src/Modules/Verto/BrowserSession.ts
+++ b/packages/js/src/Modules/Verto/BrowserSession.ts
@@ -351,6 +351,28 @@ export default abstract class BrowserSession extends BaseSession {
 
   /**
    * Return supported resolution for the given webcam.
+   *
+   * @param deviceId this is the deviceId from your webcam.
+   *
+   * ## Examples
+   *
+   * Using async/await:
+   *
+   * ```js
+   * async function() {
+   *   const client = new TelnyxRTC(options);
+   *   let result = await client.getDeviceResolutions(deviceId);
+   *   console.log(result);
+   * }
+   * ```
+   *
+   * Using ES6 `Promises`:
+   *
+   * ```js
+   * client.getDeviceResolutions(deviceId).then((result) => {
+   *   console.log(result);
+   * });
+   * ```
    */
   async getDeviceResolutions(deviceId: string) {
     try {


### PR DESCRIPTION
- Add typedoc on getDeviceResolutions method
- Create a utility method to test

## 📝 To Do

- [x] All linters pass
- [x] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

1. Navigate into `package/js/examples/react-audio`
2. Run `npm i && npm start`
3. Access http://localhost:6006/?path=/story/utilities--example
4. Clinck on the button Get Device Resolutions

## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [x] Chrome
- [ ] Firefox
- [ ] Safari

## 📸 Screenshots

| Description | Screenshot |
| ----------- | ---------- |
| Desktop     |![image](https://user-images.githubusercontent.com/16343871/100284667-48c8b600-2f4e-11eb-9ff4-6d3d1520ec69.png)|
