### PR TITLE
feat(WEBRTC-232): remove refreshToken and blade methods

### DIFF
--- a/packages/js/src/Modules/Verto/index.ts
+++ b/packages/js/src/Modules/Verto/index.ts
@@ -8,6 +8,7 @@ import { trigger } from './services/Handler';
 import { sessionStorage } from './util/storage';
 import VertoHandler from './webrtc/VertoHandler';
 import { isValidOptions } from './util/helpers';
+import logger from './util/logger';
 
 export const VERTO_PROTOCOL = 'verto-protocol';
 
@@ -64,6 +65,7 @@ export default class Verto extends BrowserSession {
       this.sessionid = response.sessid;
       sessionStorage.setItem(SESSION_ID, this.sessionid);
       trigger(SwEvent.Ready, this, this.uuid);
+      logger.info('Session Ready!');
     }
   }
 

--- a/packages/js/src/Modules/Verto/webrtc/constants.ts
+++ b/packages/js/src/Modules/Verto/webrtc/constants.ts
@@ -36,7 +36,6 @@ export const NOTIFICATION_TYPE = {
   callUpdate: 'callUpdate',
   vertoClientReady: 'vertoClientReady',
   userMediaError: 'userMediaError',
-  refreshToken: 'refreshToken',
 };
 
 export const DEFAULT_CALL_OPTIONS: CallOptions = {


### PR DESCRIPTION
We don't support `refreshToken` methods, so I removed these methods related to JWT expiration.

## 📝 To Do

- [x] All linters pass
- [x] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

1. Navigate into `package/js` && npm run build && `npm run test`
2. Run `npm pack` get the `.tgz` file and install inside `examples/react-video` using `npm i`
3. Make a call and receive a call to see if it is working.

## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [x] Chrome
- [ ] Firefox
- [ ] Safari


