### PR TITLE
Fix changelog versioning

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -32,7 +32,11 @@ jobs:
       run: npm ci --ignore-scripts
     - name: Publish package
       working-directory: packages/js
-      run: npm publish --access public
+      run: |
+        npm run release -- \
+        --ci \
+        --no-git \
+        --no-github
       env:
         CI: true
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_CI_TOKEN }}
+        NPM_TOKEN: ${{ secrets.NPM_CI_TOKEN }}

--- a/.github/workflows/webrtc-draft-release.yml
+++ b/.github/workflows/webrtc-draft-release.yml
@@ -51,7 +51,14 @@ jobs:
         git commit -m "docs: Update TS docs" || echo "No docs changes to commit"
     - name: Create draft release
       working-directory: packages/js
-      run: npm run release -- --ci --github.draft --no-npm.publish
+      run: |
+        npm show @telnyx/webrtc version | read publishedVersion && \
+        npm run release -- \
+        --ci \
+        --github.draft \
+        --no-npm.publish \
+        --dry-run \
+        --plugins.@release-it/conventional-changelog.context.previousTag=webrtc/v${publishedVersion}
       env:
         NPM_TOKEN: ${{ secrets.NPM_CI_TOKEN }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/webrtc-draft-release.yml
+++ b/.github/workflows/webrtc-draft-release.yml
@@ -54,9 +54,9 @@ jobs:
       run: |
         npm run release -- \
         --ci \
+        --no-git.tag \
         --github.draft \
-        --no-npm.publish \
-        --plugins.@release-it/conventional-changelog.context.previousTag="webrtc/v$(npm show @telnyx/webrtc version)"
+        --no-npm 
       env:
         NPM_TOKEN: ${{ secrets.NPM_CI_TOKEN }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/webrtc-draft-release.yml
+++ b/.github/workflows/webrtc-draft-release.yml
@@ -52,13 +52,11 @@ jobs:
     - name: Create draft release
       working-directory: packages/js
       run: |
-        npm show @telnyx/webrtc version | read publishedVersion && \
         npm run release -- \
         --ci \
         --github.draft \
         --no-npm.publish \
-        --dry-run \
-        --plugins.@release-it/conventional-changelog.context.previousTag=webrtc/v${publishedVersion}
+        --plugins.@release-it/conventional-changelog.context.previousTag="webrtc/v$(npm show @telnyx/webrtc version)"
       env:
         NPM_TOKEN: ${{ secrets.NPM_CI_TOKEN }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/webrtc-test-release.yml
+++ b/.github/workflows/webrtc-test-release.yml
@@ -38,13 +38,12 @@ jobs:
     - name: Release dry run
       working-directory: packages/js
       run: |
-        npm show @telnyx/webrtc version | read publishedVersion && \
         npm run release -- \
         --dry-run \
         --ci \
         --github.draft \
         --no-npm.publish \
-        --plugins.@release-it/conventional-changelog.context.previousTag=webrtc/v${publishedVersion}
+        --plugins.@release-it/conventional-changelog.context.previousTag="webrtc/v$(npm show @telnyx/webrtc version)"
       env:
         NPM_TOKEN: ${{ secrets.NPM_CI_TOKEN }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/webrtc-test-release.yml
+++ b/.github/workflows/webrtc-test-release.yml
@@ -37,7 +37,14 @@ jobs:
       run: npm run build
     - name: Release dry run
       working-directory: packages/js
-      run: npm run release -- --ci --dry-run --no-npm.publish
+      run: |
+        npm show @telnyx/webrtc version | read publishedVersion && \
+        npm run release -- \
+        --dry-run \
+        --ci \
+        --github.draft \
+        --no-npm.publish \
+        --plugins.@release-it/conventional-changelog.context.previousTag=webrtc/v${publishedVersion}
       env:
         NPM_TOKEN: ${{ secrets.NPM_CI_TOKEN }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/webrtc-test-release.yml
+++ b/.github/workflows/webrtc-test-release.yml
@@ -41,9 +41,9 @@ jobs:
         npm run release -- \
         --dry-run \
         --ci \
+        --no-git.tag \
         --github.draft \
-        --no-npm.publish \
-        --plugins.@release-it/conventional-changelog.context.previousTag="webrtc/v$(npm show @telnyx/webrtc version)"
+        --no-npm 
       env:
         NPM_TOKEN: ${{ secrets.NPM_CI_TOKEN }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -83,7 +83,8 @@
         "preset": "conventionalcommits",
         "infile": "CHANGELOG.md",
         "tagPrefix": "webrtc/v",
-        "path": "./src"
+        "path": "./src",
+        "releaseCount": 0
       }
     }
   },

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -83,8 +83,7 @@
         "preset": "conventionalcommits",
         "infile": "CHANGELOG.md",
         "tagPrefix": "webrtc/v",
-        "path": "./src",
-        "releaseCount": 0
+        "path": "./src"
       }
     }
   },


### PR DESCRIPTION
Prevents creating a git tag and bumping package.json on merge to `main`, so that we can merge multiple times without generating multiple versions.