### PR TITLE
Document setting audio input device

### DIFF
--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -460,6 +460,16 @@ export default abstract class BaseCall implements IWebRTCCall {
    * });
    * ```
    *
+   * Usage with {@link BrowserSession.getAudioInDevices}:
+   *
+   * ```js
+   * let result = await client.getAudioInDevices();
+   *
+   * if (result.length) {
+   *   call.setAudioInDevice(result[1].deviceId);
+   * }
+   * ```
+   *
    * @param deviceId The target audio input device ID
    * @returns Promise that resolves if the audio input device has been updated
    */

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -441,6 +441,28 @@ export default abstract class BaseCall implements IWebRTCCall {
     toggleAudioTracks(this.options.localStream);
   }
 
+  /**
+   * Changes the audio input device (i.e. microphone) used for the call.
+   *
+   * @examples
+   *
+   * Using async/await:
+   *
+   * ```js
+   * await call.setAudioInDevice('abc123')
+   * ```
+   *
+   * Using ES6 `Promises`:
+   *
+   * ```js
+   * call.setAudioInDevice('abc123').then(() => {
+   *   // Do something using new audio input device
+   * });
+   * ```
+   *
+   * @param deviceId The target audio input device ID
+   * @returns Promise that resolves if the audio input device has been updated
+   */
   async setAudioInDevice(deviceId: string): Promise<void> {
     const { instance } = this.peer;
     const sender = instance


### PR DESCRIPTION
Document `setAudioInDevice`

## 📝 To Do

- [ ] All linters pass
- [ ] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

1. Log in to https://webrtc.telnyx.com/rtc/index.html
2. Make a call to another destination you own. Verify you can hear audio on the other line
3. Switch microphone (https://github.com/team-telnyx/rtc-demo-2/blob/fa191a57545ed3a948f51fa2668f34609b1b4694/rtc/src/App.js#L381). Verify you can still hear audio, from a different microphone

## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [x] Chrome
- [ ] Firefox
- [ ] Safari