### PR TITLE
fix(WEBRTC-384): fix utilities examples from storybook

### DIFF
--- a/packages/js/examples/react-audio-widgets/stories/Utilities.stories.js
+++ b/packages/js/examples/react-audio-widgets/stories/Utilities.stories.js
@@ -13,6 +13,6 @@ export default {
   },
 };
 
-export const Example = (args, storybook) => (
+export const Examples = (args, storybook) => (
   <Utilities {...args} {...storybook.globals.telnyxAuth} />
 );

--- a/packages/js/examples/react-audio-widgets/stories/Utilities.stories.js
+++ b/packages/js/examples/react-audio-widgets/stories/Utilities.stories.js
@@ -4,8 +4,15 @@ import Utilities from './components/Utilities';
 
 export default {
   title: 'Utilities',
+  args: {
+    callerName: 'Caller ID Name',
+    callerNumber: 'Caller ID Number',
+    username: process.env.STORYBOOK_USERNAME,
+    password: process.env.STORYBOOK_PASSWORD,
+    defaultDestination: process.env.STORYBOOK_DESTINATION || '18004377950',
+  },
 };
 
-export const Example = (args, storybook) => {
-  return <Utilities {...storybook.globals.telnyxAuth} {...args} />;
-};
+export const Example = (args, storybook) => (
+  <Utilities {...args} {...storybook.globals.telnyxAuth} />
+);

--- a/packages/js/examples/react-audio-widgets/stories/components/Utilities.js
+++ b/packages/js/examples/react-audio-widgets/stories/components/Utilities.js
@@ -39,13 +39,23 @@ function Utilities({ username, password, token }) {
     });
   };
 
+  const diconnectClient = async (client) => {
+    if (client) {
+      await clientRef.current.disconnect();
+      clientRef.current.off('telnyx.error');
+      clientRef.current.off('telnyx.ready');
+      clientRef.current.off('telnyx.notification');
+      clientRef.current.off('telnyx.socket.close');
+    }
+  };
+
   const connect = async () => {
     if (username && password && clientRef.current) {
       if (isConnected) {
         setIsConnected(false);
         setLog({ message: 'Reconnecting...' });
 
-        await clientRef.current.disconnect();
+        diconnectClient();
 
         initClient();
       }


### PR DESCRIPTION
- fix utilities examples from storybook

## 📝 To Do

- [ ] All linters pass
- [ ] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

1. Navigate into `packages/js/exmples/react-audio-widgets`
2. Run `npm i` && `npm run storybook`
3. Access http://localhost:6006/?path=/story/utilities--example 
4. Click in some buttons to see the results.

## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [x] Chrome
- [ ] Firefox
- [ ] Safari

## 📸 Screenshots

| Description | Screenshot |
| ----------- | ---------- |
| Desktop     |![image](https://user-images.githubusercontent.com/16343871/109052157-126c1580-76ba-11eb-8899-37732ace9ef2.png)|
