### PR TITLE
docs(WEBRTC-253): add typedoc on methods getVideoDevices and setVideoDevice

### DIFF
--- a/packages/js/src/Modules/Verto/BrowserSession.ts
+++ b/packages/js/src/Modules/Verto/BrowserSession.ts
@@ -1,4 +1,3 @@
-import logger from './util/logger';
 import BaseSession from './BaseSession';
 import {
   IAudioSettings,
@@ -24,8 +23,8 @@ import {
   getUserMedia,
   assureDeviceId,
 } from './webrtc/helpers';
-import { findElementByType, objEmpty } from './util/helpers';
-import { Unsubscribe, Subscribe, Broadcast, Result } from './messages/Verto';
+import { findElementByType } from './util/helpers';
+import { Unsubscribe, Subscribe, Broadcast } from './messages/Verto';
 import { sessionStorage } from './util/storage';
 import { stopStream } from './util/webrtc';
 import { IWebRTCCall } from './webrtc/interfaces';
@@ -282,6 +281,8 @@ export default abstract class BrowserSession extends BaseSession {
    *   console.log(result);
    * });
    * ```
+   *
+   * @returns Promise with an array of MediaDeviceInfo
    */
   getAudioInDevices(): Promise<MediaDeviceInfo[]> {
     return getDevices(DeviceType.AudioIn).catch((error) => {
@@ -319,6 +320,8 @@ export default abstract class BrowserSession extends BaseSession {
    *   console.log(result);
    * });
    * ```
+   *
+   * @returns Promise with an array of MediaDeviceInfo
    */
   getAudioOutDevices(): Promise<MediaDeviceInfo[]> {
     return getDevices(DeviceType.AudioOut).catch((error) => {

--- a/packages/js/src/Modules/Verto/BrowserSession.ts
+++ b/packages/js/src/Modules/Verto/BrowserSession.ts
@@ -227,7 +227,29 @@ export default abstract class BrowserSession extends BaseSession {
   }
 
   /**
-   * Return the device list supported by the browser
+   * Returns a list of video devices supported by the browser (i.e. webcam).
+   *
+   * @examples
+   *
+   * Using async/await:
+   *
+   * ```js
+   * async function() {
+   *   const client = new TelnyxRTC(options);
+   *   let result = await client.getVideoDevices();
+   *   console.log(result);
+   * }
+   * ```
+   *
+   * Using ES6 `Promises`:
+   *
+   * ```js
+   * client.getVideoDevices().then((result) => {
+   *   console.log(result);
+   * });
+   * ```
+   *
+   * @returns Promise with an array of MediaDeviceInfo
    */
   getVideoDevices(): Promise<MediaDeviceInfo[]> {
     return getDevices(DeviceType.Video).catch((error) => {

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -539,6 +539,38 @@ export default abstract class BaseCall implements IWebRTCCall {
     toggleVideoTracks(this.options.localStream);
   }
 
+  /**
+   * Changes the video device (i.e. webcam) used for the call.
+   *
+   * @examples
+   *
+   * Using async/await:
+   *
+   * ```js
+   * await call.setVideoDevice('abc123')
+   * ```
+   *
+   * Using ES6 `Promises`:
+   *
+   * ```js
+   * call.setVideoDevice('abc123').then(() => {
+   *   // Do something using new video device
+   * });
+   * ```
+   *
+   * Usage with {@link BrowserSession.getVideoDevices}:
+   *
+   * ```js
+   * let result = await client.getVideoDevices();
+   *
+   * if (result.length) {
+   *   await call.setVideoDevice(result[1].deviceId);
+   * }
+   * ```
+   *
+   * @param deviceId The target video device ID
+   * @returns Promise that resolves if the video device has been updated
+   */
   async setVideoDevice(deviceId: string): Promise<void> {
     const { instance } = this.peer;
     const sender = instance

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -568,7 +568,7 @@ export default abstract class BaseCall implements IWebRTCCall {
    * }
    * ```
    *
-   * @param deviceId The target video device ID
+   * @param deviceId the target video device ID
    * @returns Promise that resolves if the video device has been updated
    */
   async setVideoDevice(deviceId: string): Promise<void> {


### PR DESCRIPTION
- add typedoc on methods getVideoDevices and setVideoDevice

## 📝 To Do

- [x] All linters pass
- [x] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

1. Access [web dialer](https://webrtc.telnyx.com/rtc/index.html)
2. Make a call with video options enabled.
3. You should see a select box with your webcam devices.
4. Pick a webcam and see if the video change to the right webcam.

## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [x] Chrome
- [ ] Firefox
- [ ] Safari
