### PR TITLE
Fix new call documentation

### DIFF
--- a/packages/js/src/Modules/Verto/index.ts
+++ b/packages/js/src/Modules/Verto/index.ts
@@ -78,7 +78,7 @@ export default class Verto extends BrowserSession {
    *
    * ```js
    * const call = client.newCall().catch(console.error);
-   // => `destinationNumber is required`
+   * // => `destinationNumber is required`
    */
   newCall(options: CallOptions) {
     if (!options || !options.destinationNumber) {

--- a/packages/js/src/Modules/Verto/index.ts
+++ b/packages/js/src/Modules/Verto/index.ts
@@ -72,27 +72,25 @@ export default class Verto extends BrowserSession {
    * });
    * ```
    *
-   * ### Error handling
-   *
-   * You'll receive a new error if `options` or `destinationNumber` is not specified.
+   * If `options` or `destinationNumber` is not specified, a call object will not be created.
    *
    * ```js
    * const call = client.newCall();
+   * // => `destinationNumber is required`
    *
-   * if (call instanceof Error) {
-   *   console.log(call);
-   *   // => `destinationNumber is required`
+   * if (call) {
+   *   // Do something with the call
    * }
    * ```
    */
-  newCall(options: CallOptions): Call | Error {
+  newCall(options: CallOptions) {
     if (!options || !options.destinationNumber) {
       const errorMessage =
         'Verto.newCall() error: destinationNumber is required';
 
       logger.error(errorMessage);
 
-      return new Error(errorMessage);
+      return false;
     }
 
     const call = new Call(this, options);

--- a/packages/js/src/Modules/Verto/index.ts
+++ b/packages/js/src/Modules/Verto/index.ts
@@ -72,25 +72,17 @@ export default class Verto extends BrowserSession {
    * });
    * ```
    *
-   * If `options` or `destinationNumber` is not specified, a call object will not be created.
+   * ### Error handling
+   *
+   * An error will be thrown if `destinationNumber` is not specified.
    *
    * ```js
-   * const call = client.newCall();
-   * // => `destinationNumber is required`
-   *
-   * if (call) {
-   *   // Do something with the call
-   * }
-   * ```
+   * const call = client.newCall().catch(console.error);
+   // => `destinationNumber is required`
    */
   newCall(options: CallOptions) {
     if (!options || !options.destinationNumber) {
-      const errorMessage =
-        'Verto.newCall() error: destinationNumber is required';
-
-      logger.error(errorMessage);
-
-      return false;
+      throw new Error('Verto.newCall() error: destinationNumber is required.');
     }
 
     const call = new Call(this, options);

--- a/packages/js/src/Modules/Verto/index.ts
+++ b/packages/js/src/Modules/Verto/index.ts
@@ -43,37 +43,23 @@ export default class Verto extends BrowserSession {
    * @param options.speakerId `deviceId` to use as speaker. Overrides the client's default one.
    * @param options.onNotification Overrides client's default `telnyx.notification` handler for this call.
    *
-   * @return `Promise<Call>` A promise fulfilled with the new outbound `Call` object
-   * or rejected with the error.
+   * @return The new outbound `Call` object.
    *
    * @examples
    *
    * Making an outbound call to `+1 856-444-0362` using default values from the client:
    *
-   * Using async/await:
-   *
    * ```js
-   * const call = await client.newCall({
+   * const call = client.newCall({
    *   destinationNumber: '+18564440362',
    *   callerNumber: '+15551231234'
-   * });
-   * ```
-   *
-   * Using ES6 `Promises`:
-   *
-   * ```js
-   * client.newCall({
-   *   destinationNumber: '+18564440362',
-   *   callerNumber: '+15551231234'
-   * }).then((call) => {
-   *   // do something with the call
    * });
    * ```
    *
    * You can omit `callerNumber` when dialing a SIP address:
    *
    * ```js
-   * const call = await client.newCall({
+   * const call = client.newCall({
    *  destinationNumber: 'sip:example-sip-username@voip-provider.example.net'
    * });
    * ```
@@ -81,30 +67,34 @@ export default class Verto extends BrowserSession {
    * If you are making calls from one Telnyx connection to another, you may specify just the SIP username:
    *
    * ```js
-   * const call = await client.newCall({
+   * const call = client.newCall({
    *  destinationNumber: 'telnyx-sip-username' // This is equivalent to 'sip:telnyx-sip-username@sip.telnyx.com'
    * });
    * ```
    *
    * ### Error handling
    *
-   * If `options` or `destinationNumber` is not specified, it throw an error.
+   * You'll receive a new error if `options` or `destinationNumber` is not specified.
    *
    * ```js
-   * client.newCall().catch(console.error);
-   * // => `You need to provide the options<CallOptions> object.`
-   * client.newCall({}).catch(console.error);
-   * // => `destinationNumber is required.`
+   * const call = client.newCall();
+   *
+   * if (call instanceof Error) {
+   *   console.log(call);
+   *   // => `destinationNumber is required`
+   * }
    * ```
    */
-  newCall(options: CallOptions) {
-    if (!options) {
-      throw new Error('You need to provide the options<CallOptions> object');
+  newCall(options: CallOptions): Call | Error {
+    if (!options || !options.destinationNumber) {
+      const errorMessage =
+        'Verto.newCall() error: destinationNumber is required';
+
+      logger.error(errorMessage);
+
+      return new Error(errorMessage);
     }
-    const { destinationNumber = null } = options;
-    if (!destinationNumber) {
-      throw new Error('Verto.newCall() error: destinationNumber is required.');
-    }
+
     const call = new Call(this, options);
     call.invite();
     return call;

--- a/packages/react-client/example/src/Phone.tsx
+++ b/packages/react-client/example/src/Phone.tsx
@@ -8,15 +8,17 @@ function Phone() {
   const handleSubmit = (e: any) => {
     e.preventDefault();
 
-    client?.newCall({
-      destinationNumber: destination,
-      callerName: process.env.REACT_APP_TELNYX_PHONE_NUMBER || '',
-      callerNumber: process.env.REACT_APP_TELNYX_PHONE_NUMBER || '',
-      remoteCallerName: '',
-      remoteCallerNumber: '',
-      audio: true,
-      video: false,
-    });
+    client
+      ?.newCall({
+        destinationNumber: destination,
+        callerName: process.env.REACT_APP_TELNYX_PHONE_NUMBER || '',
+        callerNumber: process.env.REACT_APP_TELNYX_PHONE_NUMBER || '',
+        remoteCallerName: '',
+        remoteCallerNumber: '',
+        audio: true,
+        video: false,
+      })
+      .catch(console.error);
   };
 
   const call = notification?.call;


### PR DESCRIPTION
Removes references to async/Promises in `newCall` doc.

Addresses [issue reported in Slack](https://telnyx.slack.com/archives/CM7AYEY78/p1607695278120900?thread_ts=1607643941.120500&cid=CM7AYEY78)

## 📝 To Do

- [x] All linters pass
- [x] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

1. Re-link and run `react-client/example`
2. Make a new call with a destination number. Verify app does not crash

## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [ ] Chrome
- [x] Firefox
- [ ] Safari