### PR TITLE
Reconnect React client on credential update

### DIFF
--- a/packages/react-client/example/src/App.tsx
+++ b/packages/react-client/example/src/App.tsx
@@ -6,17 +6,39 @@ import Phone from './Phone';
 import VideoCall from './VideoCall';
 
 const App = () => {
-  const [isAudioOnly, setIsAudioOnly] = useState<boolean>(false);
-  const credential = {
+  const [credential, setCredential] = useState({
     // Create a .env file with REACT_APP_TELNYX_LOGIN_TOKEN
     // set to your On-Demand Credential Token to try this out
     // https://developers.telnyx.com/docs/v2/webrtc/quickstart
     login_token: process.env.REACT_APP_TELNYX_LOGIN_TOKEN || 'mytoken',
+  });
+  const [loginTokenValue, setLoginTokenValue] = useState(
+    credential.login_token
+  );
+  const [isAudioOnly, setIsAudioOnly] = useState<boolean>(false);
+
+  const handleSubmit = (e: any) => {
+    e.preventDefault();
+
+    setCredential({ login_token: loginTokenValue });
   };
 
   return (
     <div style={{ padding: 20 }}>
       <TelnyxRTCProvider credential={credential}>
+        <form onSubmit={handleSubmit}>
+          <label>
+            Login token:
+            <input
+              name='telnyx_login_token'
+              type='password'
+              value={loginTokenValue}
+              onChange={(e) => setLoginTokenValue(e.target.value)}
+            />
+          </label>
+          <button type='submit'>Update token</button>
+        </form>
+
         <ClientStatus />
         <CallLog />
 

--- a/packages/react-client/src/useTelnyxRTC.ts
+++ b/packages/react-client/src/useTelnyxRTC.ts
@@ -61,13 +61,27 @@ function useTelnyxRTC(
   });
 
   useEffect(() => {
+    if (telnyxClientRef.current?.connected) {
+      // Create new client when credentials change,
+      // e.g. when refreshing token
+      // TODO reconnect without re-instantiating client
+      telnyxClientRef.current?.disconnect();
+
+      telnyxClientRef.current = new TelnyxRTC({
+        // eslint-disable-next-line @typescript-eslint/camelcase
+        login_token: '',
+        ...credentialParam,
+        ...clientOptions,
+      });
+    }
+
     // IDEA Allow caller to defer connect
     telnyxClientRef.current?.connect();
 
     return () => {
       telnyxClientRef.current?.disconnect();
     };
-  }, []);
+  }, [credentialParam]);
 
   return telnyxClientRef.current;
 }


### PR DESCRIPTION
Reconnect React client on credential changes, for example if a token is set after initiating the provider.

## 📝 To Do

- [ ] All linters pass
- [ ] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

1. [`packages/react-client`]: `npm install && npm run build`
2. [`packages/react-client/example`]: `npm install --no-package-lock`
3. [`packages/react-client/example`]: `npm start`
4. Enter in a login token and click "update token". Verify calling works
5. Generate and enter a new login token and click "update token". Verify calling still works

## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [ ] Chrome
- [x] Firefox
- [ ] Safari

## 📸 Screenshots

<img width="382" alt="Screen Shot 2021-01-22 at 12 45 00 PM" src="https://user-images.githubusercontent.com/4672952/105544647-0b637900-5cb0-11eb-85fe-fa6ff9ba8c2a.png">
