### PR TITLE
Remove support for link tag

### DIFF
--- a/packages/api-docs/package.json
+++ b/packages/api-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telnyx/webrtc-api-docs",
-  "version": "2.2.4-rc4",
+  "version": "2.2.4-rc5",
   "description": "Telnyx WebRTC Client API docs",
   "main": "lib/webrtc-api.json",
   "scripts": {

--- a/packages/js/README.md
+++ b/packages/js/README.md
@@ -271,6 +271,8 @@ If you've added comments and still do not see documentation as expected, check t
 
 In addition to the tags [supported by Typedoc](https://typedoc.org/guides/doccomments/#supported-tags), we use `apialias`, `example`/`examples` and `internalnote`.
 
+_Note: `@link` is not supported in public-facing documentation at this time._
+
 ##### `@apialias`
 
 Use `apialias` to display a different name in public documentation.

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -73,7 +73,7 @@ export default abstract class BaseCall implements IWebRTCCall {
 
   /**
    * The previous state of the call.
-   * See {@link Call.state} for all possible values.
+   * See `Call.state` for all possible values.
    */
   public prevState: string = '';
 
@@ -520,7 +520,7 @@ export default abstract class BaseCall implements IWebRTCCall {
    * });
    * ```
    *
-   * Usage with {@link BrowserSession.getAudioInDevices}:
+   * Usage with `.getAudioInDevices`:
    *
    * ```js
    * let result = await client.getAudioInDevices();
@@ -613,7 +613,7 @@ export default abstract class BaseCall implements IWebRTCCall {
    * });
    * ```
    *
-   * Usage with {@link BrowserSession.getVideoDevices}:
+   * Usage with `.getVideoDevices`:
    *
    * ```js
    * let result = await client.getVideoDevices();

--- a/packages/js/src/Modules/Verto/webrtc/Call.ts
+++ b/packages/js/src/Modules/Verto/webrtc/Call.ts
@@ -73,7 +73,7 @@ export default class Call extends BaseCall {
    * });
    * ```
    *
-   * Usage with {@link BrowserSession.getAudioOutDevices}:
+   * Usage with `.getAudioOutDevices`:
    *
    * ```js
    * let result = await client.getAudioOutDevices();

--- a/packages/js/src/utils/interfaces.ts
+++ b/packages/js/src/utils/interfaces.ts
@@ -92,7 +92,7 @@ export interface ICall {
  *
  * @examples
  *
- * Usage with {@link TelnyxRTC.on}:
+ * Usage with TelnyxRTC Client `.on`:
  * ```js
  * client.on('telnyx.notification', (notification) => {
  *   if (notification.type === 'callUpdate') {


### PR DESCRIPTION
Removes support for `@link` tag in Typedoc comments for simpler developer docs MVP.