### PR TITLE
feat(WEBRTC-376): add client state on build call to be able to use on call control

### DIFF
--- a/packages/js/src/Modules/Verto/tests/webrtc/VertoHandler.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/VertoHandler.test.ts
@@ -72,7 +72,7 @@ describe('VertoHandler', () => {
       await instance.connect();
       const callId = 'cd35e65f-a507-4bd2-8d21-80f36d134a2e';
       const msg = JSON.parse(
-        `{"jsonrpc":"2.0","id":4402,"method":"telnyx_rtc.invite","params":{"callID":"${callId}","sdp":"SDP","caller_id_name":"Extension 1004","caller_id_number":"1004","callee_id_name":"Outbound Call","callee_id_number":"1003","display_direction":"outbound","telnyx_call_control_id":"cc1234","telnyx_session_id":"si1234","telnyx_leg_id":"li1234"}}`
+        `{"jsonrpc":"2.0","id":4402,"method":"telnyx_rtc.invite","params":{"callID":"${callId}","sdp":"SDP","caller_id_name":"Extension 1004","caller_id_number":"1004","callee_id_name":"Outbound Call","callee_id_number":"1003","display_direction":"outbound","telnyx_call_control_id":"cc1234","telnyx_session_id":"si1234","telnyx_leg_id":"li1234", "client_state":"aGVsbG8gbXkgZnJpZW5k" }}`
       );
       handler.handleMessage(msg);
       expect(instance.calls).toHaveProperty(callId);
@@ -82,6 +82,7 @@ describe('VertoHandler', () => {
       );
       expect(instance.calls[callId].options.telnyxSessionId).toEqual('si1234');
       expect(instance.calls[callId].options.telnyxLegId).toEqual('li1234');
+      expect(instance.calls[callId].options.clientState).toEqual('aGVsbG8gbXkgZnJpZW5k');
       done();
     });
   });

--- a/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
+++ b/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
@@ -71,6 +71,10 @@ class VertoHandler {
         callOptions.telnyxLegId = params.telnyx_leg_id;
       }
 
+      if (params.client_state) {
+        callOptions.clientState = params.client_state;
+      }
+
       const call = new Call(session, callOptions);
       call.nodeId = this.nodeId;
       return call;

--- a/packages/js/src/Modules/Verto/webrtc/interfaces.ts
+++ b/packages/js/src/Modules/Verto/webrtc/interfaces.ts
@@ -34,6 +34,7 @@ export interface IVertoCallOptions {
   telnyxCallControlId?: string;
   telnyxSessionId?: string;
   telnyxLegId?: string;
+  clientState?: string;
 }
 
 export interface IWebRTCCall {

--- a/packages/js/src/utils/interfaces.ts
+++ b/packages/js/src/utils/interfaces.ts
@@ -118,8 +118,8 @@ export interface ICallOptions {
    */
   telnyxLegId?: string;
   /**
-   * Telnyx call client state, if using Call Control services. 
-   * It needs to encode to base64.
+   * Telnyx's Call Control client_state. Can be used with Connections with Advanced -> Events enabled. 
+   * `clientState` string should be base64 encoded.
    */
   clientState?: string;
   /**

--- a/packages/js/src/utils/interfaces.ts
+++ b/packages/js/src/utils/interfaces.ts
@@ -75,6 +75,7 @@ export interface ISIPCallOptions {
   telnyxCallControlId?: string;
   telnyxSessionId?: string;
   telnyxLegId?: string;
+  clientState?: string;
 }
 
 // TODO Consolidate with `Call`
@@ -116,6 +117,11 @@ export interface ICallOptions {
    * Telnyx call leg ID, if using Call Control services.
    */
   telnyxLegId?: string;
+  /**
+   * Telnyx call client state, if using Call Control services. 
+   * It needs to encode to base64.
+   */
+  clientState?: string;
   /**
    * If set, the call will use this stream instead of retrieving a new one.
    */


### PR DESCRIPTION
- add client state on build call to be able to use on call control

## 📝 To Do

- [x] All linters pass
- [x] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

1. Navigate into `packages/js` and run `npm run build`
2. Open any example from `packages/js/examples/*`
3. on the method `newCall` pass the `clientState` as argument.
4. Open the network tab from browser, access the tab `WS`
5. Make a call.
6. See on `WS` messages, on the `invite` message if ou can see the `clientState` param. 

## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [x] Chrome
- [x] Firefox
- [ ] Safari

## 📸 Screenshots

| Description | Screenshot |
| ----------- | ---------- |
| Desktop     |![image](https://user-images.githubusercontent.com/16343871/108745422-ce420f00-7519-11eb-91a4-03f503b9d07e.png)|
