### PR TITLE
docs(WEBRTC-233): add typedoc on setAudioSettings method

### DIFF
--- a/packages/js/examples/react-audio/stories/components/Utilities.js
+++ b/packages/js/examples/react-audio/stories/components/Utilities.js
@@ -108,6 +108,35 @@ function Utilities({ environment, username, password }) {
     });
   };
 
+  const setAudioSettings = async () => {
+    const audioInList = await clientRef.current.getAudioInDevices();
+    const deviceId = audioInList[0] ? audioInList[0].deviceId : '';
+    const label = audioInList[0] ? audioInList[0].label : '';
+
+    const settings = {
+      micId: deviceId,
+      micLabel: label,
+      echoCancellation: true,
+    };
+
+    const results = await clientRef.current
+      .setAudioSettings(settings)
+      .catch((error) => console.log(error));
+
+    setLog({
+      title: (
+        <span>
+          Returns the audio settings applied for <b>{label}</b>
+        </span>
+      ),
+      message: (
+        <pre style={{ display: 'block', backgroundColor: '#ccc' }}>
+          {JSON.stringify(results, undefined, 2)}
+        </pre>
+      ),
+    });
+  };
+
   if (!clientRef.current && environment && username && password) {
     initClient();
   }
@@ -143,6 +172,12 @@ function Utilities({ environment, username, password }) {
           <div>
             <button type='button' onClick={() => getDeviceResolutions()}>
               Get Device Resolutions
+            </button>
+          </div>
+
+          <div>
+            <button type='button' onClick={() => setAudioSettings()}>
+              Set Audio Settings
             </button>
           </div>
 

--- a/packages/js/src/Modules/Verto/BrowserSession.ts
+++ b/packages/js/src/Modules/Verto/BrowserSession.ts
@@ -448,7 +448,7 @@ export default abstract class BrowserSession extends BaseSession {
   /**
    * setAudioSettings
    *
-   * You can set the default `audio` constraints for your client. [See here](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints#Properties_of_audio_tracks) for further details.
+   * Sets the default `audio` constraints for your client. [See here](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints#Properties_of_audio_tracks) for further details.
    *
    * Note: It's a common behaviour, in WebRTC applications,
    * to persist devices user's selection to then reuse them across visits.
@@ -462,7 +462,7 @@ export default abstract class BrowserSession extends BaseSession {
    *
    * @return `Promise<MediaTrackConstraints>` Audio constraints applied to the client.
    *
-   * ## Examples
+   * @examples
    *
    * Set microphone by `id` and `label` with the `echoCancellation` flag turned off:
    *

--- a/packages/js/src/Modules/Verto/BrowserSession.ts
+++ b/packages/js/src/Modules/Verto/BrowserSession.ts
@@ -476,7 +476,11 @@ export default abstract class BrowserSession extends BaseSession {
    * ```
    */
   async setAudioSettings(settings: IAudioSettings) {
+    if (!settings) {
+      throw new Error('You need to provide the settings object');
+    }
     const { micId, micLabel, ...constraints } = settings;
+
     removeUnsupportedConstraints(constraints);
     this._audioConstraints = await checkDeviceIdConstraints(
       micId,

--- a/packages/js/src/Modules/Verto/BrowserSession.ts
+++ b/packages/js/src/Modules/Verto/BrowserSession.ts
@@ -446,8 +446,6 @@ export default abstract class BrowserSession extends BaseSession {
   }
 
   /**
-   * setAudioSettings
-   *
    * Sets the default `audio` constraints for your client. [See here](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints#Properties_of_audio_tracks) for further details.
    *
    * Note: It's a common behaviour, in WebRTC applications,

--- a/packages/js/src/Modules/Verto/BrowserSession.ts
+++ b/packages/js/src/Modules/Verto/BrowserSession.ts
@@ -445,6 +445,36 @@ export default abstract class BrowserSession extends BaseSession {
     return { audio: this._audioConstraints, video: this._videoConstraints };
   }
 
+  /**
+   * setAudioSettings
+   *
+   * You can set the default `audio` constraints for your client. [See here](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints#Properties_of_audio_tracks) for further details.
+   *
+   * Note: It's a common behaviour, in WebRTC applications,
+   * to persist devices user's selection to then reuse them across visits.
+   * Due to a Webkit’s security protocols, Safari generates random `deviceId` on each page load.
+   * To avoid this issue you can specify two additional properties
+   * `micId` and `micLabel` in the constraints input parameter.
+   * The client will use these values to assure the microphone you want to use is available
+   * by matching both id and label with the device list retrieved from the browser.
+   *
+   * @param settings [MediaTrackConstraints](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints) object with the addition of `micId` and `micLabel`.
+   *
+   * @return `Promise<MediaTrackConstraints>` Audio constraints applied to the client.
+   *
+   * ## Examples
+   *
+   * Set microphone by `id` and `label` with the `echoCancellation` flag turned off:
+   *
+   * ```js
+   * // within an async function
+   * const constraints = await client.setAudioSettings({
+   *  micId: '772e94959e12e589b1cc71133d32edf543d3315cfd1d0a4076a60601d4ff4df8',
+   *  micLabel: 'Internal Microphone (Built-in)',
+   *  echoCancellation: false
+   * })
+   * ```
+   */
   async setAudioSettings(settings: IAudioSettings) {
     const { micId, micLabel, ...constraints } = settings;
     removeUnsupportedConstraints(constraints);


### PR DESCRIPTION
- add typedoc on setAudioSettings method

## 📝 To Do

- [x] All linters pass
- [ ] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

1. Navigate into `package/js/examples/react-audio`
2. Click on `Set Audio Settings` button
3. See if returns an object with the default mic label and with the applied settings.

## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## 📸 Screenshots

| Description | Screenshot |
| ----------- | ---------- |
| Desktop     |![image](https://user-images.githubusercontent.com/16343871/100622695-eb42b980-32ff-11eb-990f-5a89aa5c194b.png)|
