### PR TITLE
Document event types

### DIFF
--- a/packages/js/src/Modules/Verto/BaseSession.ts
+++ b/packages/js/src/Modules/Verto/BaseSession.ts
@@ -190,20 +190,6 @@ export default abstract class BaseSession {
   /**
    * Attaches an event handler for a specific type of event.
    *
-   * ## Examples
-   *
-   * Subscribe to the `telnyx.ready` and `telnyx.error` events.
-   *
-   * ```js
-   * const client = new TelnyxRTC(options);
-   *
-   * client.on('telnyx.ready', (client) => {
-   *   // Your client is ready!
-   * }).on('telnyx.error', (error) => {
-   *   // Got an error...
-   * })
-   * ```
-   *
    * ## Events
    * |   |   |
    * |---|---|
@@ -217,8 +203,21 @@ export default abstract class BaseSession {
    *
    * @param eventName Event name.
    * @param callback Function to call when the event comes.
-   *
    * @return The client object itself.
+   *
+   * @examples
+   *
+   * Subscribe to the `telnyx.ready` and `telnyx.error` events.
+   *
+   * ```js
+   * const client = new TelnyxRTC(options);
+   *
+   * client.on('telnyx.ready', (client) => {
+   *   // Your client is ready!
+   * }).on('telnyx.error', (error) => {
+   *   // Got an error...
+   * })
+   * ```
    */
   on(eventName: string, callback: Function) {
     register(eventName, callback, this.uuid);

--- a/packages/js/src/Modules/Verto/BaseSession.ts
+++ b/packages/js/src/Modules/Verto/BaseSession.ts
@@ -190,11 +190,6 @@ export default abstract class BaseSession {
   /**
    * Attaches an event handler for a specific type of event.
    *
-   * @param eventName Event name.
-   * @param callback Function to call when the event comes.
-   *
-   * @return The client object itself.
-   *
    * ## Examples
    *
    * Subscribe to the `telnyx.ready` and `telnyx.error` events.
@@ -208,6 +203,22 @@ export default abstract class BaseSession {
    *   // Got an error...
    * })
    * ```
+   *
+   * ## Events
+   * |   |   |
+   * |---|---|
+   * | `telnyx.ready` | The client is authenticated and available to use |
+   * | `telnyx.error` | An error occurred at the session level |
+   * | `telnyx.notification` | An update to the call or session |
+   * | `telnyx.socket.open` | The WebSocket connection has been made |
+   * | `telnyx.socket.close` | The WebSocket connection is set to close |
+   * | `telnyx.socket.error` | An error occurred at the WebSocket level |
+   * | `telnyx.socket.message` | The client has received a message through WebSockets |
+   *
+   * @param eventName Event name.
+   * @param callback Function to call when the event comes.
+   *
+   * @return The client object itself.
    */
   on(eventName: string, callback: Function) {
     register(eventName, callback, this.uuid);


### PR DESCRIPTION
Documents possible event names in `on` method.

Note: I did some research into ways to document event names in a similar fashion but didn't find a solution that rendered nicely with typedoc. I've tried documenting the enum directly, but wasn't getting a typedoc output at all. Open to other ideas.

## 📸 Screenshots

Ran `npm run docs` and previewed the output:
<img width="1178" alt="Screen Shot 2020-12-02 at 5 26 17 PM" src="https://user-images.githubusercontent.com/4672952/100951637-ceef7a00-34c3-11eb-9ef9-a57454553363.png">

