### PR TITLE
fix(ENGDESK-19054): Voice SDK missing types when installed in TypeScript projects.

### DIFF
--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -15,7 +15,7 @@
   ],
   "main": "lib/bundle.js",
   "module": "lib/bundle.mjs",
-  "types": "lib/index.d.ts",
+  "types": "lib/src/index.d.ts",
   "files": [
     "lib"
   ],

--- a/packages/js/src/Modules/Verto/BrowserSession.ts
+++ b/packages/js/src/Modules/Verto/BrowserSession.ts
@@ -656,7 +656,7 @@ export default abstract class BrowserSession extends BaseSession {
    * // => "abc123xyz"
    * ```
    */
-  get speaker(): string | null {
+  get speaker(): string {
     return this._speaker;
   }
 
@@ -756,9 +756,8 @@ export default abstract class BrowserSession extends BaseSession {
       msg.targetNodeId = nodeId;
     }
     const response = await this.execute(msg);
-    const { unauthorized = [], subscribed = [] } = destructSubscribeResponse(
-      response
-    );
+    const { unauthorized = [], subscribed = [] } =
+      destructSubscribeResponse(response);
     if (unauthorized.length) {
       unauthorized.forEach((channel) =>
         this._removeSubscription(this.relayProtocol, channel)
@@ -786,9 +785,8 @@ export default abstract class BrowserSession extends BaseSession {
       msg.targetNodeId = nodeId;
     }
     const response = await this.execute(msg);
-    const { unsubscribed = [], notSubscribed = [] } = destructSubscribeResponse(
-      response
-    );
+    const { unsubscribed = [], notSubscribed = [] } =
+      destructSubscribeResponse(response);
     unsubscribed.forEach((channel) =>
       this._removeSubscription(this.relayProtocol, channel)
     );

--- a/packages/js/src/Modules/Verto/webrtc/interfaces.ts
+++ b/packages/js/src/Modules/Verto/webrtc/interfaces.ts
@@ -1,6 +1,6 @@
 export interface IMediaSettings {
-  useSdpASBandwidthKbps: boolean;
-  sdpASBandwidthKbps: number;
+  useSdpASBandwidthKbps?: boolean;
+  sdpASBandwidthKbps?: number;
 }
 
 export interface IVertoCallOptions {

--- a/packages/js/src/utils/interfaces.ts
+++ b/packages/js/src/utils/interfaces.ts
@@ -121,7 +121,7 @@ export interface ICallOptions {
   telnyxLegId?: string;
   /**
    *
-   * Telnyx's Call Control client_state. Can be used with Connections with Advanced -> Events enabled. 
+   * Telnyx's Call Control client_state. Can be used with Connections with Advanced -> Events enabled.
    * `clientState` string should be base64 encoded.
    */
   clientState?: string;
@@ -177,7 +177,10 @@ export interface ICallOptions {
   /**
    * Configures media (audio/video) in a call.
    */
-  mediaSettings: { useSdpASBandwidthKbps: boolean, sdpASBandwidthKbps: number };
+  mediaSettings?: {
+    useSdpASBandwidthKbps?: boolean;
+    sdpASBandwidthKbps?: number;
+  };
 }
 
 /**


### PR DESCRIPTION
 - An external customer was complaining about the Voice SDK installation. The SDK was returning an error message saying that it was not possible to find the types for `@telnyx/webrtc`.


Error: 

![image](https://user-images.githubusercontent.com/16343871/192606992-f2215e7f-87c1-4a7d-a313-81708fde1d0d.png)

Fix:

We were pointing to the wrong path to load the types.

## 📝 To Do

- [x] All linters pass
- [x] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

0. navigate to `package/js`
1. run `yarn build --watch`
2. run `yarn link`
3. get the yarn link command generated as a result of step 2
4. go to this PR https://github.com/team-telnyx/webrtc-examples/pull/7
5. link the webrtc package there and see if the error was gone.

## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [x] Chrome
- [ ] Firefox
- [ ] Safari

## 📸 Screenshots

| Description | Screenshot |
| ----------- | ---------- |
| Desktop     |![image](https://user-images.githubusercontent.com/16343871/192607287-585c7e8e-ac55-4788-8a9f-a85522e9e2ed.png)|
