### PR TITLE
fix(WEBRTC-362): add delay when call stop play audio, because it should call pause method after play method

### DIFF
--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -32,7 +32,7 @@ import {
   stopAudio,
 } from './helpers';
 import { objEmpty, mutateLiveArrayData, isFunction } from '../util/helpers';
-import { IVertoCallOptions, IWebRTCCall } from './interfaces';
+import { IVertoCallOptions, IWebRTCCall, IAudio } from './interfaces';
 import {
   attachMediaStream,
   detachMediaStream,
@@ -122,9 +122,9 @@ export default abstract class BaseCall implements IWebRTCCall {
 
   private _iceDone: boolean = false;
 
-  private _ringtone: HTMLAudioElement;
+  private _ringtone: IAudio;
 
-  private _ringback: HTMLAudioElement;
+  private _ringback: IAudio;
 
   constructor(protected session: BrowserSession, opts?: IVertoCallOptions) {
     const {

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -27,6 +27,9 @@ import {
   enableVideoTracks,
   disableVideoTracks,
   toggleVideoTracks,
+  createAudio,
+  playAudio,
+  stopAudio,
 } from './helpers';
 import { objEmpty, mutateLiveArrayData, isFunction } from '../util/helpers';
 import { IVertoCallOptions, IWebRTCCall } from './interfaces';
@@ -159,6 +162,12 @@ export default abstract class BaseCall implements IWebRTCCall {
 
     this._onMediaError = this._onMediaError.bind(this);
     this._init();
+
+    // Create _rings HTMLAudioElement
+    if (this.options) {
+      this._ringtone = createAudio(this.options.ringtoneFile, '_ringtone');
+      this._ringback = createAudio(this.options.ringbackFile, '_ringback');
+    }
   }
 
   get nodeId(): string {
@@ -247,35 +256,19 @@ export default abstract class BaseCall implements IWebRTCCall {
   }
 
   playRingtone() {
-    if (this.options.ringtoneFile) {
-      this._ringtone = new Audio(this.options.ringtoneFile);
-      this._ringtone.id = '_ringtone';
-      this._ringtone.loop = true;
-      this._ringtone.play();
-    }
+    playAudio(this._ringtone);
   }
 
   stopRingtone() {
-    if (this._ringtone) {
-      this._ringtone.pause();
-      this._ringtone.currentTime = 0;
-    }
+    stopAudio(this._ringtone);
   }
 
   playRingback() {
-    if (this.options.ringbackFile) {
-      this._ringback = new Audio(this.options.ringbackFile);
-      this._ringback.id = '_ringback';
-      this._ringback.loop = true;
-      this._ringback.play();
-    }
+    playAudio(this._ringback);
   }
 
   stopRingback() {
-    if (this._ringback) {
-      this._ringback.pause();
-      this._ringback.currentTime = 0;
-    }
+    stopAudio(this._ringback);
   }
 
   /**

--- a/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
+++ b/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
@@ -82,8 +82,8 @@ class VertoHandler {
         break;
       case VertoMethod.Invite: {
         const call = _buildCall();
-        call.setState(State.Ringing);
         call.playRingtone();
+        call.setState(State.Ringing);
         this._ack(id, method);
         break;
       }

--- a/packages/js/src/Modules/Verto/webrtc/helpers.ts
+++ b/packages/js/src/Modules/Verto/webrtc/helpers.ts
@@ -2,7 +2,11 @@ import logger from '../util/logger';
 import * as WebRTC from '../util/webrtc';
 import { isDefined } from '../util/helpers';
 import { DeviceType } from './constants';
-import { IVertoCallOptions, IWebRTCSupportedBrowser, IWebRTCInfo } from './interfaces';
+import {
+  IVertoCallOptions,
+  IWebRTCSupportedBrowser,
+  IWebRTCInfo,
+} from './interfaces';
 
 const getUserMedia = async (
   constraints: MediaStreamConstraints
@@ -458,7 +462,13 @@ function getBrowserInfo() {
 
 function getWebRTCInfo(): IWebRTCInfo {
   try {
-    const { browserInfo, name, version, supportAudio, supportVideo } = getBrowserInfo();
+    const {
+      browserInfo,
+      name,
+      version,
+      supportAudio,
+      supportVideo,
+    } = getBrowserInfo();
     const PC = window.RTCPeerConnection;
     const sessionDescription = window.RTCSessionDescription;
     const iceCandidate = window.RTCIceCandidate;
@@ -508,7 +518,11 @@ function getWebRTCSupportedBrowserList(): Array<IWebRTCSupportedBrowser> {
           features: ['audio'],
           supported: SUPPORTED_WEBRTC.full,
         },
-        { browserName: 'Firefox', features: ['audio'], supported: SUPPORTED_WEBRTC.partial },
+        {
+          browserName: 'Firefox',
+          features: ['audio'],
+          supported: SUPPORTED_WEBRTC.partial,
+        },
         { browserName: 'Safari', supported: SUPPORTED_WEBRTC.not_supported },
         { browserName: 'Edge', supported: SUPPORTED_WEBRTC.not_supported },
       ],
@@ -537,7 +551,11 @@ function getWebRTCSupportedBrowserList(): Array<IWebRTCSupportedBrowser> {
           features: ['video', 'audio'],
           supported: SUPPORTED_WEBRTC.full,
         },
-        { browserName: 'Firefox', features: ['audio'], supported: SUPPORTED_WEBRTC.partial },
+        {
+          browserName: 'Firefox',
+          features: ['audio'],
+          supported: SUPPORTED_WEBRTC.partial,
+        },
         { browserName: 'Safari', supported: SUPPORTED_WEBRTC.not_supported },
         { browserName: 'Edge', supported: SUPPORTED_WEBRTC.not_supported },
       ],
@@ -550,9 +568,21 @@ function getWebRTCSupportedBrowserList(): Array<IWebRTCSupportedBrowser> {
           features: ['video', 'audio'],
           supported: SUPPORTED_WEBRTC.full,
         },
-        { browserName: 'Firefox', features: ['audio'], supported: SUPPORTED_WEBRTC.partial },
-        { browserName: 'Safari', features: ['video', 'audio'], supported: SUPPORTED_WEBRTC.full },
-        { browserName: 'Edge', features: ['audio'], supported: SUPPORTED_WEBRTC.partial },
+        {
+          browserName: 'Firefox',
+          features: ['audio'],
+          supported: SUPPORTED_WEBRTC.partial,
+        },
+        {
+          browserName: 'Safari',
+          features: ['video', 'audio'],
+          supported: SUPPORTED_WEBRTC.full,
+        },
+        {
+          browserName: 'Edge',
+          features: ['audio'],
+          supported: SUPPORTED_WEBRTC.partial,
+        },
       ],
     },
     {
@@ -563,12 +593,57 @@ function getWebRTCSupportedBrowserList(): Array<IWebRTCSupportedBrowser> {
           features: ['video', 'audio'],
           supported: SUPPORTED_WEBRTC.full,
         },
-        { browserName: 'Firefox', features: ['audio'], supported: SUPPORTED_WEBRTC.partial },
+        {
+          browserName: 'Firefox',
+          features: ['audio'],
+          supported: SUPPORTED_WEBRTC.partial,
+        },
         { browserName: 'Safari', supported: SUPPORTED_WEBRTC.not_supported },
-        { browserName: 'Edge', features: ['audio'], supported: SUPPORTED_WEBRTC.partial },
+        {
+          browserName: 'Edge',
+          features: ['audio'],
+          supported: SUPPORTED_WEBRTC.partial,
+        },
       ],
     },
   ];
+}
+
+function createAudio(file, id): HTMLAudioElement | null {
+  if (file && id) {
+    const ringAudio = document.createElement('audio');
+    ringAudio.id = id;
+    ringAudio.loop = true;
+    ringAudio.src = file;
+    ringAudio.load();
+    document.body.appendChild(ringAudio);
+    return ringAudio;
+  }
+  return null;
+}
+
+function playAudio(audioElement: HTMLAudioElement): void {
+  if (audioElement) {
+    audioElement
+      .play()
+      .then(() => {
+        // when resolved we can call pause();
+      })
+      .catch((error) => {
+        console.error('playAudio', error);
+      });
+  }
+}
+
+function stopAudio(audioElement: HTMLAudioElement): void {
+  // Add delay to wait until play() returns the promise
+  // https://developers.google.com/web/updates/2017/06/play-request-was-interrupted
+  setTimeout(() => {
+    if (audioElement) {
+      audioElement.pause();
+      audioElement.currentTime = 0;
+    }
+  }, 1000);
 }
 
 export {
@@ -593,4 +668,7 @@ export {
   getBrowserInfo,
   getWebRTCInfo,
   getWebRTCSupportedBrowserList,
+  createAudio,
+  playAudio,
+  stopAudio,
 };

--- a/packages/js/src/Modules/Verto/webrtc/interfaces.ts
+++ b/packages/js/src/Modules/Verto/webrtc/interfaces.ts
@@ -111,3 +111,7 @@ export interface IWebRTCSupportedBrowser {
   operationSystem: string;
   supported: Array<IWebRTCBrowser>;
 }
+export interface IAudio extends HTMLAudioElement {
+  _playFulfilled: boolean;
+  _promise: Promise<any>;
+}


### PR DESCRIPTION
- add delay when call stop playing audio, because it should call pause method after play method

## 📝 To Do

- [x] All linters pass
- [ ] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

1. Access any WebRTC project and add the "auto-answer" method
```
    if (notification.call.state === 'ringing') {
            notification.call.answer();
   }
```
2. open two instances of WebRTC app and make a call to each other
3. You shouldn't get any errors on the console and you should hear the audio playing and stop the audio.

## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [x] Chrome
- [ ] Firefox
- [ ] Safari

### Error
![image](https://user-images.githubusercontent.com/16343871/107359095-06c20180-6ab3-11eb-8a23-eff37be65458.png)

