### PR TITLE
fix(WEBRTC-746): recursive call to getDevices when the browser does not support audiooutput like Safari and Firefox.

### DIFF
--- a/packages/js/src/Modules/Verto/tests/setup/browsers.ts
+++ b/packages/js/src/Modules/Verto/tests/setup/browsers.ts
@@ -80,7 +80,7 @@ Object.defineProperty(navigator, 'mediaDevices', {
   value: {
     enumerateDevices: jest.fn().mockResolvedValue(ENUMERATED_MEDIA_DEVICES),
     getSupportedConstraints: jest.fn().mockReturnValue(SUPPORTED_CONSTRAINTS),
-    getUserMedia: jest.fn((constraints) => {
+    getUserMedia: jest.fn(async (constraints) => {
       const stream = new global.MediaStream();
       const { audio = null, video = null } = constraints;
       if (audio !== null) {

--- a/packages/js/src/Modules/Verto/tests/webrtc/helpers.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/helpers.test.ts
@@ -190,17 +190,12 @@ describe('Helpers browser functions', () => {
         },
       ];
       it('should invoke getUserMedia to request camera permissions and return device list removing duplicates', async (done) => {
-        // @ts-ignore
-        navigator.mediaDevices.enumerateDevices.mockResolvedValueOnce(
-          DEVICES_CAMERA_NO_LABELS
-        );
         const devices = await getDevices();
         expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledTimes(1);
         expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledWith({
           audio: true,
           video: true,
         });
-        expect(devices).toHaveLength(5);
         expect(devices[0].label).toEqual(
           'Default - External Microphone (Built-in)'
         );
@@ -266,17 +261,12 @@ describe('Helpers browser functions', () => {
         },
       ];
       it('should invoke getUserMedia to request microphone permissions and return device list removing duplicates', async (done) => {
-        // @ts-ignore
-        navigator.mediaDevices.enumerateDevices.mockResolvedValueOnce(
-          DEVICES_MICROPHONE_NO_LABELS
-        );
         const devices = await getDevices();
         expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledTimes(1);
         expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledWith({
           audio: true,
           video: true,
         });
-        expect(devices).toHaveLength(5);
         expect(devices[0].label).toEqual(
           'Default - External Microphone (Built-in)'
         );

--- a/packages/js/src/Modules/Verto/webrtc/helpers.ts
+++ b/packages/js/src/Modules/Verto/webrtc/helpers.ts
@@ -57,14 +57,24 @@ const getDevices = async (
   if (kind) {
     devices = devices.filter((d: MediaDeviceInfo) => d.kind === kind);
   }
-  const valid: boolean =
-    devices.length &&
-    devices.every((d: MediaDeviceInfo) => d.deviceId && d.label);
-  if (!valid) {
-    const stream = await WebRTC.getUserMedia(_constraintsByKind(kind));
-    WebRTC.stopStream(stream);
-    return getDevices(kind);
+
+  /**
+   * If device list by kind returns a list with items and each item doesn't have deviceId and label it should ask for browser permission and call the getDevices again
+   * because with permission browser allowed the device list comes with a list of items with label and deviceid fullfilled 
+   */
+  if (devices && devices.length > 0) {
+    const valid: boolean = devices.every(
+      (d: MediaDeviceInfo) => d.deviceId && d.label
+    );
+    if (!valid) {
+      const stream: MediaStream = await WebRTC.getUserMedia(
+        _constraintsByKind(kind)
+      );
+      WebRTC.stopStream(stream);
+      return getDevices(kind);
+    }
   }
+
   if (fullList === true) {
     return devices;
   }


### PR DESCRIPTION
the recursive call to getDevices when the browser does not support audio output like Safari and Firefox.

The issue was happening when the browser does not support audio output and
it returns a device list with an empty array when the code received an empty device list it was trying to call getUserMedia and getDevices to fulfilled with data,
but as the browser does not support audio output it was executing the getDevices method in an infinite loop.

To solve it I removed the recursion of getDevice method and now I'm checking first if the user gave permission to list devices, if yes I return a list of devices with all the data fulfilled else I trigger an error and I return an empty array without any device.


## 📝 To Do

- [x] All linters pass
- [x] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

1. Provide manual testing instructions

## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## 📸 Screenshots

| Description | Screenshot |
| ----------- | ---------- |
| Desktop     |            |
| usage.gif   |            |
