### PR TITLE
fix(ENGDESK-11008): asking for permission on the browser when calling methods that require audio output devices

### DIFF
--- a/packages/js/src/Modules/Verto/BrowserSession.ts
+++ b/packages/js/src/Modules/Verto/BrowserSession.ts
@@ -325,6 +325,7 @@ export default abstract class BrowserSession extends BaseSession {
    */
   getAudioOutDevices(): Promise<MediaDeviceInfo[]> {
     return getDevices(DeviceType.AudioOut).catch((error) => {
+      console.error('getAudioOutDevices', error);
       trigger(SwEvent.MediaError, error, this.uuid);
       return [];
     });

--- a/packages/js/src/Modules/Verto/webrtc/helpers.ts
+++ b/packages/js/src/Modules/Verto/webrtc/helpers.ts
@@ -29,7 +29,7 @@ const _constraintsByKind = (
   kind: string = null
 ): { audio: boolean; video: boolean } => {
   return {
-    audio: !kind || kind === DeviceType.AudioIn,
+    audio: !kind || kind === DeviceType.AudioIn || kind === DeviceType.AudioOut,
     video: !kind || kind === DeviceType.Video,
   };
 };
@@ -50,7 +50,10 @@ const getDevices = async (
   kind: MediaDeviceKind | undefined = null,
   fullList: boolean = false
 ): Promise<MediaDeviceInfo[]> => {
-  let devices = await WebRTC.enumerateDevices().catch((error) => []);
+  let devices = await WebRTC.enumerateDevices().catch((error) => {
+    console.error('enumerateDevices', error);
+    return [];
+  });
   if (kind) {
     devices = devices.filter((d: MediaDeviceInfo) => d.kind === kind);
   }


### PR DESCRIPTION
-  asking for permission on the browser when calling methods that require audio output devices


## 📝 To Do

- [x] All linters pass
- [ ] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

1. Navigate to `js/examples/react-audio-widget`
2. Run `npm run setup` and `npm run storybook`
3. Access http://localhost:6006/?path=/story/utilities--examples in an incognito tab
4. Click on `Get output audio devices` button and see if will prompt a modal asking for permission.
5. Click in Allow and see if it returns the audio output device list 

## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [x] Chrome
- [ ] Firefox
- [ ] Safari

## 📸 Screenshots

| Description | Screenshot |
| ----------- | ---------- |
| Desktop     |![image](https://user-images.githubusercontent.com/16343871/132051488-acabc827-246c-41bb-ab26-66a03986c033.png)|

