### PR TITLE
Document hold/unhold

### DIFF
--- a/packages/js/examples/react-audio/stories/components/WebDialer.jsx
+++ b/packages/js/examples/react-audio/stories/components/WebDialer.jsx
@@ -158,10 +158,17 @@ const WebDialer = ({
     }
   };
 
-  const toggleHold = () => {
+  const toggleHold = async () => {
     if (call) {
-      setIsHold(!isHold);
-      call.toggleHold();
+      if (isHold) {
+        await call.unhold();
+      } else {
+        await call.hold();
+      }
+      // Alternatively, use `toggleHold`:
+      // await call.toggleHold();
+
+      setIsHold(call.state === 'held');
     }
   };
 

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -253,7 +253,16 @@ export default abstract class BaseCall implements IWebRTCCall {
     this._execute(msg);
   }
 
-  hold() {
+  /**
+   * Holds the call.
+   *
+   * @examples
+   *
+   * ```js
+   * call.hold()
+   * ```
+   */
+  hold(): void {
     const msg = new Modify({
       sessid: this.session.sessionid,
       action: 'hold',

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -331,7 +331,7 @@ export default abstract class BaseCall implements IWebRTCCall {
    * ```js
    * await call.toggleHold()
    * console.log(call.state) // => 'held'
-   
+   *
    * await call.toggleHold()
    * console.log(call.state) // => 'active'
    * ```

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -256,13 +256,26 @@ export default abstract class BaseCall implements IWebRTCCall {
   /**
    * Holds the call.
    *
+   * @returns Promise that resolves or rejects based on server response
+   *
    * @examples
    *
+   * Using async/await:
+   *
    * ```js
-   * call.hold()
+   * await call.hold()
+   * console.log(call.state) // => 'held'
+   * ```
+   *
+   * Using ES6 `Promises`:
+   *
+   * ```js
+   * call.hold().then(() => {
+   *   console.log(call.state) // => 'held'
+   * });
    * ```
    */
-  hold(): void {
+  hold(): Promise<any> {
     const msg = new Modify({
       sessid: this.session.sessionid,
       action: 'hold',
@@ -276,13 +289,26 @@ export default abstract class BaseCall implements IWebRTCCall {
   /**
    * Removes hold from the call.
    *
+   * @returns Promise that resolves or rejects based on server response
+   *
    * @examples
    *
+   * Using async/await:
+   *
    * ```js
-   * call.unhold()
+   * await call.unhold()
+   * console.log(call.state) // => 'active'
+   * ```
+   *
+   * Using ES6 `Promises`:
+   *
+   * ```js
+   * call.unhold().then(() => {
+   *   console.log(call.state) // => 'active'
+   * });
    * ```
    */
-  unhold() {
+  unhold(): Promise<any> {
     const msg = new Modify({
       sessid: this.session.sessionid,
       action: 'unhold',
@@ -293,7 +319,24 @@ export default abstract class BaseCall implements IWebRTCCall {
       .catch(this._handleChangeHoldStateError.bind(this));
   }
 
-  toggleHold() {
+  /**
+   * Toggles hold state of the call.
+   *
+   * @returns Promise that resolves or rejects based on server response
+   *
+   * @examples
+   *
+   * Using async/await:
+   *
+   * ```js
+   * await call.toggleHold()
+   * console.log(call.state) // => 'held'
+   
+   * await call.toggleHold()
+   * console.log(call.state) // => 'active'
+   * ```
+   */
+  toggleHold(): Promise<any> {
     const msg = new Modify({
       sessid: this.session.sessionid,
       action: 'toggleHold',

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -273,6 +273,15 @@ export default abstract class BaseCall implements IWebRTCCall {
       .catch(this._handleChangeHoldStateError.bind(this));
   }
 
+  /**
+   * Removes hold from the call.
+   *
+   * @examples
+   *
+   * ```js
+   * call.unhold()
+   * ```
+   */
   unhold() {
     const msg = new Modify({
       sessid: this.session.sessionid,


### PR DESCRIPTION
Documents hold, unhold and toggle hold.

## 📝 To Do

- [ ] All linters pass
- [ ] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

1. Start Storybook: `cd packages/js/examples/react-audio && npm start`
2. Go to http://localhost:6006/?path=/story/webdialer--example and fill in your username, password etc.
3. Make a call to another device that you can access
4. Place call on hold by clicking on "play"/triangle symbol button. Verify that line held becomes silent
5. Unhold the call by clicking button again. Verify that line is unheld

## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [x] Chrome
- [x] Firefox
- [ ] Safari