### PR TITLE
chore: fix screenshot url to show on the npm registry

### DIFF
--- a/packages/js/README.md
+++ b/packages/js/README.md
@@ -215,7 +215,7 @@ open index.html
 ```
 
 Screenshot:
-![Video call](./examples/vanilla/vanilla-screeshot.png)
+![Video call](https://raw.githubusercontent.com/team-telnyx/webrtc/master/packages/js/examples/vanilla/vanilla-screeshot.png)
 
 ---
 
@@ -235,7 +235,7 @@ npm run storybook
 Configuration options for your Telnyx account are available under the [Storybook **Knobs**](https://github.com/storybookjs/storybook/tree/master/addons/knobs).
 
 Screenshot:
-![Web Dialer](./examples/react-audio/storybook-screenshot.png)
+![Web Dialer](https://raw.githubusercontent.com/team-telnyx/webrtc/master/packages/js/examples/react-audio/storybook-screenshot.png)
 
 #### Video call
 
@@ -247,7 +247,7 @@ npm start
 ```
 
 Screenshot:
-![Web Dialer](./examples/react-video/react-video-screenshot.png)
+![Web Dialer](https://raw.githubusercontent.com/team-telnyx/webrtc/master/packages/js/examples/react-video/react-video-screenshot.png)
 
 ---
 

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -145,7 +145,7 @@ You can access the documentation [here](https://www.npmjs.com/package/@telnyx/re
 ```
 
 Screenshot:
-![Video call app](./examples/calling-video-app/app-screenshot.png)
+![Video call app](https://raw.githubusercontent.com/team-telnyx/webrtc/master/packages/react-native/examples/calling-video-app/app-screenshot.png)
 
 ---
 


### PR DESCRIPTION
Change the URL path from screenshot to show correctly on npm registry

https://www.npmjs.com/package/@telnyx/webrtc

## 📝 To Do

- [ ] All linters pass
- [ ] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

1. Provide manual testing instructions

## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## 📸 Screenshots

| Description | Screenshot |
| ----------- | ---------- |
| Desktop     |            |
| usage.gif   |            |
