### PR TITLE
[WEBRTC-577 WEBRTC-578 WEBRTC-613 WEBRTC-614] Dynamic bandwidth control

### DIFF
--- a/packages/js/src/Modules/Verto/services/Connection.ts
+++ b/packages/js/src/Modules/Verto/services/Connection.ts
@@ -95,7 +95,7 @@ export default class Connection {
 
   send(bladeObj: any): Promise<any> {
     const { request } = bladeObj;
-	  const promise = new Promise<void>((resolve, reject) => {
+    const promise = new Promise<void>((resolve, reject) => {
       if (request.hasOwnProperty('result')) {
         return resolve();
       }

--- a/packages/js/src/Modules/Verto/tests/webrtc/Call.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/Call.test.ts
@@ -4,8 +4,7 @@ import Call from '../../webrtc/Call';
 import Verto from '../..';
 const Connection = require('../../services/Connection');
 
-function getBitrate(call, kind)
-{
+function getBitrate(call, kind) {
   if (!call || !call.peer) {
     return 0;
   }
@@ -16,10 +15,11 @@ function getBitrate(call, kind)
     return 0;
   }
 
-  const sender = senders.find(({ track: { kind } }: RTCRtpSender) => kind === kind);
+  const sender = senders.find(
+    ({ track: { kind } }: RTCRtpSender) => kind === kind
+  );
 
   if (sender) {
-
     let p = sender.getParameters();
     const parameters = p as RTCRtpSendParameters;
     if (!parameters.encodings) {

--- a/packages/js/src/Modules/Verto/tests/webrtc/Call.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/Call.test.ts
@@ -4,6 +4,32 @@ import Call from '../../webrtc/Call';
 import Verto from '../..';
 const Connection = require('../../services/Connection');
 
+function getBitrate(call, kind)
+{
+  if (!call || !call.peer) {
+    return 0;
+  }
+
+  const { instance } = call.peer;
+  const senders = instance.getSenders();
+  if (!senders) {
+    return 0;
+  }
+
+  const sender = senders.find(({ track: { kind } }: RTCRtpSender) => kind === kind);
+
+  if (sender) {
+
+    let p = sender.getParameters();
+    const parameters = p as RTCRtpSendParameters;
+    if (!parameters.encodings) {
+      return 0;
+    }
+
+    return parameters.encodings[0].maxBitrate;
+  }
+}
+
 describe('Call', () => {
   let session: Verto;
   let call: Call;
@@ -482,6 +508,26 @@ describe('Call', () => {
       call.setState(State.Answering);
       Call.setStateTelnyx(call);
       expect(call.state).toEqual('ringing');
+    });
+  });
+
+  describe('.setAudioBandwidthEncodingsMaxBps()', () => {
+    it('if audio is used it should set audio max bitrate to 200 kbits/s', () => {
+      const maxBitsPerSecond = 200000;
+      if (call.options.audio && call.peer) {
+        call.setAudioBandwidthEncodingsMaxBps(maxBitsPerSecond);
+        expect(getBitrate(call, 'audio')).toEqual(maxBitsPerSecond);
+      }
+    });
+  });
+
+  describe('.setVideoBandwidthEncodingsMaxBps()', () => {
+    it('if video is used it should set video max bitrate to 300 kbits/s', () => {
+      const maxBitsPerSecond = 300000;
+      if (call.options.video && call.peer) {
+        call.setVideoBandwidthEncodingsMaxBps(maxBitsPerSecond);
+        expect(getBitrate(call, 'video')).toEqual(maxBitsPerSecond);
+      }
     });
   });
 });

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -706,7 +706,7 @@ export default abstract class BaseCall implements IWebRTCCall {
     toggleAudioTracks(this.options.remoteStream);
   }
 
-  setBandwidthEncodingsMax(max: number, _kind: string) {
+  setBandwidthEncodingsMaxBps(max: number, _kind: string) {
     const { instance } = this.peer;
     const sender = instance
         .getSenders()
@@ -720,9 +720,9 @@ export default abstract class BaseCall implements IWebRTCCall {
           parameters.encodings = [{ rid : 'h' }];
         }
         logger.info("Parameters: ", parameters);
-        logger.info("Setting max ", _kind === 'audio' ? "audio" : "video", " bandwidth to: ", max, " [kbps]");
+        logger.info("Setting max ", _kind === 'audio' ? "audio" : "video", " bandwidth to: ", max, " [bps]");
 
-        parameters.encodings[0].maxBitrate = max * 1024;
+        parameters.encodings[0].maxBitrate = max;
 
         sender.setParameters(parameters)
             .then(() => {
@@ -734,12 +734,12 @@ export default abstract class BaseCall implements IWebRTCCall {
     }
   }
 
-  setAudioBandwidthEncodingsMax(max: number) {
-    this.setBandwidthEncodingsMax(max, 'audio');
+  setAudioBandwidthEncodingsMaxBps(max: number) {
+    this.setBandwidthEncodingsMaxBps(max, 'audio');
   }
 
-  setVideoBandwidthEncodingsMax(max: number) {
-    this.setBandwidthEncodingsMax(max, 'video');
+  setVideoBandwidthEncodingsMaxBps(max: number) {
+    this.setBandwidthEncodingsMaxBps(max, 'video');
   }
 
   setState(state: State) {

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -706,11 +706,11 @@ export default abstract class BaseCall implements IWebRTCCall {
     toggleAudioTracks(this.options.remoteStream);
   }
 
-  setAudioBandwidth(min: number, max: number) {
+  setBandwidthEncodingsMax(max: number, _kind: string) {
     const { instance } = this.peer;
     const sender = instance
         .getSenders()
-        .find(({ track: { kind } }: RTCRtpSender) => kind === 'audio');
+        .find(({ track: { kind } }: RTCRtpSender) => kind === _kind);
 
     if (sender) {
 
@@ -720,31 +720,26 @@ export default abstract class BaseCall implements IWebRTCCall {
           parameters.encodings = [{ rid : 'h' }];
         }
         logger.info("Parameters: ", parameters);
+        logger.info("Setting max ", _kind === 'audio' ? "audio" : "video", " bandwidth to: ", max, " [kbps]");
 
-        if (min) {
-            logger.info("Setting min audio bandwidth to: ", min, " [kbps]");
-            //parameters.encodings[0].minBitrate = min * 1024;
-        }
-        if (max) {
-            logger.info("Setting max audio bandwidth to: ", max, " [kbps]");
-            parameters.encodings[0].maxBitrate = max * 1024;
-        }
+        parameters.encodings[0].maxBitrate = max * 1024;
+
         sender.setParameters(parameters)
             .then(() => {
-                logger.info("New audio bandwidth settings in use: ", sender.getParameters());
+                logger.info( _kind === 'audio' ? "New audio" : "New video", " bandwidth settings in use: ", sender.getParameters());
                 })
                 .catch(e => console.error(e));
     } else {
-        logger.error("Could not set audio bandwidth");
+        logger.error("Could not set bandwidth");
     }
   }
 
-  setAudioBandwidthMin(min: number) {
-    this.setAudioBandwidth(min, null);
+  setAudioBandwidthEncodingsMax(max: number) {
+    this.setBandwidthEncodingsMax(max, 'audio');
   }
 
-  setAudioBandwidthMax(max: number) {
-    this.setAudioBandwidth(null, max);
+  setVideoBandwidthEncodingsMax(max: number) {
+    this.setBandwidthEncodingsMax(max, 'video');
   }
 
   setState(state: State) {

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -730,7 +730,7 @@ export default abstract class BaseCall implements IWebRTCCall {
                 })
                 .catch(e => console.error(e));
     } else {
-        logger.error("Could not set bandwidth");
+        logger.error("Could not set bandwidth. Dynamic bandwidth can only be set when there is a call running - is there any call running?)");
     }
   }
 

--- a/packages/js/src/Modules/Verto/webrtc/Peer.ts
+++ b/packages/js/src/Modules/Verto/webrtc/Peer.ts
@@ -311,7 +311,7 @@ export default class Peer {
       googleMaxBitrate,
       googleMinBitrate,
       googleStartBitrate,
-      mediaSettings
+      mediaSettings,
     } = this.options;
 
     if (useStereo) {
@@ -327,8 +327,15 @@ export default class Peer {
       );
     }
 
-    if (mediaSettings && mediaSettings.useSdpASBandwidthKbps && mediaSettings.sdpASBandwidthKbps !== null) {
-      sessionDescription.sdp = sdpBitrateASHack(sessionDescription.sdp, mediaSettings.sdpASBandwidthKbps);
+    if (
+      mediaSettings &&
+      mediaSettings.useSdpASBandwidthKbps &&
+      mediaSettings.sdpASBandwidthKbps !== null
+    ) {
+      sessionDescription.sdp = sdpBitrateASHack(
+        sessionDescription.sdp,
+        mediaSettings.sdpASBandwidthKbps
+      );
     }
     return this.instance.setLocalDescription(sessionDescription);
   }

--- a/packages/js/src/Modules/Verto/webrtc/Peer.ts
+++ b/packages/js/src/Modules/Verto/webrtc/Peer.ts
@@ -327,8 +327,8 @@ export default class Peer {
       );
     }
 
-    if (mediaSettings && mediaSettings.useSdpASBandwidth_kbps && mediaSettings.sdpASBandwidth_kbps != null) {
-      sessionDescription.sdp = sdpBitrateASHack(sessionDescription.sdp, mediaSettings.sdpASBandwidth_kbps);
+    if (mediaSettings && mediaSettings.useSdpASBandwidthKbps && mediaSettings.sdpASBandwidthKbps !== null) {
+      sessionDescription.sdp = sdpBitrateASHack(sessionDescription.sdp, mediaSettings.sdpASBandwidthKbps);
     }
     return this.instance.setLocalDescription(sessionDescription);
   }

--- a/packages/js/src/Modules/Verto/webrtc/Peer.ts
+++ b/packages/js/src/Modules/Verto/webrtc/Peer.ts
@@ -327,8 +327,8 @@ export default class Peer {
       );
     }
 
-    if (mediaSettings.useSdpASBandwidth && mediaSettings.sdpASBandwidth != null) {
-      sessionDescription.sdp = sdpBitrateASHack(sessionDescription.sdp, mediaSettings.sdpASBandwidth);
+    if (mediaSettings.useSdpASBandwidth_kbps && mediaSettings.sdpASBandwidth_kbps != null) {
+      sessionDescription.sdp = sdpBitrateASHack(sessionDescription.sdp, mediaSettings.sdpASBandwidth_kbps);
     }
     return this.instance.setLocalDescription(sessionDescription);
   }

--- a/packages/js/src/Modules/Verto/webrtc/Peer.ts
+++ b/packages/js/src/Modules/Verto/webrtc/Peer.ts
@@ -327,7 +327,7 @@ export default class Peer {
       );
     }
 
-    if (mediaSettings.useSdpASBandwidth_kbps && mediaSettings.sdpASBandwidth_kbps != null) {
+    if (mediaSettings && mediaSettings.useSdpASBandwidth_kbps && mediaSettings.sdpASBandwidth_kbps != null) {
       sessionDescription.sdp = sdpBitrateASHack(sessionDescription.sdp, mediaSettings.sdpASBandwidth_kbps);
     }
     return this.instance.setLocalDescription(sessionDescription);

--- a/packages/js/src/Modules/Verto/webrtc/Peer.ts
+++ b/packages/js/src/Modules/Verto/webrtc/Peer.ts
@@ -4,6 +4,7 @@ import {
   getMediaConstraints,
   sdpStereoHack,
   sdpBitrateHack,
+  sdpBitrateASHack,
   sdpMediaOrderHack,
 } from './helpers';
 import { SwEvent } from '../util/constants';
@@ -310,6 +311,7 @@ export default class Peer {
       googleMaxBitrate,
       googleMinBitrate,
       googleStartBitrate,
+      mediaSettings
     } = this.options;
 
     if (useStereo) {
@@ -323,6 +325,10 @@ export default class Peer {
         googleMinBitrate,
         googleStartBitrate
       );
+    }
+
+    if (mediaSettings.useSdpASBandwidth && mediaSettings.sdpASBandwidth != null) {
+      sessionDescription.sdp = sdpBitrateASHack(sessionDescription.sdp, mediaSettings.sdpASBandwidth);
     }
     return this.instance.setLocalDescription(sessionDescription);
   }

--- a/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
+++ b/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
@@ -57,6 +57,7 @@ class VertoHandler {
         callerName: params.callee_id_name,
         callerNumber: params.callee_id_number,
         attach,
+        mediaSettings: params.mediaSettings
       };
 
       if (params.telnyx_call_control_id) {

--- a/packages/js/src/Modules/Verto/webrtc/constants.ts
+++ b/packages/js/src/Modules/Verto/webrtc/constants.ts
@@ -50,6 +50,7 @@ export const DEFAULT_CALL_OPTIONS: IVertoCallOptions = {
   attach: false,
   screenShare: false,
   userVariables: {},
+  mediaSettings: { useSdpASBandwidth: false, sdpASBandwidth: 0 },
 };
 
 export enum State {

--- a/packages/js/src/Modules/Verto/webrtc/constants.ts
+++ b/packages/js/src/Modules/Verto/webrtc/constants.ts
@@ -50,7 +50,7 @@ export const DEFAULT_CALL_OPTIONS: IVertoCallOptions = {
   attach: false,
   screenShare: false,
   userVariables: {},
-  mediaSettings: { useSdpASBandwidth: false, sdpASBandwidth: 0 },
+  mediaSettings: { useSdpASBandwidth_kbps: false, sdpASBandwidth_kbps: 0 },
 };
 
 export enum State {

--- a/packages/js/src/Modules/Verto/webrtc/constants.ts
+++ b/packages/js/src/Modules/Verto/webrtc/constants.ts
@@ -50,7 +50,7 @@ export const DEFAULT_CALL_OPTIONS: IVertoCallOptions = {
   attach: false,
   screenShare: false,
   userVariables: {},
-  mediaSettings: { useSdpASBandwidth_kbps: false, sdpASBandwidth_kbps: 0 },
+  mediaSettings: { useSdpASBandwidthKbps: false, sdpASBandwidthKbps: 0 },
 };
 
 export enum State {

--- a/packages/js/src/Modules/Verto/webrtc/helpers.ts
+++ b/packages/js/src/Modules/Verto/webrtc/helpers.ts
@@ -378,17 +378,14 @@ const sdpBitrateASHack = (
   bandwidth: number
 ) => {
   let modifier = 'AS';
-  // TODO check for firefox
-  //if (adapter.browserDetails.browser === 'firefox') {
-  //  bandwidth = (bandwidth >>> 0) * 1000;
-  //  modifier = 'TIAS';
-  //}
+
   if (sdp.indexOf('b=' + modifier + ':') === -1) {
     // insert b= after c= line.
     sdp = sdp.replace(/c=IN (.*)\r\n/, 'c=IN $1\r\nb=' + modifier + ':' + bandwidth + '\r\n');
   } else {
     sdp = sdp.replace(new RegExp('b=' + modifier + ':.*\r\n'), 'b=' + modifier + ':' + bandwidth + '\r\n');
   }
+
   return sdp;
 };
 

--- a/packages/js/src/Modules/Verto/webrtc/helpers.ts
+++ b/packages/js/src/Modules/Verto/webrtc/helpers.ts
@@ -375,18 +375,19 @@ const sdpBitrateHack = (
 
 const sdpBitrateASHack = (
   sdp: string,
-  bandwidth_kbps: number
+  bandwidthKbps: number
 ) => {
   let modifier = 'AS';
-  let bandwidth = bandwidth_kbps;
+  let bandwidth = bandwidthKbps;
 
   if (
     navigator.userAgent.match(/firefox/gim) &&
     !navigator.userAgent.match(/OPR\/[0-9]{2}/gi) &&
     !navigator.userAgent.match(/edg/gim)
   ) {
+    const BITS_PER_KILOBITS = 1000;
     modifier = 'TIAS';
-    bandwidth = (bandwidth_kbps >>> 0) * 1000;
+    bandwidth = (bandwidthKbps >>> 0) * BITS_PER_KILOBITS;
   }
 
   if (sdp.indexOf('b=' + modifier + ':') === -1) {

--- a/packages/js/src/Modules/Verto/webrtc/helpers.ts
+++ b/packages/js/src/Modules/Verto/webrtc/helpers.ts
@@ -373,10 +373,7 @@ const sdpBitrateHack = (
   return lines.join(endOfLine);
 };
 
-const sdpBitrateASHack = (
-  sdp: string,
-  bandwidthKbps: number
-) => {
+const sdpBitrateASHack = (sdp: string, bandwidthKbps: number) => {
   let modifier = 'AS';
   let bandwidth = bandwidthKbps;
 
@@ -392,9 +389,15 @@ const sdpBitrateASHack = (
 
   if (sdp.indexOf('b=' + modifier + ':') === -1) {
     // insert b= after c= line.
-    sdp = sdp.replace(/c=IN (.*)\r\n/, 'c=IN $1\r\nb=' + modifier + ':' + bandwidth + '\r\n');
+    sdp = sdp.replace(
+      /c=IN (.*)\r\n/,
+      'c=IN $1\r\nb=' + modifier + ':' + bandwidth + '\r\n'
+    );
   } else {
-    sdp = sdp.replace(new RegExp('b=' + modifier + ':.*\r\n'), 'b=' + modifier + ':' + bandwidth + '\r\n');
+    sdp = sdp.replace(
+      new RegExp('b=' + modifier + ':.*\r\n'),
+      'b=' + modifier + ':' + bandwidth + '\r\n'
+    );
   }
 
   return sdp;

--- a/packages/js/src/Modules/Verto/webrtc/helpers.ts
+++ b/packages/js/src/Modules/Verto/webrtc/helpers.ts
@@ -373,6 +373,25 @@ const sdpBitrateHack = (
   return lines.join(endOfLine);
 };
 
+const sdpBitrateASHack = (
+  sdp: string,
+  bandwidth: number
+) => {
+  let modifier = 'AS';
+  // TODO check for firefox
+  //if (adapter.browserDetails.browser === 'firefox') {
+  //  bandwidth = (bandwidth >>> 0) * 1000;
+  //  modifier = 'TIAS';
+  //}
+  if (sdp.indexOf('b=' + modifier + ':') === -1) {
+    // insert b= after c= line.
+    sdp = sdp.replace(/c=IN (.*)\r\n/, 'c=IN $1\r\nb=' + modifier + ':' + bandwidth + '\r\n');
+  } else {
+    sdp = sdp.replace(new RegExp('b=' + modifier + ':.*\r\n'), 'b=' + modifier + ':' + bandwidth + '\r\n');
+  }
+  return sdp;
+};
+
 function getBrowserInfo() {
   if (!window || !window.navigator || !window.navigator.userAgent) {
     throw new Error(
@@ -680,6 +699,7 @@ export {
   sdpStereoHack,
   sdpMediaOrderHack,
   sdpBitrateHack,
+  sdpBitrateASHack,
   checkSubscribeResponse,
   destructSubscribeResponse,
   enableAudioTracks,

--- a/packages/js/src/Modules/Verto/webrtc/helpers.ts
+++ b/packages/js/src/Modules/Verto/webrtc/helpers.ts
@@ -375,9 +375,19 @@ const sdpBitrateHack = (
 
 const sdpBitrateASHack = (
   sdp: string,
-  bandwidth: number
+  bandwidth_kbps: number
 ) => {
   let modifier = 'AS';
+  let bandwidth = bandwidth_kbps;
+
+  if (
+    navigator.userAgent.match(/firefox/gim) &&
+    !navigator.userAgent.match(/OPR\/[0-9]{2}/gi) &&
+    !navigator.userAgent.match(/edg/gim)
+  ) {
+    modifier = 'TIAS';
+    bandwidth = (bandwidth_kbps >>> 0) * 1000;
+  }
 
   if (sdp.indexOf('b=' + modifier + ':') === -1) {
     // insert b= after c= line.

--- a/packages/js/src/Modules/Verto/webrtc/interfaces.ts
+++ b/packages/js/src/Modules/Verto/webrtc/interfaces.ts
@@ -1,3 +1,8 @@
+export interface IMediaSettings {
+  useSdpASBandwidthKbps: boolean,
+  sdpASBandwidthKbps: number
+}
+
 export interface IVertoCallOptions {
   // Required
   destinationNumber: string;
@@ -38,7 +43,7 @@ export interface IVertoCallOptions {
   skipNotifications?: boolean
   negotiateAudio?: boolean
   negotiateVideo?: boolean
-  mediaSettings: { useSdpASBandwidth_kbps: boolean, sdpASBandwidth_kbps: number };
+  mediaSettings?: IMediaSettings;
 }
 
 export interface IWebRTCCall {

--- a/packages/js/src/Modules/Verto/webrtc/interfaces.ts
+++ b/packages/js/src/Modules/Verto/webrtc/interfaces.ts
@@ -38,7 +38,7 @@ export interface IVertoCallOptions {
   skipNotifications?: boolean
   negotiateAudio?: boolean
   negotiateVideo?: boolean
-  mediaSettings: { useSdpASBandwidth: boolean, sdpASBandwidth: number };
+  mediaSettings: { useSdpASBandwidth_kbps: boolean, sdpASBandwidth_kbps: number };
 }
 
 export interface IWebRTCCall {
@@ -75,8 +75,8 @@ export interface IWebRTCCall {
   deaf: () => void;
   undeaf: () => void;
   toggleDeaf: () => void;
-  setAudioBandwidthEncodingsMax: (max: number) => void,
-  setVideoBandwidthEncodingsMax: (max: number) => void,
+  setAudioBandwidthEncodingsMaxBps: (max: number) => void,
+  setVideoBandwidthEncodingsMaxBps: (max: number) => void,
   setState: (state: any) => void;
   // Privates
   handleMessage: (msg: any) => void;

--- a/packages/js/src/Modules/Verto/webrtc/interfaces.ts
+++ b/packages/js/src/Modules/Verto/webrtc/interfaces.ts
@@ -1,6 +1,6 @@
 export interface IMediaSettings {
-  useSdpASBandwidthKbps: boolean,
-  sdpASBandwidthKbps: number
+  useSdpASBandwidthKbps: boolean;
+  sdpASBandwidthKbps: number;
 }
 
 export interface IVertoCallOptions {
@@ -27,7 +27,7 @@ export interface IVertoCallOptions {
   camId?: string;
   camLabel?: string;
   speakerId?: string;
-  userVariables?: { [key: string]: any }
+  userVariables?: { [key: string]: any };
   screenShare?: boolean;
   onNotification?: Function;
   googleMaxBitrate?: number;
@@ -40,9 +40,9 @@ export interface IVertoCallOptions {
   telnyxSessionId?: string;
   telnyxLegId?: string;
   clientState?: string;
-  skipNotifications?: boolean
-  negotiateAudio?: boolean
-  negotiateVideo?: boolean
+  skipNotifications?: boolean;
+  negotiateAudio?: boolean;
+  negotiateVideo?: boolean;
   mediaSettings?: IMediaSettings;
 }
 
@@ -80,8 +80,8 @@ export interface IWebRTCCall {
   deaf: () => void;
   undeaf: () => void;
   toggleDeaf: () => void;
-  setAudioBandwidthEncodingsMaxBps: (max: number) => void,
-  setVideoBandwidthEncodingsMaxBps: (max: number) => void,
+  setAudioBandwidthEncodingsMaxBps: (max: number) => void;
+  setVideoBandwidthEncodingsMaxBps: (max: number) => void;
   setState: (state: any) => void;
   // Privates
   handleMessage: (msg: any) => void;
@@ -109,9 +109,9 @@ export interface IWebRTCInfo {
   supportGetUserMedia: boolean;
 }
 export interface IWebRTCBrowser {
-  browserName: string
+  browserName: string;
   features?: Array<string>;
-  supported: string
+  supported: string;
 }
 export interface IWebRTCSupportedBrowser {
   operationSystem: string;

--- a/packages/js/src/Modules/Verto/webrtc/interfaces.ts
+++ b/packages/js/src/Modules/Verto/webrtc/interfaces.ts
@@ -38,6 +38,7 @@ export interface IVertoCallOptions {
   skipNotifications?: boolean
   negotiateAudio?: boolean
   negotiateVideo?: boolean
+  mediaSettings: { useSdpASBandwidth: boolean, sdpASBandwidth: number };
 }
 
 export interface IWebRTCCall {
@@ -74,8 +75,8 @@ export interface IWebRTCCall {
   deaf: () => void;
   undeaf: () => void;
   toggleDeaf: () => void;
-  setAudioBandwidthMin: (min: number) => void,
-  setAudioBandwidthMax: (max: number) => void,
+  setAudioBandwidthEncodingsMax: (max: number) => void,
+  setVideoBandwidthEncodingsMax: (max: number) => void,
   setState: (state: any) => void;
   // Privates
   handleMessage: (msg: any) => void;

--- a/packages/js/src/utils/interfaces.ts
+++ b/packages/js/src/utils/interfaces.ts
@@ -178,7 +178,7 @@ export interface ICallOptions {
   /**
    * Configures media (audio/video) in a call.
    */
-  mediaSettings: { useSdpASBandwidth_kbps: boolean, sdpASBandwidth_kbps: number };
+  mediaSettings: { useSdpASBandwidthKbps: boolean, sdpASBandwidthKbps: number };
 }
 
 /**

--- a/packages/js/src/utils/interfaces.ts
+++ b/packages/js/src/utils/interfaces.ts
@@ -174,6 +174,11 @@ export interface ICallOptions {
    * Overrides client's default `telnyx.notification` handler for this call.
    */
   onNotification?: Function;
+
+  /**
+   * Configures media (audio/video) in a call.
+   */
+  mediaSettings: { useSdpASBandwidth: boolean, sdpASBandwidth: number };
 }
 
 /**

--- a/packages/js/src/utils/interfaces.ts
+++ b/packages/js/src/utils/interfaces.ts
@@ -178,7 +178,7 @@ export interface ICallOptions {
   /**
    * Configures media (audio/video) in a call.
    */
-  mediaSettings: { useSdpASBandwidth: boolean, sdpASBandwidth: number };
+  mediaSettings: { useSdpASBandwidth_kbps: boolean, sdpASBandwidth_kbps: number };
 }
 
 /**


### PR DESCRIPTION
This makes possible to control codecs outgoing bitrate on a running call,
and displays bitrate on a chart. 

## 📝 To Do

- [x] All linters pass
- [x] All tests pass
- [x] Change documentation based on my changes

## ✋ Manual testing


1. Make a call
2. Switch to a new tab on Panel settings, named 'Media settings'
3. Input bitrate and click Apply
4. Observe changes taking effect on chart
5. Confirm values make sense with webrtc-internals, etc

## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [x] Chrome
- [ ] Firefox
TODO
- [x] Safari

## 📸 Screenshots
![media_bitrate_control](https://user-images.githubusercontent.com/40000574/124973851-fa22e480-e023-11eb-9818-7f24e5dd0ceb.png)

![Screenshot from 2021-07-08 18-04-27](https://user-images.githubusercontent.com/40000574/124973692-c6e05580-e023-11eb-9ea7-e32772fa398a.png)

