### PR TITLE
WEBRTC-635 Enable async stats

### DIFF
--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -771,7 +771,7 @@ export default abstract class BaseCall implements IWebRTCCall {
     this._statsBindings.push(binding);
   
     if (!this._statsIntervalId) {
-      const STATS_INTERVAL = 5000;
+      const STATS_INTERVAL = 2000;
       this._startStats(STATS_INTERVAL);
     }
   }

--- a/packages/js/src/Modules/Verto/webrtc/interfaces.ts
+++ b/packages/js/src/Modules/Verto/webrtc/interfaces.ts
@@ -46,6 +46,11 @@ export interface IVertoCallOptions {
   mediaSettings?: IMediaSettings;
 }
 
+export interface IStatsBinding {
+  constraints: any;
+  callback: Function;
+}
+
 export interface IWebRTCCall {
   id: string;
   state: string;
@@ -82,6 +87,7 @@ export interface IWebRTCCall {
   toggleDeaf: () => void;
   setAudioBandwidthEncodingsMaxBps: (max: number) => void;
   setVideoBandwidthEncodingsMaxBps: (max: number) => void;
+  getStats: (callback: Function, constraints: any) => void;
   setState: (state: any) => void;
   // Privates
   handleMessage: (msg: any) => void;


### PR DESCRIPTION
https://telnyx.atlassian.net/browse/WEBRTC-637

This adds getStats call to pulbic interface of IWebRTCCall.
The purpose is to enable user to register callback for async stats.
User can call getStats with callback (stats processor) and optional filter on the stats reports.
On each RTCStatsReport the caller's callback gets called with report if report passes user's filter,
or if there is no filter at all.
Filter passing is implemented with the following logic:
- if there is no filter supplied, call user's callback with report
- if there is filter, then for each property present on filter object:
- if the report's property value doesn't match filter's property value, or if there is no this property on report, then do not call user's callback, otherwise all props match - call user's callback with report

The above logic enables to address changes in interface of RTCStatsReport. Chrome version 90 or below uses outbound-rtp to signal report is about local outgoing data and field isRemote to tell if it's local or remote report. Chrome 91 and above uses outbound-rtp type to signal local report about outgoing local data, and remote-outbound-rtp type to signal remote report about outgoing local data. It doesn't use isRemote prop. User can register for specific type of report if user is sure about browsers version of RTCStatsReport, or user can register callback for both versions and check it:


               const localOutboundAudioStatsProcessor = function(report) {
                  console.log('Got stats: ', report);
                  if (report.hasOwnProperty('isRemote')) {
                    // Chrome version 90 or before
                    console.debug("Stats using old interface (isRemote)");
                  } else {
                    // Chrome 91 or above and report is local
                    console.debug("Stats using new interface (undefined isRemote)");
                  }
                };

                // Chrome 91 or above and report is local
                constraints = { type: 'outbound-rtp', kind: 'audio' };
                notification.call.getStats(localOutboundAudioStatsProcessor, constraints);
                // Chrome version 90 or before
                constraints = { type: 'outbound-rtp', kind: 'audio', isRemote: false };
                notification.call.getStats(localOutboundAudioStatsProcessor, constraints);


## 📝 To Do

- [x] All inters pass
- [x] All tests pass
- [x] Change documentation based on my changes

## ✋ Manual testing

1. Provide manual testing instructions

## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [x] Chrome
- [ ] Firefox
- [x] Safari

## 📸 Screenshots
![Screenshot from 2021-07-23 18-04-50](https://user-images.githubusercontent.com/40000574/126816875-48c9ae34-6b49-47da-aa61-fcd9605d949e.png)

