### PR TITLE
chore(WEBRTC-2012): change wss port number to use default 443

### DIFF
--- a/packages/js/src/Modules/Verto/util/constants/index.ts
+++ b/packages/js/src/Modules/Verto/util/constants/index.ts
@@ -3,8 +3,8 @@ export const ADD = 'add';
 export const REMOVE = 'remove';
 export const SESSION_ID = 'sessId';
 
-export const PROD_HOST = 'wss://rtc.telnyx.com:14938';
-export const DEV_HOST = 'wss://rtcdev.telnyx.com:14938';
+export const PROD_HOST = 'wss://rtc.telnyx.com';
+export const DEV_HOST = 'wss://rtcdev.telnyx.com';
 export const STUN_SERVER = { urls: 'stun:stun.telnyx.com:3478' };
 export const TURN_SERVER = {
   urls: 'turn:turn.telnyx.com:3478?transport=tcp',


### PR DESCRIPTION
- Change wss port number to use default 443

## 📝 To Do

- [ ] All linters pass
- [ ] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

1. Access the web dialer http://localhost:3000/ and try to connect/register

## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## 📸 Screenshots

| Description | Screenshot |
| ----------- | ---------- |
| Desktop     | ![image](https://user-images.githubusercontent.com/16343871/177199277-e40e23e4-4dbc-4f02-903b-74bf98507c39.png)|
