### PR TITLE
fix: change previousGatewayState only if gateWayState exist to avoid send many REGISTER messages

### DIFF
--- a/packages/js/src/Modules/Verto/services/Connection.ts
+++ b/packages/js/src/Modules/Verto/services/Connection.ts
@@ -101,7 +101,9 @@ export default class Connection {
         trigger(SwEvent.SocketMessage, msg, this.session.uuid);
 
         // save previous gate state
-        this.previousGatewayState = gateWayState;
+        if(Boolean(gateWayState)) {
+          this.previousGatewayState = gateWayState;
+        }
       }
     };
   }


### PR DESCRIPTION
- change previousGatewayState only if gateway state exist to avoid send many REGISTER messages

## 📝 To Do

- [x] All linters pass
- [ ] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

1. Provide manual testing instructions

## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## 📸 Screenshots

| Description | Screenshot |
| ----------- | ---------- |
| Desktop     |            |
| usage.gif   |            |
