### PR TITLE
Update docs when drafting release

### DIFF
--- a/.github/workflows/webrtc-draft-release.yml
+++ b/.github/workflows/webrtc-draft-release.yml
@@ -43,6 +43,15 @@ jobs:
     - name: Build
       working-directory: packages/js
       run: npm run build
+    - name: Generate docs
+      working-directory: packages/js
+      run: npm run docs
+    - name: Commit docs
+      working-directory: packages/js
+      run: |
+        # Stage the file, commit and push
+        git add docs
+        git commit -m "docs: Update TS docs" || echo "No docs changes to commit"
     - name: Create draft release
       working-directory: packages/js
       run: npm run release -- --ci --github.draft --no-npm.publish

--- a/.github/workflows/webrtc-draft-release.yml
+++ b/.github/workflows/webrtc-draft-release.yml
@@ -45,11 +45,8 @@ jobs:
       run: npm run build
     - name: Generate docs
       working-directory: packages/js
-      run: npm run docs
-    - name: Commit docs
-      working-directory: packages/js
       run: |
-        # Stage the file, commit and push
+        npm run docs -- --gitRevision main # IDEA Set git revision to release-it tag
         git add docs
         git commit -m "docs: Update TS docs" || echo "No docs changes to commit"
     - name: Create draft release

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -22,7 +22,7 @@
     "prepare": "npm run build",
     "prepublishOnly": "if [[ -z \"${CI}\" ]]; then npm run test; else echo \"Skipping tests in CI\"; fi",
     "test": "jest",
-    "docs": "typedoc src --gitRevision main",
+    "docs": "typedoc src",
     "release": "release-it",
     "compile": "../../node_modules/.bin/tsc -w",
     "format": "prettier --write 'src/**/*.ts'"

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -22,7 +22,7 @@
     "prepare": "npm run build",
     "prepublishOnly": "if [[ -z \"${CI}\" ]]; then npm run test; else echo \"Skipping tests in CI\"; fi",
     "test": "jest",
-    "docs": "typedoc src",
+    "docs": "typedoc src --gitRevision main",
     "release": "release-it",
     "compile": "../../node_modules/.bin/tsc -w",
     "format": "prettier --write 'src/**/*.ts'"


### PR DESCRIPTION
Adds step to draft release workflow that generates and commits `js/docs` changes.

## 📝 To Do

- [ ] All linters pass
- [ ] All tests pass
- [x] Change documentation based on my changes