### PR TITLE
fix(WEBRTC-707): enabling auto reconnect on gateway FAIL

### DIFF
--- a/packages/js/src/Modules/Verto/BaseSession.ts
+++ b/packages/js/src/Modules/Verto/BaseSession.ts
@@ -405,4 +405,12 @@ export default abstract class BaseSession {
   static uuid(): string {
     return uuidv4();
   }
+
+  public clearConnection() {
+    this.connection = null;
+  }
+
+  public hasAutoReconnect() {
+    return this._autoReconnect;
+  }
 }

--- a/packages/js/src/Modules/Verto/index.ts
+++ b/packages/js/src/Modules/Verto/index.ts
@@ -51,6 +51,7 @@ export default class Verto extends BrowserSession {
       passwd,
       login_token,
       userVariables,
+      autoReconnect = true,
     } = this.options;
     const msg = new Login(
       login,
@@ -61,11 +62,9 @@ export default class Verto extends BrowserSession {
     );
     const response = await this.execute(msg).catch(this._handleLoginError);
     if (response) {
-      this._autoReconnect = true;
+      this._autoReconnect = autoReconnect;
       this.sessionid = response.sessid;
       sessionStorage.setItem(SESSION_ID, this.sessionid);
-      // trigger(SwEvent.Ready, this, this.uuid);
-      // logger.info('Session Ready!');
     }
   }
 

--- a/packages/js/src/Modules/Verto/util/interfaces.ts
+++ b/packages/js/src/Modules/Verto/util/interfaces.ts
@@ -14,6 +14,7 @@ export interface IVertoOptions {
   ringbackFile?: string;
   env?: Environment;
   iceServers?: RTCIceServer[];
+  autoReconnect?: boolean; 
 }
 export interface SubscribeParams {
   channels?: string[];

--- a/packages/js/src/Modules/Verto/util/interfaces.ts
+++ b/packages/js/src/Modules/Verto/util/interfaces.ts
@@ -14,7 +14,12 @@ export interface IVertoOptions {
   ringbackFile?: string;
   env?: Environment;
   iceServers?: RTCIceServer[];
-  autoReconnect?: boolean; 
+  /**
+   * autoReconnect: Determine if the SDK has to re-connect automatically when detecting a gateway connection failure. 
+   * This is set to`true` as default
+   * @type {boolean}
+   */
+  autoReconnect?: boolean;
 }
 export interface SubscribeParams {
   channels?: string[];

--- a/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
+++ b/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
@@ -177,7 +177,7 @@ class VertoHandler {
             }
           case 'FAILED':
           case 'FAIL_WAIT': {
-            if (!this.session.hasAutoReconnect) {
+            if (!this.session.hasAutoReconnect()) {
               trigger(SwEvent.Error, params, session.uuid);
               break;
             }

--- a/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
+++ b/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
@@ -16,6 +16,9 @@ import { Gateway } from '../messages/verto/Gateway';
  */
 
 const RETRY_REGISTER_TIME = 3;
+const RETRY_CONNECT_TIME = 3;
+let retriedConnect = 0;
+
 class VertoHandler {
   public nodeId: string;
 
@@ -89,7 +92,6 @@ class VertoHandler {
     };
 
     const messageToCheckRegisterState = new Gateway();
-    
 
     switch (method) {
       case VertoMethod.Punt:
@@ -145,7 +147,8 @@ class VertoHandler {
 
       case VertoMethod.GatewayState:
         // eslint-disable-next-line no-case-declarations
-        const gateWayState = msg && msg.params && msg.params.state ? msg.params.state : '';
+        const gateWayState =
+          msg && msg.params && msg.params.state ? msg.params.state : '';
 
         switch (gateWayState) {
           // If the user is REGED tell the client that it is ready to make calls
@@ -172,12 +175,28 @@ class VertoHandler {
               this.session.execute(messageToCheckRegisterState);
               break;
             }
-          case 'FAIL_WAIT':
-            trigger(SwEvent.Error, params, session.uuid);
-            break;
           case 'FAILED':
-            trigger(SwEvent.Error, params, session.uuid);
+          case 'FAIL_WAIT': {
+            if (!this.session.hasAutoReconnect) {
+              trigger(SwEvent.Error, params, session.uuid);
+              break;
+            }
+            
+            retriedConnect += 1;
+            if (retriedConnect === RETRY_CONNECT_TIME) {
+              retriedConnect = 0;
+              trigger(SwEvent.Error, params, session.uuid);
+              break;
+            } else {
+              setTimeout(() => {
+                this.session.disconnect().then(() => {
+                  this.session.clearConnection();
+                  this.session.connect();
+                });
+              }, 500);
+            }
             break;
+          }
           default:
             logger.warn('GatewayState message unknown method:', msg);
             break;

--- a/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
+++ b/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
@@ -178,6 +178,7 @@ class VertoHandler {
           case 'FAILED':
           case 'FAIL_WAIT': {
             if (!this.session.hasAutoReconnect()) {
+              retriedConnect = 0;
               trigger(SwEvent.Error, params, session.uuid);
               break;
             }


### PR DESCRIPTION
- enabling auto-reconnect on gateway FAIL

This new version will add an auto-reconnect feature when SDK receives FAIL and FAIL_WAIT from the server.
To keep your own reconnect implementation in your UI client inside the` telnyx.error` notification, please add `autoReconnect: false` in your TelnyxRTC instance. 

For example:

```
new TelnyxRTC({
login_token: "********",
autoReconnect: false
});

```

With `autoReconnect: false` the SDK won't try to reconnect automatically so you will need to do this in your application.

If you want that the Telnyx SDK do the auto-reconnect for you. You don't need to set `autoReconnect`, because it is `true` by default.

## How the `auto-reconnect` works?

So when the server sends FAIL or FAIL_WAIT the SDK will try to reconnect automatically three times in the background keeping your connection alive and you can be able to receive and make calls.


## 📝 To Do

- [x] All linters pass
- [ ] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

1. Provide manual testing instructions

## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## 📸 Screenshots

| Description | Screenshot |
| ----------- | ---------- |
| Desktop     | ![image](https://user-images.githubusercontent.com/16343871/140322952-11d45aa4-4b7a-4577-8ba5-6182d5de7d50.png)|
