### PR TITLE
fix(WEBRTC-757): change the timeout value of 500 to use a random number

### DIFF
--- a/packages/js/src/Modules/Verto/BaseSession.ts
+++ b/packages/js/src/Modules/Verto/BaseSession.ts
@@ -70,7 +70,7 @@ export default abstract class BaseSession {
   }
 
   get reconnectDelay() {
-    return randomInt(6, 2) * 1000;
+    return randomInt(2, 6) * 1000;
   }
 
   /**

--- a/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
+++ b/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
@@ -11,7 +11,7 @@ import { MCULayoutEventHandler } from './LayoutHandler';
 import { IWebRTCCall, IVertoCallOptions } from './interfaces';
 import { Gateway } from '../messages/verto/Gateway';
 import { ErrorResponse } from './ErrorResponse';
-import { getGatewayState } from '../util/helpers';
+import { getGatewayState, randomInt } from '../util/helpers';
 
 /**
  * @ignore Hide in docs output
@@ -34,6 +34,10 @@ class VertoHandler {
       msg.targetNodeId = this.nodeId;
     }
     this.session.execute(msg);
+  }
+
+  private reconnectDelay() {
+    return randomInt(2, 6) * 1000
   }
 
   handleMessage(msg: any) {
@@ -194,7 +198,7 @@ class VertoHandler {
               } else {
                 setTimeout(() => {
                   this.session.execute(messageToCheckRegisterState);
-                }, 500);
+                }, this.reconnectDelay());
                 break;
               }
             case GatewayStateType.FAILED:
@@ -229,7 +233,7 @@ class VertoHandler {
                       this.session.clearConnection();
                       this.session.connect();
                     });
-                  }, 500);
+                  }, this.reconnectDelay());
                 }
               }
               break;


### PR DESCRIPTION
 - Change the timeout value of 500 to use a random number between 3000 and 5000 milliseconds to avoid many users trying to connect to the server at the same time.

## 📝 To Do

- [x] All linters pass
- [ ] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

1. Navigate into `packages/js` and run  `npm run build `
2. Open another project with a web dialer and run `npm link`
3. Try to make many registrations and see if the time change

## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [x] Chrome
- [ ] Firefox
- [ ] Safari

## 📸 Screenshots

| Description | Screenshot |
| ----------- | ---------- |
| Desktop     |![image](https://user-images.githubusercontent.com/16343871/148072684-daf375e8-8fd0-4ca8-b6c4-545dbb2ed161.png)|
