### PR TITLE
feat(WEBRTC-642): Add user agent for call volume track

### DIFF
--- a/packages/js/docs/ts/interfaces/icalloptions.md
+++ b/packages/js/docs/ts/interfaces/icalloptions.md
@@ -12,6 +12,7 @@ ICallOptions
 - [callerName](icalloptions.md#callername)
 - [callerNumber](icalloptions.md#callernumber)
 - [camId](icalloptions.md#camid)
+- [clientState](icalloptions.md#clientstate)
 - [destinationNumber](icalloptions.md#destinationnumber)
 - [iceServers](icalloptions.md#iceservers)
 - [id](icalloptions.md#id)
@@ -60,6 +61,15 @@ ___
 • `Optional` **camId**: *string*
 
 `deviceId` to use as webcam. Overrides the client's default one.
+
+___
+
+### clientState
+
+• `Optional` **clientState**: *string*
+
+Telnyx's Call Control client_state. Can be used with Connections with Advanced -> Events enabled.
+`clientState` string should be base64 encoded.
 
 ___
 

--- a/packages/js/package-lock.json
+++ b/packages/js/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@telnyx/webrtc",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2146,6 +2146,40 @@
         "lodash.get": "^4.4.2",
         "lodash.set": "^4.3.2",
         "mock-fs": "^4.13.0"
+      }
+    },
+    "@rollup/plugin-json": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-4.1.0.tgz",
+      "integrity": "sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.0.8"
+      }
+    },
+    "@rollup/pluginutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "0.0.39",
+        "estree-walker": "^1.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "dependencies": {
+        "@types/estree": {
+          "version": "0.0.39",
+          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+          "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+          "dev": true
+        },
+        "estree-walker": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+          "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+          "dev": true
+        }
       }
     },
     "@sindresorhus/is": {

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -46,6 +46,7 @@
   "devDependencies": {
     "@babel/preset-env": "^7.11.0",
     "@release-it/bumper": "^2.0.0",
+    "@rollup/plugin-json": "^4.1.0",
     "@types/uuid": "^7.0.0",
     "@types/webrtc": "0.0.26",
     "@typescript-eslint/eslint-plugin": "^3.6.1",

--- a/packages/js/rollup.config.js
+++ b/packages/js/rollup.config.js
@@ -2,6 +2,7 @@ import resolve from 'rollup-plugin-node-resolve';
 import commonJS from 'rollup-plugin-commonjs';
 import typescript from 'rollup-plugin-typescript2';
 import { terser } from 'rollup-plugin-terser';
+import json from '@rollup/plugin-json';
 import pkg from './package.json';
 
 const input = 'src/index.ts';
@@ -28,6 +29,7 @@ const plugins = [
     objectHashIgnoreUnknownHack: true,
   }),
   terser(),
+  json(),
 ];
 
 export default [

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -44,7 +44,8 @@ import {
 import { MCULayoutEventHandler } from './LayoutHandler';
 import Call from './Call';
 
-export const SDK_VERSION = '2.5.1';
+const SDK_VERSION = '2.5.1';
+
 /**
  * @ignore Hide in docs output
  */

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -43,8 +43,9 @@ import {
 } from '../util/webrtc';
 import { MCULayoutEventHandler } from './LayoutHandler';
 import Call from './Call';
+import pkg from '../../../../package.json';
 
-const SDK_VERSION = '2.5.1';
+const SDK_VERSION = pkg.version;
 
 /**
  * @ignore Hide in docs output

--- a/packages/js/src/utils/interfaces.ts
+++ b/packages/js/src/utils/interfaces.ts
@@ -120,7 +120,6 @@ export interface ICallOptions {
    */
   telnyxLegId?: string;
   /**
-   * @hidden
    *
    * Telnyx's Call Control client_state. Can be used with Connections with Advanced -> Events enabled. 
    * `clientState` string should be base64 encoded.

--- a/packages/js/tsconfig.json
+++ b/packages/js/tsconfig.json
@@ -3,8 +3,8 @@
   "compilerOptions": {
     "declarationDir": "./lib",
     "outDir": "./lib",
-    "rootDir": "./src",
-    "baseUrl": "."
+    "baseUrl": ".",
+    "resolveJsonModule": true
   },
   "typedocOptions": {
     "out": "./docs/ts",


### PR DESCRIPTION
 - Add user agent for call volume track

## 📝 To Do

- [ ] All linters pass
- [ ] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

1. Navigate to 'package/js' and run `npm run build`
2. Choose one of the examples in `examples` folder and make a `link`
3. Make a call and see if you can find the `User-Agent` in `WS` messages in browser.

## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [x] Chrome
- [ ] Firefox
- [ ] Safari

## 📸 Screenshots

| Description | Screenshot |
| ----------- | ---------- |
| Desktop     | ![image](https://user-images.githubusercontent.com/16343871/129761952-b0a7fe5d-cbe6-48c9-8823-1c94eff20000.png)|
