### PR TITLE
docs(WEBRTC-252): add typedoc on method setAudioOutDevice

### DIFF
--- a/packages/js/src/Modules/Verto/webrtc/Call.ts
+++ b/packages/js/src/Modules/Verto/webrtc/Call.ts
@@ -51,6 +51,38 @@ export default class Call extends BaseCall {
     }
   }
 
+  /**
+   * Changes the audio output device (i.e. speaker) used for the call.
+   *
+   * @examples
+   *
+   * Using async/await:
+   *
+   * ```js
+   * await call.setAudioOutDevice('abc123')
+   * ```
+   *
+   * Using ES6 `Promises`:
+   *
+   * ```js
+   * call.setAudioOutDevice('abc123').then(() => {
+   *   // Do something using new audio output device
+   * });
+   * ```
+   *
+   * Usage with {@link BrowserSession.getAudioOutDevices}:
+   *
+   * ```js
+   * let result = await client.getAudioOutDevices();
+   *
+   * if (result.length) {
+   *   await call.setAudioOutDevice(result[1].deviceId);
+   * }
+   * ```
+   *
+   * @param deviceId The target audio output device ID
+   * @returns Promise that returns a boolean
+   */
   async setAudioOutDevice(deviceId: string): Promise<boolean> {
     this.options.speakerId = deviceId;
     const { remoteElement, speakerId } = this.options;


### PR DESCRIPTION
- add typedoc on method setAudioOutDevice

## 📝 To Do

- [x] All linters pass
- [x] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

1. Access webdialer and make a call
2. When a call is active you can select another Speaker 
3. You can see the implementation here https://github.com/team-telnyx/rtc-demo-2/blob/master/rtc/src/App.js#L405

## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [x] Chrome
- [ ] Firefox
- [ ] Safari


