### PR TITLE
docs(WEBRTC-355): add documentation to call off event method when call client.disconnect.

### DIFF
--- a/packages/js/README.md
+++ b/packages/js/README.md
@@ -48,9 +48,16 @@ const client = new TelnyxRTC({
 // Connect and login
 client.connect();
 
-// You can disconnect when you're done
-//  client.disconnect();
+
+// You can call client.disconnect() when you're done.
+// Note: When you call `client.disconnect()` you need to remove all ON event methods had attached before.
+
+// Disconnecting and Removing listeners. 
+// client.disconnect();
+// client.off('telnyx.ready')
+// client.off('telnyx.notification');
 ```
+> See ON [Events](https://github.com/team-telnyx/webrtc/tree/main/packages/js#events)
 
 > See [TelnyxRTC#constructor](./docs/ts/classes/telnyxrtc.md#constructor) for all options.
 

--- a/packages/js/README.md
+++ b/packages/js/README.md
@@ -50,7 +50,7 @@ client.connect();
 
 
 // You can call client.disconnect() when you're done.
-// Note: When you call `client.disconnect()` you need to remove all ON event methods had attached before.
+// Note: When you call `client.disconnect()` you need to remove all ON event methods you've had attached before.
 
 // Disconnecting and Removing listeners. 
 // client.disconnect();

--- a/packages/js/src/TelnyxRTC.ts
+++ b/packages/js/src/TelnyxRTC.ts
@@ -36,8 +36,14 @@ import {
  * // Connect and login
  * client.connect();
  *
- * // You can disconnect when you're done
- * //  client.disconnect();
+ * // You can disconnect when you're done.
+ * // Disconnecting and Removing listeners.
+ * Note: When you call `client.disconnect()` you need to remove all ON methods had attached before.
+ *
+ * client.disconnect();
+ * client.off('telnyx.ready')
+ * client.off('telnyx.notification');
+ *
  * ```
  *
  * @category Client

--- a/packages/js/src/TelnyxRTC.ts
+++ b/packages/js/src/TelnyxRTC.ts
@@ -37,7 +37,7 @@ import {
  * client.connect();
  *
  * // You can call client.disconnect() when you're done.
- * Note: When you call `client.disconnect()` you need to remove all ON event methods had attached before.
+ * Note: When you call `client.disconnect()` you need to remove all ON event methods you've had attached before.
  *
  * // Disconnecting and Removing listeners.
  * client.disconnect();

--- a/packages/js/src/TelnyxRTC.ts
+++ b/packages/js/src/TelnyxRTC.ts
@@ -36,14 +36,13 @@ import {
  * // Connect and login
  * client.connect();
  *
- * // You can disconnect when you're done.
- * // Disconnecting and Removing listeners.
- * Note: When you call `client.disconnect()` you need to remove all ON methods had attached before.
+ * // You can call client.disconnect() when you're done.
+ * Note: When you call `client.disconnect()` you need to remove all ON event methods had attached before.
  *
+ * // Disconnecting and Removing listeners.
  * client.disconnect();
  * client.off('telnyx.ready')
  * client.off('telnyx.notification');
- *
  * ```
  *
  * @category Client


### PR DESCRIPTION
- add documentation to call off event method when call client.disconnect.

## 📝 To Do

- [x] All linters pass
- [x] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

1. Open README from `packages/js` and see the new doc

