### PR TITLE
Document speaker property

### DIFF
--- a/packages/js/examples/react-audio/stories/components/Utilities.js
+++ b/packages/js/examples/react-audio/stories/components/Utilities.js
@@ -1,10 +1,12 @@
-import React, { useRef, useState } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import { TelnyxRTC } from '@telnyx/webrtc';
 
 function Utilities({ environment, username, password }) {
   const clientRef = useRef();
   const [isConnected, setIsConnected] = useState(false);
   const [log, setLog] = useState({ title: '', message: '' });
+  const [speakers, setSpeakers] = useState([]);
+  const [selectedSpeakerId, setSelectedSpeakerId] = useState('');
 
   function getListFormat({ key, label }) {
     return (
@@ -68,11 +70,32 @@ function Utilities({ environment, username, password }) {
   const getAudioOutDevices = async () => {
     const results = await clientRef.current.getAudioOutDevices();
 
+    setSpeakers(results);
+
     setLog({
       title: 'Audio output devices:',
       message: `${
         results.length ? results.map(({ label }) => label).join(', ') : 'None'
       }`,
+    });
+  };
+
+  const setSpeaker = (speakerId) => {
+    clientRef.current.speaker = speakerId;
+
+    setLog({
+      message: 'Updated speaker',
+    });
+  };
+
+  const getSpeaker = () => {
+    const speakerDevice =
+      clientRef.current.speaker &&
+      speakers.find(({ deviceId }) => deviceId === clientRef.current.speaker);
+
+    setLog({
+      title: 'Speaker:',
+      message: speakerDevice ? speakerDevice.label : 'None',
     });
   };
 
@@ -177,6 +200,16 @@ function Utilities({ environment, username, password }) {
     initClient();
   }
 
+  useEffect(() => {
+    const getDeviceLists = async () => {
+      const results = await clientRef.current.getAudioOutDevices();
+
+      setSpeakers(results);
+    };
+
+    getDeviceLists();
+  }, []);
+
   return (
     <div>
       <section>
@@ -194,8 +227,29 @@ function Utilities({ environment, username, password }) {
           </div>
 
           <div>
+            <label htmlFor='audioOutDevices'>Choose speaker:</label>{' '}
+            <select
+              id='audioOutDevices'
+              onChange={(e) => setSelectedSpeakerId(e.target.value)}
+            >
+              {speakers.map((device) => (
+                <option key={device.deviceId} value={device.deviceId}>
+                  {device.label}
+                </option>
+              ))}
+            </select>{' '}
+            <button type='button' onClick={() => setSpeaker(selectedSpeakerId)}>
+              Update
+            </button>
+          </div>
+
+          <div>
             <button type='button' onClick={() => getAudioOutDevices()}>
               Get Audio Output Devices
+            </button>
+
+            <button type='button' onClick={() => getSpeaker()}>
+              Get Speaker
             </button>
           </div>
 

--- a/packages/js/src/Modules/Verto/BrowserSession.ts
+++ b/packages/js/src/Modules/Verto/BrowserSession.ts
@@ -25,8 +25,8 @@ import {
   getUserMedia,
   assureDeviceId,
 } from './webrtc/helpers';
-import { findElementByType } from './util/helpers';
-import { Unsubscribe, Subscribe, Broadcast } from './messages/Verto';
+import { findElementByType, objEmpty } from './util/helpers';
+import { Unsubscribe, Subscribe, Broadcast, Result } from './messages/Verto';
 import { sessionStorage } from './util/storage';
 import { stopStream } from './util/webrtc';
 import { IWebRTCCall } from './webrtc/interfaces';
@@ -647,12 +647,27 @@ export default abstract class BrowserSession extends BaseSession {
     return this._iceServers;
   }
 
+  /**
+   * Sets the default audio output device for subsequent calls.
+   *
+   * ## Example
+   *
+   * ```js
+   * let result = await client.getAudioOutDevices();
+   *
+   * if (result.length) {
+   *   client.speaker = result[1].deviceId;
+   * }
+   * ```
+   *
+   * @type {(string | null)}
+   */
   set speaker(deviceId: string) {
     this._speaker = deviceId;
   }
 
   /**
-   * Audio output device currently used by the client
+   * Default audio output device, if set by client.
    *
    * ## Example
    *
@@ -660,7 +675,7 @@ export default abstract class BrowserSession extends BaseSession {
    * const client = new TelnyxRTC(options);
    *
    * console.log(client.speaker);
-   * // => "device ID"
+   * // => "abc123xyz"
    * ```
    *
    * @type {(string | null)}

--- a/packages/js/src/Modules/Verto/BrowserSession.ts
+++ b/packages/js/src/Modules/Verto/BrowserSession.ts
@@ -651,7 +651,21 @@ export default abstract class BrowserSession extends BaseSession {
     this._speaker = deviceId;
   }
 
-  get speaker() {
+  /**
+   * Audio output device currently used by the client
+   *
+   * ## Example
+   *
+   * ```js
+   * const client = new TelnyxRTC(options);
+   *
+   * console.log(client.speaker);
+   * // => "device ID"
+   * ```
+   *
+   * @type {(string | null)}
+   */
+  get speaker(): string | null {
     return this._speaker;
   }
 

--- a/packages/js/src/Modules/Verto/BrowserSession.ts
+++ b/packages/js/src/Modules/Verto/BrowserSession.ts
@@ -650,7 +650,7 @@ export default abstract class BrowserSession extends BaseSession {
   /**
    * Sets the default audio output device for subsequent calls.
    *
-   * ## Example
+   * @example
    *
    * ```js
    * let result = await client.getAudioOutDevices();
@@ -669,7 +669,7 @@ export default abstract class BrowserSession extends BaseSession {
   /**
    * Default audio output device, if set by client.
    *
-   * ## Example
+   * @example
    *
    * ```js
    * const client = new TelnyxRTC(options);
@@ -677,8 +677,6 @@ export default abstract class BrowserSession extends BaseSession {
    * console.log(client.speaker);
    * // => "abc123xyz"
    * ```
-   *
-   * @type {(string | null)}
    */
   get speaker(): string | null {
     return this._speaker;


### PR DESCRIPTION
Documents speaker getter & setter, adds manual testing utility

## 📝 To Do

- [ ] All linters pass
- [ ] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

1. Run storybook app in `js/examples/react-audio`
2. Go to http://localhost:6006/?path=/story/utilities--example in Chrome
3. Choose a different speaker and click "Update"
4. Click "Get Speaker". Verify that the new speaker is returned


## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [x] Chrome
- [ ] Firefox
- [ ] Safari

## 📸 Screenshots

<img width="448" alt="Screen Shot 2020-12-02 at 3 44 41 PM" src="https://user-images.githubusercontent.com/4672952/100945064-5da8ca80-34b5-11eb-90a2-2619d3333f8a.png">

