### PR TITLE
feta(WEBRTC-683): add gateway state messages to have the certain that the user is registered before make a new call

### DIFF
--- a/packages/js/.eslintrc.json
+++ b/packages/js/.eslintrc.json
@@ -23,6 +23,7 @@
         "tsx": "never"
       }
     ],
+    "import/prefer-default-export": "off",
     "no-underscore-dangle": "off",
     "camelcase": "off",
     "no-plusplus": "off"

--- a/packages/js/examples/react-audio-widgets/stories/components/ClickToCall.jsx
+++ b/packages/js/examples/react-audio-widgets/stories/components/ClickToCall.jsx
@@ -59,6 +59,15 @@ const ClickToCall = ({
     setCall(newCall);
   };
 
+  function detachListeners(client) {
+    if (client) {
+      client.off('telnyx.error');
+      client.off('telnyx.ready');
+      client.off('telnyx.notification');
+      client.off('telnyx.socket.close');
+    }
+  }
+
   const connectAndCall = () => {
     const session = new TelnyxRTC({
       login_token: token,
@@ -79,16 +88,20 @@ const ClickToCall = ({
     session.on('telnyx.error', (error) => {
       console.log('telnyx.error', error);
       alert(error.message);
+      session.disconnect();
+      detachListeners(session);
     });
 
     session.on('telnyx.socket.error', (error) => {
       console.log('telnyx.socket.error', error);
       session.disconnect();
+      detachListeners(session);
     });
 
     session.on('telnyx.socket.close', (error) => {
       console.log('telnyx.socket.close', error);
       session.disconnect();
+      detachListeners(session);
     });
 
     session.on('telnyx.notification', (notification) => {
@@ -145,12 +158,16 @@ const ClickToCall = ({
         </button>
       )}
 
-      {registering && !registered && <div data-testid='state-call-registering'>registering...</div>}
+      {registering && !registered && (
+        <div data-testid='state-call-registering'>registering...</div>
+      )}
 
       {call && (
         <div>
           <div>
-            <button data-testid='btn-end-call' onClick={hangup}>End Call</button>
+            <button data-testid='btn-end-call' onClick={hangup}>
+              End Call
+            </button>
           </div>
           <div data-testid={`state-call-${status}`}>{status}</div>
         </div>

--- a/packages/js/examples/react-audio-widgets/stories/components/WebDialer.jsx
+++ b/packages/js/examples/react-audio-widgets/stories/components/WebDialer.jsx
@@ -85,6 +85,15 @@ const WebDialer = ({
     }
   }, [registered, disableMicrophone]);
 
+  const detachListeners = (client) => {
+    if (client) {
+      client.off('telnyx.error');
+      client.off('telnyx.ready');
+      client.off('telnyx.notification');
+      client.off('telnyx.socket.close');
+    }
+  };
+
   const connectAndCall = () => {
     const session = new TelnyxRTC({
       login_token: token,
@@ -108,16 +117,20 @@ const WebDialer = ({
       console.error('telnyx.error', error);
       setRegistered(false);
       setRegistering(false);
+      session.disconnect();
+      detachListeners(session);
     });
 
     session.on('telnyx.socket.error', (error) => {
       console.log('telnyx.socket.error', error);
       session.disconnect();
+      detachListeners(session);
     });
 
     session.on('telnyx.socket.close', (error) => {
       console.log('telnyx.socket.close', error);
       session.disconnect();
+      detachListeners(session);
     });
 
     session.on('telnyx.notification', (notification) => {

--- a/packages/js/examples/react-video-calling-app/src/App.js
+++ b/packages/js/examples/react-video-calling-app/src/App.js
@@ -41,6 +41,15 @@ function App() {
     }
   }
 
+  function detachListeners(client){
+    if(client) {
+      client.off('telnyx.error');
+      client.off('telnyx.ready');
+      client.off('telnyx.notification');
+      client.off('telnyx.socket.close');
+    }
+  }
+
   function connect(params) {
     setLoginParams(params);
 
@@ -50,19 +59,24 @@ function App() {
     session.on('telnyx.ready', (session) => {
       setState({ connected: true });
     });
+
     session.on('telnyx.error', (error) => {
       alert(error.message);
+      session.disconnect();
+      detachListeners(session);
     });
 
     session.on('telnyx.socket.error', (error) => {
       setState({ connected: false });
       session.disconnect();
+      detachListeners(session);
     });
 
     session.on('telnyx.socket.close', (error) => {
       console.log('close', error);
       setState({ connected: false });
       session.disconnect();
+      detachListeners(session);
     });
 
     session.on('telnyx.notification', (notification) => {

--- a/packages/js/examples/vanilla-js-app/index.html
+++ b/packages/js/examples/vanilla-js-app/index.html
@@ -9,16 +9,16 @@
     />
 
     <!-- Cross Browser WebRTC Adapter -->
-    <script
-      type="text/javascript"
-      src="https://webrtc.github.io/adapter/adapter-latest.js"
-    ></script>
-
-    <!-- Include the Telnyx WEBRTC JS SDK -->
     <!-- <script
       type="text/javascript"
-      src="https://unpkg.com/@telnyx/webrtc"
+      src="https://webrtc.github.io/adapter/adapter-latest.js"
     ></script> -->
+
+    <!-- Include the Telnyx WEBRTC JS SDK -->
+    <script
+      type="text/javascript"
+      src="https://unpkg.com/@telnyx/webrtc"
+    ></script>
 
     <script
     type="text/javascript"

--- a/packages/js/examples/vanilla-js-app/index.html
+++ b/packages/js/examples/vanilla-js-app/index.html
@@ -9,10 +9,10 @@
     />
 
     <!-- Cross Browser WebRTC Adapter -->
-    <!-- <script
+    <script
       type="text/javascript"
       src="https://webrtc.github.io/adapter/adapter-latest.js"
-    ></script> -->
+    ></script>
 
     <!-- Include the Telnyx WEBRTC JS SDK -->
     <script
@@ -20,10 +20,10 @@
       src="https://unpkg.com/@telnyx/webrtc"
     ></script>
 
-    <script
+    <!-- <script
     type="text/javascript"
     src="../../lib/bundle.js"
-  ></script>
+  ></script> -->
 
     <!-- To style up the demo a little -->
     <link

--- a/packages/js/examples/vanilla-js-app/index.html
+++ b/packages/js/examples/vanilla-js-app/index.html
@@ -15,10 +15,15 @@
     ></script>
 
     <!-- Include the Telnyx WEBRTC JS SDK -->
-    <script
+    <!-- <script
       type="text/javascript"
       src="https://unpkg.com/@telnyx/webrtc"
-    ></script>
+    ></script> -->
+
+    <script
+    type="text/javascript"
+    src="../../lib/bundle.js"
+  ></script>
 
     <!-- To style up the demo a little -->
     <link

--- a/packages/js/examples/vanilla-js-app/index.html
+++ b/packages/js/examples/vanilla-js-app/index.html
@@ -216,6 +216,14 @@
         document.getElementById('env').checked = '1';
       });
 
+      function detachListeners(client){
+        if(client) {
+          client.off('telnyx.error');
+          client.off('telnyx.ready');
+          client.off('telnyx.notification');
+          client.off('telnyx.socket.close');
+        }
+      }
       /**
        * Connect with TelnyxWebRTC.TelnyxRTC creating a client and attaching all the event handler.
        */
@@ -260,11 +268,19 @@
           btnConnect.classList.remove('d-none');
           btnDisconnect.classList.add('d-none');
           connectStatus.innerHTML = 'Disconnected';
+          client.disconnect();
+          detachListeners(client);
         });
 
         // Handle error...
         client.on('telnyx.error', function (error) {
           console.error('telnyx error:', error);
+          alert(error.message)
+          btnConnect.classList.remove('d-none');
+          btnDisconnect.classList.add('d-none');
+          connectStatus.innerHTML = 'Disconnected';
+          client.disconnect();
+          detachListeners(client);
         });
 
         client.on('telnyx.notification', handleNotification);

--- a/packages/js/src/Modules/Verto/messages/verto/Gateway.ts
+++ b/packages/js/src/Modules/Verto/messages/verto/Gateway.ts
@@ -1,0 +1,20 @@
+import { VertoMethod } from '../../webrtc/constants';
+import BaseRequest from './BaseRequest';
+
+class Gateway extends BaseRequest {
+  method: string = VertoMethod.GatewayState;
+
+  constructor() {
+    super();
+
+    const params: any = {
+      method: VertoMethod.GatewayState,
+      jsonrpc: '2.0',
+      params: {},
+    };
+
+    this.buildRequest({ method: this.method, params });
+  }
+}
+
+export { Gateway };

--- a/packages/js/src/Modules/Verto/tests/webrtc/VertoHandler.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/VertoHandler.test.ts
@@ -12,7 +12,7 @@ const DEFAULT_PARAMS = {
   callerName: 'Jest Client',
   callerNumber: '5678',
 };
-describe('VertoHandler', () => {
+describe.only('VertoHandler', () => {
   let instance: BrowserSession;
   let handler: VertoHandler;
   let call: Call;
@@ -172,18 +172,16 @@ describe('VertoHandler', () => {
         type: 'vertoClientReady',
       });
       
+      handler.handleMessage(
+        JSON.parse(
+          '{"jsonrpc":"2.0","id":37,"method":"telnyx_rtc.clientReady","params":{"reattached_sessions":["test"], "state": "REGED"}}'
+        )
+      );
 
-      // handler.handleMessage(
-      //   JSON.parse(
-      //     '{"jsonrpc":"2.0","id":37,"method":"telnyx_rtc.clientReady","params":{"reattached_sessions":["test"], state: "REGED"}}'
-      //   )
-      // );
-
-      // expect(onNotification).toBeCalledWith({
-      //   type: 'vertoClientReady',
-      //   reattached_sessions: ['test'],
-      //   state: 'REGED',
-      // });
+      expect(onNotification).toBeCalledWith({
+        state: 'REGED',
+        type: 'vertoClientReady',
+      });
     });
   });
 });

--- a/packages/js/src/Modules/Verto/tests/webrtc/VertoHandler.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/VertoHandler.test.ts
@@ -31,7 +31,10 @@ describe('VertoHandler', () => {
       token: 'token',
     });
     onNotification.mockClear();
-    instance.on('telnyx.notification', onNotification);
+    instance.on('telnyx.notification', (notification) => {
+      // console.log('=========>notification', notification)
+      onNotification(notification);
+    });
     handler = new VertoHandler(instance);
   });
 
@@ -82,7 +85,9 @@ describe('VertoHandler', () => {
       );
       expect(instance.calls[callId].options.telnyxSessionId).toEqual('si1234');
       expect(instance.calls[callId].options.telnyxLegId).toEqual('li1234');
-      expect(instance.calls[callId].options.clientState).toEqual('aGVsbG8gbXkgZnJpZW5k');
+      expect(instance.calls[callId].options.clientState).toEqual(
+        'aGVsbG8gbXkgZnJpZW5k'
+      );
       done();
     });
   });
@@ -154,27 +159,31 @@ describe('VertoHandler', () => {
     });
   });
 
-  describe('telnyx_rtc.clientReady', () => {
+  describe('telnyx_rtc.gatewayState', () => {
     it('should dispatch a notification', () => {
       handler.handleMessage(
         JSON.parse(
-          '{"jsonrpc":"2.0","id":37,"method":"telnyx_rtc.clientReady","params":{"reattached_sessions":[]}}'
+          '{"jsonrpc":"2.0","id":20342,"method":"telnyx_rtc.gatewayState","params":{"state":"REGED"}}'
         )
       );
-      expect(onNotification).toBeCalledWith({
-        type: 'vertoClientReady',
-        reattached_sessions: [],
-      });
 
-      handler.handleMessage(
-        JSON.parse(
-          '{"jsonrpc":"2.0","id":37,"method":"telnyx_rtc.clientReady","params":{"reattached_sessions":["test"]}}'
-        )
-      );
       expect(onNotification).toBeCalledWith({
+        state: 'REGED',
         type: 'vertoClientReady',
-        reattached_sessions: ['test'],
       });
+      
+
+      // handler.handleMessage(
+      //   JSON.parse(
+      //     '{"jsonrpc":"2.0","id":37,"method":"telnyx_rtc.clientReady","params":{"reattached_sessions":["test"], state: "REGED"}}'
+      //   )
+      // );
+
+      // expect(onNotification).toBeCalledWith({
+      //   type: 'vertoClientReady',
+      //   reattached_sessions: ['test'],
+      //   state: 'REGED',
+      // });
     });
   });
 });

--- a/packages/js/src/Modules/Verto/tests/webrtc/VertoHandler.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/VertoHandler.test.ts
@@ -12,7 +12,7 @@ const DEFAULT_PARAMS = {
   callerName: 'Jest Client',
   callerNumber: '5678',
 };
-describe.only('VertoHandler', () => {
+describe('VertoHandler', () => {
   let instance: BrowserSession;
   let handler: VertoHandler;
   let call: Call;

--- a/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
+++ b/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
@@ -88,7 +88,11 @@ class VertoHandler {
       return call;
     };
 
-    const messageTocheckRegisterState = new Gateway();
+    const messageToCheckRegisterState = new Gateway();
+
+    console.log("====>method", method);
+    console.log("====>msg", msg);
+    console.log("====>params", params);
 
     switch (method) {
       case VertoMethod.Punt:
@@ -139,12 +143,13 @@ class VertoHandler {
       case VertoMethod.ClientReady:
         // We need to send a GatewayState to make sure that the user is registered
         // to avoid GATEWAY_DOWN when the user tries to make a new call
-        this.session.execute(messageTocheckRegisterState);
+        this.session.execute(messageToCheckRegisterState);
         break;
 
       case VertoMethod.GatewayState:
         // If the user is REGED tell the client that it is ready to make calls
         if (msg.params && msg.params.state && msg.params.state === 'REGED') {
+          this.retriedRegister = 0;
           params.type = NOTIFICATION_TYPE.vertoClientReady;
           trigger(SwEvent.Notification, params, session.uuid);
           break;
@@ -164,7 +169,7 @@ class VertoHandler {
             trigger(SwEvent.Error, params, session.uuid);
             break;
           } else {
-            this.session.execute(messageTocheckRegisterState);
+            this.session.execute(messageToCheckRegisterState);
           }
         }
 

--- a/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
+++ b/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
@@ -90,10 +90,6 @@ class VertoHandler {
 
     const messageToCheckRegisterState = new Gateway();
 
-    console.log("====>method", method);
-    console.log("====>msg", msg);
-    console.log("====>params", params);
-
     switch (method) {
       case VertoMethod.Punt:
         session.disconnect();

--- a/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
+++ b/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
@@ -57,7 +57,7 @@ class VertoHandler {
         callerName: params.callee_id_name,
         callerNumber: params.callee_id_number,
         attach,
-        mediaSettings: params.mediaSettings
+        mediaSettings: params.mediaSettings,
       };
 
       if (params.telnyx_call_control_id) {
@@ -80,6 +80,8 @@ class VertoHandler {
       call.nodeId = this.nodeId;
       return call;
     };
+
+    console.log('method===>', method);
 
     switch (method) {
       case VertoMethod.Punt:
@@ -126,10 +128,19 @@ class VertoHandler {
         params.type = NOTIFICATION_TYPE.generic;
         trigger(SwEvent.Notification, params, session.uuid);
         break;
-      case VertoMethod.ClientReady:
-        params.type = NOTIFICATION_TYPE.vertoClientReady;
-        trigger(SwEvent.Notification, params, session.uuid);
+
+      case VertoMethod.GatewayState:
+        logger.warn('Verto message GatewayState:', msg);
+        if (msg.params && msg.params.state && msg.params.state === 'REGED') {
+          params.type = NOTIFICATION_TYPE.vertoClientReady;
+          trigger(SwEvent.Notification, params, session.uuid);
+        }
         break;
+      // case VertoMethod.ClientReady:
+      //   logger.warn('Verto message ClientReady method:', msg);
+      //   // params.type = NOTIFICATION_TYPE.vertoClientReady;
+      //   // trigger(SwEvent.Notification, params, session.uuid);
+      //   break;
       default:
         logger.warn('Verto message unknown method:', msg);
     }

--- a/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
+++ b/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
@@ -136,11 +136,11 @@ class VertoHandler {
           trigger(SwEvent.Notification, params, session.uuid);
         }
         break;
-      // case VertoMethod.ClientReady:
-      //   logger.warn('Verto message ClientReady method:', msg);
-      //   // params.type = NOTIFICATION_TYPE.vertoClientReady;
-      //   // trigger(SwEvent.Notification, params, session.uuid);
-      //   break;
+      case VertoMethod.ClientReady:
+        logger.warn('Verto message ClientReady method:', msg);
+        params.type = NOTIFICATION_TYPE.vertoClientReady;
+        trigger(SwEvent.Notification, params, session.uuid);
+        break;
       default:
         logger.warn('Verto message unknown method:', msg);
     }

--- a/packages/js/src/Modules/Verto/webrtc/constants.ts
+++ b/packages/js/src/Modules/Verto/webrtc/constants.ts
@@ -26,6 +26,7 @@ export enum VertoMethod {
   ClientReady = 'telnyx_rtc.clientReady',
   Modify = 'telnyx_rtc.modify',
   Ringing = 'telnyx_rtc.ringing',
+  GatewayState = 'telnyx_rtc.gatewayState',
 }
 
 export const NOTIFICATION_TYPE = {


### PR DESCRIPTION
 - add gateway state messages to have the certainty that the user is registered before make a new call

## 📝 To Do

- [x] All linters pass
- [ ] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

1. Navigate into `js` folder and run `npm run build`
2. Pointing in the `index.html` the script `lib/bundle.js` file.
3. Go to `examples/vanilla/index.html` and try to register the user and see if the server sends the messages to `REGED` before sends the `invite` message

## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [x] Chrome
- [ ] Firefox
- [ ] Safari

## 📸 Screenshots

| Description | Screenshot |
| ----------- | ---------- |
| Desktop     |![image](https://user-images.githubusercontent.com/16343871/132724861-032be4a9-c10a-4317-989b-c47962283d67.png)|
