### PR TITLE
docs(WEBRTC-234): add typedoc on setVideoSettings method

### DIFF
--- a/packages/js/examples/react-audio/stories/components/Utilities.js
+++ b/packages/js/examples/react-audio/stories/components/Utilities.js
@@ -108,35 +108,6 @@ function Utilities({ environment, username, password }) {
     });
   };
 
-  const setAudioSettings = async () => {
-    const audioInList = await clientRef.current.getAudioInDevices();
-    const deviceId = audioInList[0] ? audioInList[0].deviceId : '';
-    const label = audioInList[0] ? audioInList[0].label : '';
-
-    const settings = {
-      micId: deviceId,
-      micLabel: label,
-      echoCancellation: true,
-    };
-
-    const results = await clientRef.current
-      .setAudioSettings(settings)
-      .catch((error) => console.log(error));
-
-    setLog({
-      title: (
-        <span>
-          Returns the audio settings applied for <b>{label}</b>
-        </span>
-      ),
-      message: (
-        <pre style={{ display: 'block', backgroundColor: '#ccc' }}>
-          {JSON.stringify(results, undefined, 2)}
-        </pre>
-      ),
-    });
-  };
-
   const setVideoSettings = async () => {
     const videoInList = await clientRef.current.getVideoDevices();
     const deviceId = videoInList[0] ? videoInList[0].deviceId : '';
@@ -202,12 +173,6 @@ function Utilities({ environment, username, password }) {
           <div>
             <button type='button' onClick={() => getDeviceResolutions()}>
               Get Device Resolutions
-            </button>
-          </div>
-
-          <div>
-            <button type='button' onClick={() => setAudioSettings()}>
-              Set Audio Settings
             </button>
           </div>
 

--- a/packages/js/examples/react-audio/stories/components/Utilities.js
+++ b/packages/js/examples/react-audio/stories/components/Utilities.js
@@ -126,7 +126,37 @@ function Utilities({ environment, username, password }) {
     setLog({
       title: (
         <span>
-          Returns the audio applied settings for <b>{label}</b>
+          Returns the audio settings applied for <b>{label}</b>
+        </span>
+      ),
+      message: (
+        <pre style={{ display: 'block', backgroundColor: '#ccc' }}>
+          {JSON.stringify(results, undefined, 2)}
+        </pre>
+      ),
+    });
+  };
+
+  const setVideoSettings = async () => {
+    const videoInList = await clientRef.current.getVideoDevices();
+    const deviceId = videoInList[0] ? videoInList[0].deviceId : '';
+    const label = videoInList[0] ? videoInList[0].label : '';
+
+    const settings = {
+      camId: deviceId,
+      camLabel: label,
+      width: 1080,
+      height: 720,
+    };
+
+    const results = await clientRef.current
+      .setVideoSettings(settings)
+      .catch((error) => console.log(error));
+
+    setLog({
+      title: (
+        <span>
+          Returns the video settings applied for <b>{label}</b>
         </span>
       ),
       message: (
@@ -178,6 +208,12 @@ function Utilities({ environment, username, password }) {
           <div>
             <button type='button' onClick={() => setAudioSettings()}>
               Set Audio Settings
+            </button>
+          </div>
+
+          <div>
+            <button type='button' onClick={() => setVideoSettings()}>
+              Set Video Settings
             </button>
           </div>
 

--- a/packages/js/examples/react-audio/stories/components/Utilities.js
+++ b/packages/js/examples/react-audio/stories/components/Utilities.js
@@ -108,6 +108,35 @@ function Utilities({ environment, username, password }) {
     });
   };
 
+  const setAudioSettings = async () => {
+    const audioInList = await clientRef.current.getAudioInDevices();
+    const deviceId = audioInList[0] ? audioInList[0].deviceId : '';
+    const label = audioInList[0] ? audioInList[0].label : '';
+
+    const settings = {
+      micId: deviceId,
+      micLabel: label,
+      echoCancellation: true,
+    };
+
+    const results = await clientRef.current
+      .setAudioSettings(settings)
+      .catch((error) => console.log(error));
+
+    setLog({
+      title: (
+        <span>
+          Returns the audio applied settings for <b>{label}</b>
+        </span>
+      ),
+      message: (
+        <pre style={{ display: 'block', backgroundColor: '#ccc' }}>
+          {JSON.stringify(results, undefined, 2)}
+        </pre>
+      ),
+    });
+  };
+
   if (!clientRef.current && environment && username && password) {
     initClient();
   }
@@ -143,6 +172,12 @@ function Utilities({ environment, username, password }) {
           <div>
             <button type='button' onClick={() => getDeviceResolutions()}>
               Get Device Resolutions
+            </button>
+          </div>
+
+          <div>
+            <button type='button' onClick={() => setAudioSettings()}>
+              Set Audio Settings
             </button>
           </div>
 

--- a/packages/js/src/Modules/Verto/BrowserSession.ts
+++ b/packages/js/src/Modules/Verto/BrowserSession.ts
@@ -445,6 +445,36 @@ export default abstract class BrowserSession extends BaseSession {
     return { audio: this._audioConstraints, video: this._videoConstraints };
   }
 
+  /**
+   * setAudioSettings
+   *
+   * You can set the default audio constraints for your client. [See here](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints#Properties_of_audio_tracks) for further details.
+   *
+   * Notes: Note: It's a common behaviour, in WebRTC applications,
+   * to persist devices user's selection to then reuse them across visits.
+   * Due to a Webkit’s security protocols, Safari generates random `deviceId` on each page load.
+   * To avoid this issue you can specify two additional properties
+   * `micId` and `micLabel` in the constraints input parameter.
+   * The client will use these values to assure the microphone you want to use is available
+   * by matching both id and label with the device list retrieved from the browser.
+   *
+   * @param settings - [MediaTrackConstraints](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints) object with the addition of `micId` and `micLabel`.
+   *
+   * @return `Promise<MediaTrackConstraints>` - Audio constraints applied to the client.
+   *
+   * ## Examples
+   *
+   * Set microphone by `id` and `label` with the `echoCancellation` flag turned off.:
+   *
+   * ```js
+   * // within an async function
+   * const constraints = await client.setAudioSettings({
+   *  micId: '772e94959e12e589b1cc71133d32edf543d3315cfd1d0a4076a60601d4ff4df8',
+   *  micLabel: 'Internal Microphone (Built-in)',
+   *  echoCancellation: false
+   * })
+   * ```
+   */
   async setAudioSettings(settings: IAudioSettings) {
     const { micId, micLabel, ...constraints } = settings;
     removeUnsupportedConstraints(constraints);

--- a/packages/js/src/Modules/Verto/BrowserSession.ts
+++ b/packages/js/src/Modules/Verto/BrowserSession.ts
@@ -448,9 +448,9 @@ export default abstract class BrowserSession extends BaseSession {
   /**
    * setAudioSettings
    *
-   * You can set the default audio constraints for your client. [See here](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints#Properties_of_audio_tracks) for further details.
+   * You can set the default `audio` constraints for your client. [See here](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints#Properties_of_audio_tracks) for further details.
    *
-   * Notes: Note: It's a common behaviour, in WebRTC applications,
+   * Note: It's a common behaviour, in WebRTC applications,
    * to persist devices user's selection to then reuse them across visits.
    * Due to a Webkit’s security protocols, Safari generates random `deviceId` on each page load.
    * To avoid this issue you can specify two additional properties
@@ -458,13 +458,13 @@ export default abstract class BrowserSession extends BaseSession {
    * The client will use these values to assure the microphone you want to use is available
    * by matching both id and label with the device list retrieved from the browser.
    *
-   * @param settings - [MediaTrackConstraints](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints) object with the addition of `micId` and `micLabel`.
+   * @param settings [MediaTrackConstraints](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints) object with the addition of `micId` and `micLabel`.
    *
-   * @return `Promise<MediaTrackConstraints>` - Audio constraints applied to the client.
+   * @return `Promise<MediaTrackConstraints>` Audio constraints applied to the client.
    *
    * ## Examples
    *
-   * Set microphone by `id` and `label` with the `echoCancellation` flag turned off.:
+   * Set microphone by `id` and `label` with the `echoCancellation` flag turned off.
    *
    * ```js
    * // within an async function
@@ -539,6 +539,37 @@ export default abstract class BrowserSession extends BaseSession {
     this._audioConstraints = true;
   }
 
+  /**
+   * setVideoSettings
+   *
+   * You can set the default `video` constraints for your client. [See here](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints#Properties_of_video_tracks) for further details.
+   *
+   * Note: It's a common behaviour, in WebRTC applications,
+   * to persist devices user's selection to then reuse them across visits.
+   * Due to a Webkit’s security protocols, Safari generates random `deviceId` on each page load.
+   * To avoid this issue you can specify two additional properties
+   * `camId` and `camLabel` in the constraints input parameter.
+   * The client will use these values to assure the webcam you want to use is available
+   * by matching both `id` and `label` with the device list retrieved from the browser.
+   *
+   * @param settings [MediaTrackConstraints](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints) object with the addition of `camId` and `camLabel`.
+   *
+   * @return `Promise<MediaTrackConstraints>` Video constraints applied to the client.
+   *
+   * ## Examples
+   *
+   * Set webcam by `id` and `label` with 720p resolution.
+   *
+   * ```js
+   * // within an async function
+   * const constraints = await client.setVideoSettings({
+   *  camId: '882e94959e12e589b1cc71133d32edf543d3315cfd1d0a4076a60601d4ff4df8',
+   *  camLabel: 'Default WebCam (Built-in)',
+   *  width: 1080,
+   *  height: 720
+   * })
+   * ```
+   */
   async setVideoSettings(settings: IVideoSettings) {
     const { camId, camLabel, ...constraints } = settings;
     removeUnsupportedConstraints(constraints);

--- a/packages/js/src/Modules/Verto/BrowserSession.ts
+++ b/packages/js/src/Modules/Verto/BrowserSession.ts
@@ -476,7 +476,12 @@ export default abstract class BrowserSession extends BaseSession {
    * ```
    */
   async setAudioSettings(settings: IAudioSettings) {
+    if (!settings) {
+      throw new Error('You need to provide the settings object');
+    }
+
     const { micId, micLabel, ...constraints } = settings;
+
     removeUnsupportedConstraints(constraints);
     this._audioConstraints = await checkDeviceIdConstraints(
       micId,
@@ -571,7 +576,12 @@ export default abstract class BrowserSession extends BaseSession {
    * ```
    */
   async setVideoSettings(settings: IVideoSettings) {
+    if (!settings) {
+      throw new Error('You need to provide the settings object');
+    }
+
     const { camId, camLabel, ...constraints } = settings;
+
     removeUnsupportedConstraints(constraints);
     this._videoConstraints = await checkDeviceIdConstraints(
       camId,

--- a/packages/js/src/Modules/Verto/BrowserSession.ts
+++ b/packages/js/src/Modules/Verto/BrowserSession.ts
@@ -445,41 +445,8 @@ export default abstract class BrowserSession extends BaseSession {
     return { audio: this._audioConstraints, video: this._videoConstraints };
   }
 
-  /**
-   * Sets the default `audio` constraints for your client. [See here](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints#Properties_of_audio_tracks) for further details.
-   *
-   * Note: It's a common behaviour, in WebRTC applications,
-   * to persist devices user's selection to then reuse them across visits.
-   * Due to a Webkit’s security protocols, Safari generates random `deviceId` on each page load.
-   * To avoid this issue you can specify two additional properties
-   * `micId` and `micLabel` in the constraints input parameter.
-   * The client will use these values to assure the microphone you want to use is available
-   * by matching both id and label with the device list retrieved from the browser.
-   *
-   * @param settings [MediaTrackConstraints](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints) object with the addition of `micId` and `micLabel`.
-   *
-   * @return `Promise<MediaTrackConstraints>` Audio constraints applied to the client.
-   *
-   * ## Examples
-   *
-   * Set microphone by `id` and `label` with the `echoCancellation` flag turned off.
-   *
-   * ```js
-   * // within an async function
-   * const constraints = await client.setAudioSettings({
-   *  micId: '772e94959e12e589b1cc71133d32edf543d3315cfd1d0a4076a60601d4ff4df8',
-   *  micLabel: 'Internal Microphone (Built-in)',
-   *  echoCancellation: false
-   * })
-   * ```
-   */
   async setAudioSettings(settings: IAudioSettings) {
-    if (!settings) {
-      throw new Error('You need to provide the settings object');
-    }
-
     const { micId, micLabel, ...constraints } = settings;
-
     removeUnsupportedConstraints(constraints);
     this._audioConstraints = await checkDeviceIdConstraints(
       micId,
@@ -543,9 +510,7 @@ export default abstract class BrowserSession extends BaseSession {
   }
 
   /**
-   * setVideoSettings
-   *
-   * You can set the default `video` constraints for your client. [See here](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints#Properties_of_video_tracks) for further details.
+   * Sets the default `video` constraints for your client. [See here](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints#Properties_of_video_tracks) for further details.
    *
    * Note: It's a common behaviour, in WebRTC applications,
    * to persist devices user's selection to then reuse them across visits.
@@ -559,7 +524,7 @@ export default abstract class BrowserSession extends BaseSession {
    *
    * @return `Promise<MediaTrackConstraints>` Video constraints applied to the client.
    *
-   * ## Examples
+   * @examples
    *
    * Set webcam by `id` and `label` with 720p resolution.
    *

--- a/packages/js/src/Modules/Verto/BrowserSession.ts
+++ b/packages/js/src/Modules/Verto/BrowserSession.ts
@@ -446,9 +446,7 @@ export default abstract class BrowserSession extends BaseSession {
   }
 
   /**
-   * setAudioSettings
-   *
-   * You can set the default `audio` constraints for your client. [See here](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints#Properties_of_audio_tracks) for further details.
+   * Sets the default `audio` constraints for your client. [See here](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints#Properties_of_audio_tracks) for further details.
    *
    * Note: It's a common behaviour, in WebRTC applications,
    * to persist devices user's selection to then reuse them across visits.


### PR DESCRIPTION
- add typedoc on setVideoSettings method

## 📝 To Do

- [x] All linters pass
- [ ] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

1. Navigate into `package/js/examples/react-audio`
2. Click on `Set Video Settings` button
3. See if returns an object with the default mic label and with the applied settings.

## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [x] Chrome
- [ ] Firefox
- [ ] Safari

## 📸 Screenshots

| Description | Screenshot |
| ----------- | ---------- |
| Desktop     |![image](https://user-images.githubusercontent.com/16343871/100632914-2b0f9e00-330c-11eb-8d4e-6505d5c9e456.png)|
