### PR TITLE
Document mute/unmute/toggle video

### DIFF
--- a/packages/js/examples/react-video/src/components/phone/Dialog.js
+++ b/packages/js/examples/react-video/src/components/phone/Dialog.js
@@ -60,7 +60,7 @@ class DialogActions extends Component {
         {dialog.state === 'held' && (
           <button onClick={dialog.toggleHold.bind(dialog)}>UnHold</button>
         )}
-        <button onClick={this.toggleVideoMute}>
+        <button onClick={() => this.toggleVideoMute()}>
           {isVideoMute ? 'Unmute video' : 'Mute video'}
         </button>
       </div>

--- a/packages/js/examples/react-video/src/components/phone/Dialog.js
+++ b/packages/js/examples/react-video/src/components/phone/Dialog.js
@@ -30,8 +30,25 @@ class DialogVideo extends Component {
 }
 
 class DialogActions extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isVideoMute: false,
+    };
+  }
+
+  toggleVideoMute() {
+    this.setState({
+      isVideoMute: !this.state.isVideoMute,
+    });
+
+    this.props.dialog.toggleVideoMute.bind(this.props.dialog)();
+  }
+
   render() {
     const { dialog } = this.props;
+    const { isVideoMute } = this.state;
+
     return (
       <div className='dialog-actions'>
         {dialog.state === 'active' && (
@@ -43,6 +60,9 @@ class DialogActions extends Component {
         {dialog.state === 'held' && (
           <button onClick={dialog.toggleHold.bind(dialog)}>UnHold</button>
         )}
+        <button onClick={this.toggleVideoMute}>
+          {isVideoMute ? 'Unmute video' : 'Mute video'}
+        </button>
       </div>
     );
   }

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -435,7 +435,7 @@ export default abstract class BaseCall implements IWebRTCCall {
   }
 
   /**
-   * Turns off the local video output, i.e. hides
+   * Turns off the video output, i.e. hides
    * video from other call participants.
    *
    * @examples
@@ -449,7 +449,7 @@ export default abstract class BaseCall implements IWebRTCCall {
   }
 
   /**
-   * Turns on the local video output, i.e. makes
+   * Turns on the video output, i.e. makes
    * video visible to other call participants.
    *
    * @examples
@@ -463,7 +463,7 @@ export default abstract class BaseCall implements IWebRTCCall {
   }
 
   /**
-   * Toggles the local video output on/off.
+   * Toggles the video output on/off.
    *
    * @examples
    *

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -435,7 +435,7 @@ export default abstract class BaseCall implements IWebRTCCall {
   }
 
   /**
-   * Turns off the video output, i.e. hides
+   * Turns off the local video output, i.e. hides
    * video from other call participants.
    *
    * @examples
@@ -449,7 +449,7 @@ export default abstract class BaseCall implements IWebRTCCall {
   }
 
   /**
-   * Turns on the video output, i.e. makes
+   * Turns on the local video output, i.e. makes
    * video visible to other call participants.
    *
    * @examples
@@ -463,7 +463,7 @@ export default abstract class BaseCall implements IWebRTCCall {
   }
 
   /**
-   * Toggles the video output on/off.
+   * Toggles the local video output on/off.
    *
    * @examples
    *

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -434,14 +434,41 @@ export default abstract class BaseCall implements IWebRTCCall {
     }
   }
 
+  /**
+   * Turns off the local video stream.
+   *
+   * @examples
+   *
+   * ```js
+   * call.muteVideo();
+   * ```
+   */
   muteVideo() {
     disableVideoTracks(this.options.localStream);
   }
 
+  /**
+   * Turns the local video stream back on.
+   *
+   * @examples
+   *
+   * ```js
+   * call.unmuteVideo();
+   * ```
+   */
   unmuteVideo() {
     enableVideoTracks(this.options.localStream);
   }
 
+  /**
+   * Toggles the local video stream on/off.
+   *
+   * @examples
+   *
+   * ```js
+   * call.toggleVideoMute();
+   * ```
+   */
   toggleVideoMute() {
     toggleVideoTracks(this.options.localStream);
   }

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -435,7 +435,8 @@ export default abstract class BaseCall implements IWebRTCCall {
   }
 
   /**
-   * Turns off the local video stream.
+   * Turns off the video output, i.e. hides
+   * video from other call participants.
    *
    * @examples
    *
@@ -448,7 +449,8 @@ export default abstract class BaseCall implements IWebRTCCall {
   }
 
   /**
-   * Turns the local video stream back on.
+   * Turns on the video output, i.e. makes
+   * video visible to other call participants.
    *
    * @examples
    *
@@ -461,7 +463,7 @@ export default abstract class BaseCall implements IWebRTCCall {
   }
 
   /**
-   * Toggles the local video stream on/off.
+   * Toggles the video output on/off.
    *
    * @examples
    *


### PR DESCRIPTION
Documents `muteVideo`, `unmuteVideo` and `toggleVideoMute`.

IMO it'd be clearer to rename this something like `turnOffVideo`, `turnOnVideo` and `toggleVideo` since this method effects video visibility as well as audio, thoughts?

## 📝 To Do

- [ ] All linters pass
- [ ] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

1. Start `react-video` Storybook app and login
2. Make a video call. Verify that you see the video stream
3. Mute the video. Verify that the video is now hidden and silent for the other participant

## 🦊 Browser testing

### Desktop

Known issue on Firefox

- [ ] Edge (latest)
- [x] Chrome
- [ ] Firefox
- [ ] Safari