### PR TITLE
feat(ENGDESK-21003): add beforeunload event to hang up active calls when the browser is closed or refreshed

### DIFF
--- a/packages/js/src/Modules/Verto/index.ts
+++ b/packages/js/src/Modules/Verto/index.ts
@@ -1,5 +1,9 @@
 import BrowserSession from './BrowserSession';
-import { SubscribeParams, BroadcastParams } from './util/interfaces';
+import {
+  SubscribeParams,
+  BroadcastParams,
+  IVertoOptions,
+} from './util/interfaces';
 import { IVertoCallOptions } from './webrtc/interfaces';
 import { Login } from './messages/Verto';
 import Call from './webrtc/Call';
@@ -14,6 +18,20 @@ export default class Verto extends BrowserSession {
   public relayProtocol: string = VERTO_PROTOCOL;
 
   public timeoutErrorCode = -329990; // fake verto timeout error code.
+
+  constructor(options: IVertoOptions) {
+    super(options);
+    // hang up current call when browser closes or refreshes.
+    window.addEventListener('beforeunload', (e) => {
+      if (this.calls) {
+        Object.keys(this.calls).forEach((callId) => {
+          if (this.calls[callId]) {
+            this.calls[callId].hangup({}, true);
+          }
+        });
+      }
+    });
+  }
 
   validateOptions() {
     return isValidOptions(this.options);


### PR DESCRIPTION
 - add `beforeunload` event to hang up active calls when the browser is closed or refreshed

## 📝 To Do

- [x] All linters pass
- [ ] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

1. Access webrtc.telnyx.com
2. Make a call 
3. After the callee picks up the call close the caller browser.
4. It should hang up the call on the callee side.

## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [x] Chrome
- [ ] Firefox
- [ ] Safari

## 📸 Screenshots

| Description | Screenshot |
| ----------- | ---------- |
| Desktop     |            |
| usage.gif   |            |
