### PR TITLE
fix(WEBRTC-702): add Fail and Fail_wait messages in gateway_state

### DIFF
--- a/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
+++ b/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
@@ -166,11 +166,10 @@ class VertoHandler {
             if (this.retriedRegister === RETRY_REGISTER_TIME) {
               this.retriedRegister = 0;
               trigger(SwEvent.SocketError, params, session.uuid);
-              break;
             } else {
               this.session.execute(messageToCheckRegisterState);
-              break;
             }
+            break;
           case 'FAIL_WAIT':
             trigger(SwEvent.SocketError, params, session.uuid);
             break;


### PR DESCRIPTION
- adding Fail and Fail_wait messages in gateway_state handle. When we receive any of these messages we need to disconnect the webrtc sdk.


## 📝 To Do

- [x] All linters pass
- [x] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

1. Provide manual testing instructions

## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## 📸 Screenshots

| Description | Screenshot |
| ----------- | ---------- |
| Desktop     |            |
| usage.gif   |            |
