### PR TITLE
fix(ENGDESK-12851): add code to avoid multiples REGED messages on the client side

### DIFF
--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telnyx/webrtc",
-  "version": "2.7.1",
+  "version": "2.7.3",
   "description": "Telnyx WebRTC Client",
   "keywords": [
     "telnyx",

--- a/packages/js/src/Modules/Verto/BaseSession.ts
+++ b/packages/js/src/Modules/Verto/BaseSession.ts
@@ -27,7 +27,7 @@ export default abstract class BaseSession {
   public contexts: string[] = [];
   public timeoutErrorCode = -32000;
 
-  protected connection: Connection = null;
+  public connection: Connection = null;
   protected _jwtAuth: boolean = false;
   protected _doKeepAlive: boolean = false;
   protected _keepAliveTimeout: any;

--- a/packages/js/src/Modules/Verto/services/Connection.ts
+++ b/packages/js/src/Modules/Verto/services/Connection.ts
@@ -24,7 +24,7 @@ const WS_STATE = {
 const TIMEOUT_MS = 10 * 1000;
 
 export default class Connection {
-  private previousGatewayState = '';
+  public previousGatewayState = '';
   private _wsClient: any = null;
   private _host: string = PROD_HOST;
   private _timers: { [id: string]: any } = {};
@@ -106,19 +106,25 @@ export default class Connection {
 
         const gateWayState = hasStateResult || hasStateParam;
 
-        // Used to send the first REGED WebSocket Message
-        if (
-          gateWayState === GatewayStateType.REGED &&
-          this.previousGatewayState !== GatewayStateType.REGED
-        ) {
-          this.previousGatewayState = GatewayStateType.REGED;
-          trigger(SwEvent.SocketMessage, msg, this.session.uuid);
-        }
 
-        // If the next messages is not REGED dispatch the new messages
-        if (gateWayState !== GatewayStateType.REGED) {
-          trigger(SwEvent.SocketMessage, msg, this.session.uuid);
-        }
+        // // Used to send the first REGED WebSocket Message
+        // if (
+        //   gateWayState === GatewayStateType.REGED &&
+        //   this.previousGatewayState !== GatewayStateType.REGED
+        // ) {
+        //   trigger(SwEvent.SocketMessage, msg, this.session.uuid);
+        // }
+
+        // // If the next messages is not REGED dispatch the new messages
+        // if (gateWayState !== GatewayStateType.REGED) {
+        //   trigger(SwEvent.SocketMessage, msg, this.session.uuid);
+        // }
+        console.log('OLX====> current state', gateWayState);
+        console.log('OLX====> this.previousGatewayState state', this.previousGatewayState);
+
+        trigger(SwEvent.SocketMessage, msg, this.session.uuid);
+
+        this.previousGatewayState = gateWayState;
       }
     };
   }

--- a/packages/js/src/Modules/Verto/services/Connection.ts
+++ b/packages/js/src/Modules/Verto/services/Connection.ts
@@ -6,6 +6,7 @@ import {
   checkWebSocketHost,
   destructResponse,
   isFunction,
+  getGatewayState,
 } from '../util/helpers';
 import { registerOnce, trigger } from './Handler';
 import { GatewayStateType } from '../webrtc/constants';
@@ -95,16 +96,7 @@ export default class Connection {
         !trigger(msg.id, msg)
       ) {
         // If there is not an handler for this message, dispatch an incoming!
-
-        const hasStateResult =
-          msg && msg.result && msg.result.params && msg.result.params.state
-            ? msg.result.params.state
-            : '';
-
-        const hasStateParam =
-          msg && msg.params && msg.params.state ? msg.params.state : '';
-
-        const gateWayState = hasStateResult || hasStateParam;
+        const gateWayState = getGatewayState(msg);
 
         trigger(SwEvent.SocketMessage, msg, this.session.uuid);
 

--- a/packages/js/src/Modules/Verto/services/Connection.ts
+++ b/packages/js/src/Modules/Verto/services/Connection.ts
@@ -106,19 +106,6 @@ export default class Connection {
 
         const gateWayState = hasStateResult || hasStateParam;
 
-
-        // // Used to send the first REGED WebSocket Message
-        // if (
-        //   gateWayState === GatewayStateType.REGED &&
-        //   this.previousGatewayState !== GatewayStateType.REGED
-        // ) {
-        //   trigger(SwEvent.SocketMessage, msg, this.session.uuid);
-        // }
-
-        // // If the next messages is not REGED dispatch the new messages
-        // if (gateWayState !== GatewayStateType.REGED) {
-        //   trigger(SwEvent.SocketMessage, msg, this.session.uuid);
-        // }
         console.log('OLX====> current state', gateWayState);
         console.log('OLX====> this.previousGatewayState state', this.previousGatewayState);
 

--- a/packages/js/src/Modules/Verto/services/Connection.ts
+++ b/packages/js/src/Modules/Verto/services/Connection.ts
@@ -106,11 +106,9 @@ export default class Connection {
 
         const gateWayState = hasStateResult || hasStateParam;
 
-        console.log('OLX====> current state', gateWayState);
-        console.log('OLX====> this.previousGatewayState state', this.previousGatewayState);
-
         trigger(SwEvent.SocketMessage, msg, this.session.uuid);
 
+        // save previous gate state
         this.previousGatewayState = gateWayState;
       }
     };

--- a/packages/js/src/Modules/Verto/util/helpers.ts
+++ b/packages/js/src/Modules/Verto/util/helpers.ts
@@ -133,15 +133,18 @@ export const isValidOptions = ({
 };
 
 export const getGatewayState = (msg: IMessageRPC): GatewayStateType | '' => {
-  const hasStateResult: GatewayStateType | '' =
-    msg && msg.result && msg.result.params && msg.result.params.state
-      ? msg.result.params.state
-      : '';
+  let stateResult: GatewayStateType | '' = '';
+  let stateParam: GatewayStateType | '' = '';
 
-  const hasStateParam: GatewayStateType | '' =
-    msg && msg.params && msg.params.state ? msg.params.state : '';
+  if (msg?.result?.params?.state) {
+    stateResult = msg?.result?.params?.state;
+  }
 
-  const gateWayState = hasStateResult || hasStateParam;
+  if (msg?.params?.state) {
+    stateParam = msg?.params?.state;
+  }
+
+  const gateWayState = stateResult || stateParam;
 
   return gateWayState;
 };

--- a/packages/js/src/Modules/Verto/util/helpers.ts
+++ b/packages/js/src/Modules/Verto/util/helpers.ts
@@ -1,6 +1,7 @@
-import { IVertoOptions } from './interfaces';
+import { IMessageRPC, IVertoOptions } from './interfaces';
 import logger from './logger';
 import { STORAGE_PREFIX } from './constants';
+import { GatewayStateType } from '../webrtc/constants';
 
 // hack to remove undefined values from the object
 export const deepCopy = (obj: Object) => JSON.parse(JSON.stringify(obj));
@@ -129,4 +130,18 @@ export const isValidOptions = ({
   const isLogin = login && (passwd || password);
   const isToken = login_token;
   return Boolean(isLogin || isToken);
+};
+
+export const getGatewayState = (msg: IMessageRPC): GatewayStateType | '' => {
+  const hasStateResult: GatewayStateType | '' =
+    msg && msg.result && msg.result.params && msg.result.params.state
+      ? msg.result.params.state
+      : '';
+
+  const hasStateParam: GatewayStateType | '' =
+    msg && msg.params && msg.params.state ? msg.params.state : '';
+
+  const gateWayState = hasStateResult || hasStateParam;
+
+  return gateWayState;
 };

--- a/packages/js/src/Modules/Verto/util/interfaces.ts
+++ b/packages/js/src/Modules/Verto/util/interfaces.ts
@@ -49,3 +49,18 @@ export interface INotificationEventData {
   displayNumber?: string;
   displayDirection?: string;
 }
+
+export interface IRequestRPC {
+  id: any;
+  method?: any;
+  params?: any;
+}
+
+export interface IResponseRPC {
+  id: any;
+  result?: {
+    params: any;
+  };
+}
+
+export interface IMessageRPC extends IRequestRPC, IResponseRPC {}

--- a/packages/js/src/Modules/Verto/util/tests/helpers.test.ts
+++ b/packages/js/src/Modules/Verto/util/tests/helpers.test.ts
@@ -1,0 +1,63 @@
+import { getGatewayState } from '../helpers';
+import { IRequestRPC, IResponseRPC } from '../interfaces';
+
+describe('getGatewayState', () => {
+  it('it should return empty string if server did not send the gateway state in the request', () => {
+    const msg: IRequestRPC = {
+      id: '',
+      method: '',
+      params: '',
+    };
+
+    const state = getGatewayState(msg);
+    expect(state).toBeFalsy();
+  });
+  it('it should return empty string if server did not send the gateway state in the response', () => {
+    const msg: IResponseRPC = {
+      id: '',
+      result: {
+        params: {},
+      },
+    };
+
+    const state = getGatewayState(msg);
+    expect(state).toBeFalsy();
+  });
+
+  it('it should return REGED in request', () => {
+    const msg: IRequestRPC = {
+      id: '',
+      method: 'telnyx_rtc.gatewayState',
+      params: {
+        state: 'REGED',
+      },
+    };
+
+    const state = getGatewayState(msg);
+    expect(state).toEqual(msg.params.state);
+  });
+
+  it('it should return REGED in response', () => {
+    const msg: IResponseRPC = {
+      id: '',
+      result: {
+        params: { state: 'REGED' },
+      },
+    };
+
+    const state = getGatewayState(msg);
+    expect(state).toEqual(msg.result.params.state);
+  });
+
+  it('it should return TRYING in response', () => {
+    const msg: IResponseRPC = {
+      id: '',
+      result: {
+        params: { state: 'TRYING' },
+      },
+    };
+
+    const state = getGatewayState(msg);
+    expect(state).toEqual(msg.result.params.state);
+  });
+});

--- a/packages/js/src/Modules/Verto/util/tests/helpers.test.ts
+++ b/packages/js/src/Modules/Verto/util/tests/helpers.test.ts
@@ -2,62 +2,67 @@ import { getGatewayState } from '../helpers';
 import { IRequestRPC, IResponseRPC } from '../interfaces';
 
 describe('getGatewayState', () => {
-  it('it should return empty string if server did not send the gateway state in the request', () => {
-    const msg: IRequestRPC = {
-      id: '',
-      method: '',
-      params: '',
-    };
+  describe('request', () => {
+    it('it should return empty string if server did not send the gateway state', () => {
+      const msg: IRequestRPC = {
+        id: '',
+        method: '',
+        params: '',
+      };
 
-    const state = getGatewayState(msg);
-    expect(state).toBeFalsy();
-  });
-  it('it should return empty string if server did not send the gateway state in the response', () => {
-    const msg: IResponseRPC = {
-      id: '',
-      result: {
-        params: {},
-      },
-    };
+      const state = getGatewayState(msg);
+      expect(state).toBeFalsy();
+    });
 
-    const state = getGatewayState(msg);
-    expect(state).toBeFalsy();
-  });
+    it('it should return REGED', () => {
+      const msg: IRequestRPC = {
+        id: '',
+        method: 'telnyx_rtc.gatewayState',
+        params: {
+          state: 'REGED',
+        },
+      };
 
-  it('it should return REGED in request', () => {
-    const msg: IRequestRPC = {
-      id: '',
-      method: 'telnyx_rtc.gatewayState',
-      params: {
-        state: 'REGED',
-      },
-    };
-
-    const state = getGatewayState(msg);
-    expect(state).toEqual(msg.params.state);
+      const state = getGatewayState(msg);
+      expect(state).toEqual(msg.params.state);
+    });
   });
 
-  it('it should return REGED in response', () => {
-    const msg: IResponseRPC = {
-      id: '',
-      result: {
-        params: { state: 'REGED' },
-      },
-    };
+  describe('response', () => {
+    it('it should return empty string if server did not send the gateway state', () => {
+      const msg: IResponseRPC = {
+        id: '',
+        result: {
+          params: {},
+        },
+      };
 
-    const state = getGatewayState(msg);
-    expect(state).toEqual(msg.result.params.state);
-  });
+      const state = getGatewayState(msg);
+      expect(state).toBeFalsy();
+    });
 
-  it('it should return TRYING in response', () => {
-    const msg: IResponseRPC = {
-      id: '',
-      result: {
-        params: { state: 'TRYING' },
-      },
-    };
+    it('it should return REGED', () => {
+      const msg: IResponseRPC = {
+        id: '',
+        result: {
+          params: { state: 'REGED' },
+        },
+      };
 
-    const state = getGatewayState(msg);
-    expect(state).toEqual(msg.result.params.state);
+      const state = getGatewayState(msg);
+      expect(state).toEqual(msg.result.params.state);
+    });
+
+    it('it should return TRYING', () => {
+      const msg: IResponseRPC = {
+        id: '',
+        result: {
+          params: { state: 'TRYING' },
+        },
+      };
+
+      const state = getGatewayState(msg);
+      expect(state).toEqual(msg.result.params.state);
+    });
   });
 });

--- a/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
+++ b/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
@@ -158,14 +158,25 @@ class VertoHandler {
 
         const gateWayState = hasStateResult || hasStateParam;
 
+        console.log('OLX====> VERTO current state', gateWayState);
+        console.log('OLX====> VERTO session.connection.previousGatewayState state', session.connection.previousGatewayState);
+
         if (gateWayState) {
           // eslint-disable-next-line no-case-declarations
           switch (gateWayState) {
             // If the user is REGED tell the client that it is ready to make calls
+            case GatewayStateType.REGISTER:
             case GatewayStateType.REGED: {
-              VertoHandler.retriedRegister = 0;
-              params.type = NOTIFICATION_TYPE.vertoClientReady;
-              trigger(SwEvent.Ready, params, session.uuid);
+              if (
+                session.connection.previousGatewayState !==
+                  GatewayStateType.REGED &&
+                session.connection.previousGatewayState !==
+                  GatewayStateType.REGISTER
+              ) {
+                VertoHandler.retriedRegister = 0;
+                params.type = NOTIFICATION_TYPE.vertoClientReady;
+                trigger(SwEvent.Ready, params, session.uuid);
+              }
               break;
             }
 
@@ -198,31 +209,38 @@ class VertoHandler {
               }
             case GatewayStateType.FAILED:
             case GatewayStateType.FAIL_WAIT: {
-              if (!this.session.hasAutoReconnect()) {
-                VertoHandler.retriedConnect = 0;
-                trigger(
-                  SwEvent.Error,
-                  new ErrorResponse(
-                    `Fail to connect the server, the server tried ${RETRY_CONNECT_TIME} times`,
-                    'FAILED|FAIL_WAIT'
-                  ),
-                  session.uuid
-                );
-                break;
-              }
+              if (
+                session.connection.previousGatewayState !==
+                  GatewayStateType.FAILED &&
+                session.connection.previousGatewayState !==
+                  GatewayStateType.FAIL_WAIT
+              ) {
+                if (!this.session.hasAutoReconnect()) {
+                  VertoHandler.retriedConnect = 0;
+                  trigger(
+                    SwEvent.Error,
+                    new ErrorResponse(
+                      `Fail to connect the server, the server tried ${RETRY_CONNECT_TIME} times`,
+                      'FAILED|FAIL_WAIT'
+                    ),
+                    session.uuid
+                  );
+                  break;
+                }
 
-              VertoHandler.retriedConnect += 1;
-              if (VertoHandler.retriedConnect === RETRY_CONNECT_TIME) {
-                VertoHandler.retriedConnect = 0;
-                trigger(SwEvent.Error, params, session.uuid);
-                break;
-              } else {
-                setTimeout(() => {
-                  this.session.disconnect().then(() => {
-                    this.session.clearConnection();
-                    this.session.connect();
-                  });
-                }, 500);
+                VertoHandler.retriedConnect += 1;
+                if (VertoHandler.retriedConnect === RETRY_CONNECT_TIME) {
+                  VertoHandler.retriedConnect = 0;
+                  trigger(SwEvent.Error, params, session.uuid);
+                  break;
+                } else {
+                  setTimeout(() => {
+                    this.session.disconnect().then(() => {
+                      this.session.clearConnection();
+                      this.session.connect();
+                    });
+                  }, 500);
+                }
               }
               break;
             }

--- a/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
+++ b/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
@@ -158,9 +158,6 @@ class VertoHandler {
 
         const gateWayState = hasStateResult || hasStateParam;
 
-        console.log('OLX====> VERTO current state', gateWayState);
-        console.log('OLX====> VERTO session.connection.previousGatewayState state', session.connection.previousGatewayState);
-
         if (gateWayState) {
           // eslint-disable-next-line no-case-declarations
           switch (gateWayState) {

--- a/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
+++ b/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
@@ -11,6 +11,7 @@ import { MCULayoutEventHandler } from './LayoutHandler';
 import { IWebRTCCall, IVertoCallOptions } from './interfaces';
 import { Gateway } from '../messages/verto/Gateway';
 import { ErrorResponse } from './ErrorResponse';
+import { getGatewayState } from '../util/helpers';
 
 /**
  * @ignore Hide in docs output
@@ -148,15 +149,7 @@ class VertoHandler {
         break;
 
       default: {
-        const hasStateResult =
-          msg && msg.result && msg.result.params && msg.result.params.state
-            ? msg.result.params.state
-            : '';
-
-        const hasStateParam =
-          msg && msg.params && msg.params.state ? msg.params.state : '';
-
-        const gateWayState = hasStateResult || hasStateParam;
+        const gateWayState = getGatewayState(msg);
 
         if (gateWayState) {
           // eslint-disable-next-line no-case-declarations


### PR DESCRIPTION
 - add code to avoid multiples REGED messages on the client-side

## 📝 To Do

- [x] All linters pass
- [x] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

1. You can run any example project inside `packages/js/examples`
2. Make a npm link
3. Register in the SDK and see if the `telnyx.ready` will dispatch only once.

## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [x] Chrome
- [ ] Firefox
- [ ] Safari

## 📸 Screenshots

| Description | Screenshot |
| ----------- | ---------- |
| Desktop     |![image (12)](https://user-images.githubusercontent.com/16343871/145574104-d98b6965-4bae-49e2-b628-ae23b55eae2e.png)|

