### PR TITLE
Add dynamic bandwidth selection

### DIFF
--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -706,6 +706,47 @@ export default abstract class BaseCall implements IWebRTCCall {
     toggleAudioTracks(this.options.remoteStream);
   }
 
+  setAudioBandwidth(min: number, max: number) {
+    const { instance } = this.peer;
+    const sender = instance
+        .getSenders()
+        .find(({ track: { kind } }: RTCRtpSender) => kind === 'audio');
+
+    if (sender) {
+
+        let p = sender.getParameters();
+        const parameters = p as RTCRtpSendParameters;
+        if (!parameters.encodings) {
+          parameters.encodings = [{ rid : 'h' }];
+        }
+        logger.info("Parameters: ", parameters);
+
+        if (min) {
+            logger.info("Setting min audio bandwidth to: ", min, " [kbps]");
+            //parameters.encodings[0].minBitrate = min * 1024;
+        }
+        if (max) {
+            logger.info("Setting max audio bandwidth to: ", max, " [kbps]");
+            parameters.encodings[0].maxBitrate = max * 1024;
+        }
+        sender.setParameters(parameters)
+            .then(() => {
+                logger.info("New audio bandwidth settings in use: ", sender.getParameters());
+                })
+                .catch(e => console.error(e));
+    } else {
+        logger.error("Could not set audio bandwidth");
+    }
+  }
+
+  setAudioBandwidthMin(min: number) {
+    this.setAudioBandwidth(min, null);
+  }
+
+  setAudioBandwidthMax(max: number) {
+    this.setAudioBandwidth(null, max);
+  }
+
   setState(state: State) {
     this._prevState = this._state;
     this._state = state;

--- a/packages/js/src/Modules/Verto/webrtc/interfaces.ts
+++ b/packages/js/src/Modules/Verto/webrtc/interfaces.ts
@@ -71,6 +71,8 @@ export interface IWebRTCCall {
   deaf: () => void;
   undeaf: () => void;
   toggleDeaf: () => void;
+  setAudioBandwidthMin: (min: number) => void,
+  setAudioBandwidthMax: (max: number) => void,
   setState: (state: any) => void;
   // Privates
   handleMessage: (msg: any) => void;


### PR DESCRIPTION
[WEBRTC-577](https://telnyx.atlassian.net/browse/WEBRTC-577)

Enable dynamic bandwidth selection

## 📝 To Do

- [x] All linters pass
- [x] All tests pass
- [x] Change documentation based on my changes

## ✋ Manual testing

1. Provide manual testing instructions

1.1 Start a call
1.2 Open "Media settings' subpage in rtc-demo-2 app
1.2 Set bandwidth and click apply
1.3 See changes taking effect by inspection of webrtc-internals

## 🦊 Browser testing

### Desktop

- [x] Edge (latest)
- [x] Chrome
- [x] Firefox
- [x] Safari

## 📸 Screenshots


![Screenshot from 2021-06-07 16-13-30](https://user-images.githubusercontent.com/40000574/121042289-7028f700-c7ab-11eb-83d3-2de8df8443dc.png)
![Screenshot from 2021-06-07 16-13-41](https://user-images.githubusercontent.com/40000574/121042322-77500500-c7ab-11eb-856e-b05ae370053b.png)
