### PR TITLE
feat(WEBRTC-744): adding trigger error in telnyx_bye catch block

### DIFF
--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -325,7 +325,10 @@ export default abstract class BaseCall implements IWebRTCCall {
         causeCode: 17,
       });
       this._execute(bye)
-        .catch((error) => logger.error('telnyl_rtc.bye failed!', error))
+        .catch((error) => {
+          logger.error('telnyl_rtc.bye failed!', error)
+          trigger(SwEvent.Error, error, this.session.uuid);
+        })
         .then(_close.bind(this));
     } else {
       _close();


### PR DESCRIPTION
 - Dispatching `telnyx.error` event when `telnyx_bye` fails

## 📝 To Do

- [ ] All linters pass
- [ ] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

1. Provide manual testing instructions

## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## 📸 Screenshots

| Description | Screenshot |
| ----------- | ---------- |
| Desktop     |![image](https://user-images.githubusercontent.com/16343871/144459009-488f1b73-e6c7-4f88-8af5-59a5c3acc421.png)|
