### PR TITLE
chore: add watch option for pkg development

### DIFF
--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -19,6 +19,7 @@
   ],
   "scripts": {
     "build": "rollup -c",
+    "watch": "rollup -c --watch",
     "prepare": "npm run build",
     "test": "jest",
     "docs": "typedoc src",


### PR DESCRIPTION
A minor change adding a watch option using rollup, this is handy for development

## 📝 To Do

- [x] All linters pass
- [x] All tests pass
- [ ] Change documentation based on my changes