### PR TITLE
fix(WEBRTC-723): REGED message with result prop was not firing telnyx.ready event

### DIFF
--- a/packages/js/.eslintrc.json
+++ b/packages/js/.eslintrc.json
@@ -26,7 +26,8 @@
     "import/prefer-default-export": "off",
     "no-underscore-dangle": "off",
     "camelcase": "off",
-    "no-plusplus": "off"
+    "no-plusplus": "off",
+    "operator-linebreak": "off"
   },
   "settings": {
     "import/resolver": {

--- a/packages/js/src/Modules/Verto/index.ts
+++ b/packages/js/src/Modules/Verto/index.ts
@@ -3,12 +3,10 @@ import { SubscribeParams, BroadcastParams } from './util/interfaces';
 import { IVertoCallOptions } from './webrtc/interfaces';
 import { Login } from './messages/Verto';
 import Call from './webrtc/Call';
-import { SwEvent, SESSION_ID } from './util/constants';
-import { trigger } from './services/Handler';
+import { SESSION_ID } from './util/constants';
 import { sessionStorage } from './util/storage';
 import VertoHandler from './webrtc/VertoHandler';
 import { isValidOptions } from './util/helpers';
-import logger from './util/logger';
 
 export const VERTO_PROTOCOL = 'verto-protocol';
 

--- a/packages/js/src/Modules/Verto/messages/verto/Gateway.ts
+++ b/packages/js/src/Modules/Verto/messages/verto/Gateway.ts
@@ -8,7 +8,6 @@ class Gateway extends BaseRequest {
     super();
 
     const params: any = {
-      method: VertoMethod.GatewayState,
       jsonrpc: '2.0',
       params: {},
     };

--- a/packages/js/src/Modules/Verto/messages/verto/Gateway.ts
+++ b/packages/js/src/Modules/Verto/messages/verto/Gateway.ts
@@ -7,10 +7,7 @@ class Gateway extends BaseRequest {
   constructor() {
     super();
 
-    const params: any = {
-      jsonrpc: '2.0',
-      params: {},
-    };
+    const params: any = {};
 
     this.buildRequest({ method: this.method, params });
   }

--- a/packages/js/src/Modules/Verto/services/Connection.ts
+++ b/packages/js/src/Modules/Verto/services/Connection.ts
@@ -8,6 +8,7 @@ import {
   isFunction,
 } from '../util/helpers';
 import { registerOnce, trigger } from './Handler';
+import { GatewayStateType } from '../webrtc/constants';
 
 let WebSocketClass: any = typeof WebSocket !== 'undefined' ? WebSocket : null;
 export const setWebSocket = (websocket: any): void => {
@@ -82,7 +83,16 @@ export default class Connection {
       }
       this._unsetTimer(msg.id);
       logger.debug('RECV: \n', JSON.stringify(msg, null, 2), '\n');
-      if (!trigger(msg.id, msg)) {
+
+      /**
+       * GatewayStateType
+       * It was necesary to dispatch the VertoHandler to check
+       * GatewayState messages with result prop inside the JSON-RPC
+       */
+      if (
+        !trigger(msg.id, msg) ||
+        GatewayStateType[`${msg?.result?.params?.state}`]
+      ) {
         // If there is not an handler for this message, dispatch an incoming!
         trigger(SwEvent.SocketMessage, msg, this.session.uuid);
       }

--- a/packages/js/src/Modules/Verto/services/Connection.ts
+++ b/packages/js/src/Modules/Verto/services/Connection.ts
@@ -90,8 +90,8 @@ export default class Connection {
        * GatewayState messages with result prop inside the JSON-RPC
        */
       if (
-        !trigger(msg.id, msg) ||
-        GatewayStateType[`${msg?.result?.params?.state}`]
+        GatewayStateType[`${msg?.result?.params?.state}`] ||
+        !trigger(msg.id, msg)
       ) {
         // If there is not an handler for this message, dispatch an incoming!
         trigger(SwEvent.SocketMessage, msg, this.session.uuid);

--- a/packages/js/src/Modules/Verto/services/Handler.ts
+++ b/packages/js/src/Modules/Verto/services/Handler.ts
@@ -90,7 +90,7 @@ const trigger = (
   data: any,
   uniqueId: string = GLOBAL,
   globalPropagation: boolean = true
-) => {
+): boolean => {
   const _propagate: boolean = globalPropagation && uniqueId !== GLOBAL;
   if (!isQueued(event, uniqueId)) {
     if (_propagate) {

--- a/packages/js/src/Modules/Verto/tests/webrtc/VertoHandler.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/VertoHandler.test.ts
@@ -164,7 +164,7 @@ describe('VertoHandler', () => {
   });
 
   describe('telnyx_rtc.gatewayState', () => {
-    it('should dispatch a notification', () => {
+    it('should dispatch a telnyx.ready notification', () => {
       handler.handleMessage(
         JSON.parse(
           '{"jsonrpc":"2.0","id":20342,"method":"telnyx_rtc.gatewayState","params":{"state":"REGED"}}'
@@ -175,7 +175,7 @@ describe('VertoHandler', () => {
         state: 'REGED',
         type: 'vertoClientReady',
       });
-      
+
       handler.handleMessage(
         JSON.parse(
           '{"jsonrpc":"2.0","id":37,"method":"telnyx_rtc.clientReady","params":{"reattached_sessions":["test"], "state": "REGED"}}'
@@ -184,6 +184,20 @@ describe('VertoHandler', () => {
 
       expect(onNotification).toBeCalledWith({
         state: 'REGED',
+        type: 'vertoClientReady',
+      });
+    });
+  });
+
+  describe('Verto message unknown method:', () => {
+    it('if result.params.state is REGED should dispatch a telnyx.ready notification', () => {
+      handler.handleMessage(
+        JSON.parse(
+          '{"jsonrpc":"2.0","id":"db971dc0-d571","result":{"params":{"state":"REGED"},"sessid":"fab032b1-9b27-43fc"}}'
+        )
+      );
+
+      expect(onNotification).toBeCalledWith({
         type: 'vertoClientReady',
       });
     });

--- a/packages/js/src/Modules/Verto/webrtc/ErrorResponse.ts
+++ b/packages/js/src/Modules/Verto/webrtc/ErrorResponse.ts
@@ -1,0 +1,11 @@
+class ErrorResponse {
+  private code?: string;
+
+  private message: string;
+
+  constructor(message: string, code?: string) {
+    this.code = code;
+    this.message = message;
+  }
+}
+export { ErrorResponse };

--- a/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
+++ b/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
@@ -18,7 +18,6 @@ import { Gateway } from '../messages/verto/Gateway';
 const RETRY_REGISTER_TIME = 3;
 const RETRY_CONNECT_TIME = 3;
 let retriedConnect = 0;
-let previousGatewayState = '';
 class VertoHandler {
   public nodeId: string;
 
@@ -164,17 +163,10 @@ class VertoHandler {
           switch (gateWayState) {
             // If the user is REGED tell the client that it is ready to make calls
             case 'REGED': {
-              /**
-               * This is necessary to avoid dispaching the telnyx.ready many times
-               * due to the a lot of REGED messages that are coming from the server
-               */
+              this.retriedRegister = 0;
+              params.type = NOTIFICATION_TYPE.vertoClientReady;
+              trigger(SwEvent.Ready, params, session.uuid);
 
-              if (previousGatewayState !== gateWayState) {
-                previousGatewayState = gateWayState;
-                this.retriedRegister = 0;
-                params.type = NOTIFICATION_TYPE.vertoClientReady;
-                trigger(SwEvent.Ready, params, session.uuid);
-              }
               break;
             }
 
@@ -187,7 +179,6 @@ class VertoHandler {
             case 'UNREGED':
             case 'NOREG':
               this.retriedRegister += 1;
-              previousGatewayState = '';
               if (this.retriedRegister === RETRY_REGISTER_TIME) {
                 this.retriedRegister = 0;
                 trigger(SwEvent.Error, params, session.uuid);
@@ -198,7 +189,6 @@ class VertoHandler {
               }
             case 'FAILED':
             case 'FAIL_WAIT': {
-              previousGatewayState = '';
               if (!this.session.hasAutoReconnect()) {
                 retriedConnect = 0;
                 trigger(SwEvent.Error, params, session.uuid);

--- a/packages/js/src/Modules/Verto/webrtc/constants.ts
+++ b/packages/js/src/Modules/Verto/webrtc/constants.ts
@@ -95,3 +95,15 @@ export enum DeviceType {
   AudioIn = 'audioinput',
   AudioOut = 'audiooutput',
 }
+
+export enum GatewayStateType {
+  REGED = 'REGED',
+  UNREGED = 'UNREGED',
+  NOREG = 'NOREG',
+  FAILED = 'FAILED',
+  FAIL_WAIT = 'FAIL_WAIT',
+  REGISTER = 'REGISTER',
+  TRYING = 'TRYING',
+  EXPIRED = 'EXPIRED',
+  UNREGISTER = 'UNREGISTER',
+}

--- a/packages/js/src/TelnyxRTC.ts
+++ b/packages/js/src/TelnyxRTC.ts
@@ -10,6 +10,8 @@ import {
   IWebRTCSupportedBrowser,
 } from './Modules/Verto/webrtc/interfaces';
 
+import * as pkg from '../package.json';
+
 /**
  * The `TelnyxRTC` client connects your application to the Telnyx backend,
  * enabling you to make outgoing calls and handle incoming calls.
@@ -105,6 +107,7 @@ export class TelnyxRTC extends TelnyxRTCClient {
    */
   constructor(options: IClientOptions) {
     super(options);
+    console.log(`SDK version: ${pkg.version}`);
   }
 
   /**


### PR DESCRIPTION
 - REGED message with `result` prop was not firing `telnyx.ready` event

## 📝 To Do

- [ ] All linters pass
- [ ] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

1. try to reconnect many times using the JWT_Token and see if it is firing the `telnyx.ready` event

## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [x] Chrome
- [ ] Firefox
- [ ] Safari

## 📸 Screenshots

| Description | Screenshot |
| ----------- | ---------- |
| Desktop     |            |
| usage.gif   |            |
