### PR TITLE
fix: change SocketError to Error event

### DIFF
--- a/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
+++ b/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
@@ -165,16 +165,16 @@ class VertoHandler {
 
             if (this.retriedRegister === RETRY_REGISTER_TIME) {
               this.retriedRegister = 0;
-              trigger(SwEvent.SocketError, params, session.uuid);
+              trigger(SwEvent.Error, params, session.uuid);
             } else {
               this.session.execute(messageToCheckRegisterState);
             }
             break;
           case 'FAIL_WAIT':
-            trigger(SwEvent.SocketError, params, session.uuid);
+            trigger(SwEvent.Error, params, session.uuid);
             break;
           case 'FAILED':
-            trigger(SwEvent.SocketError, params, session.uuid);
+            trigger(SwEvent.Error, params, session.uuid);
             break;
           default:
             logger.warn('GatewayState message unknown method:', msg);


### PR DESCRIPTION
- change SocketError to Error event because the SocketError is not dispatching ws messages in front end client


## 📝 To Do

- [ ] All linters pass
- [ ] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

1. Provide manual testing instructions

## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## 📸 Screenshots

| Description | Screenshot |
| ----------- | ---------- |
| Desktop     |            |
| usage.gif   |            |
