### PR TITLE
feat(ENGDESK-26634): add custom headers to invite and answer messages

### DIFF
--- a/packages/js/rollup.config.js
+++ b/packages/js/rollup.config.js
@@ -28,7 +28,7 @@ const plugins = [
   typescript({
     objectHashIgnoreUnknownHack: true,
   }),
-  terser(),
+  // terser(),
   json(),
 ];
 

--- a/packages/js/rollup.config.js
+++ b/packages/js/rollup.config.js
@@ -28,7 +28,7 @@ const plugins = [
   typescript({
     objectHashIgnoreUnknownHack: true,
   }),
-  // terser(),
+  terser(),
   json(),
 ];
 

--- a/packages/js/src/Modules/Verto/messages/verto/BaseRequest.ts
+++ b/packages/js/src/Modules/Verto/messages/verto/BaseRequest.ts
@@ -7,6 +7,7 @@ const tmpMap = {
   remoteCallerNumber: 'remote_caller_id_number',
   callerName: 'caller_id_name',
   callerNumber: 'caller_id_number',
+  customHeaders: 'custom_headers',
 };
 
 export default abstract class BaseRequest extends BaseMessage {
@@ -24,12 +25,14 @@ export default abstract class BaseRequest extends BaseMessage {
         speakerId,
         ...dialogParams
       } = params.dialogParams;
+
       for (const key in tmpMap) {
         if (key && dialogParams.hasOwnProperty(key)) {
           dialogParams[tmpMap[key]] = dialogParams[key];
           delete dialogParams[key];
         }
       }
+
       params.dialogParams = dialogParams;
     }
 

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -1387,14 +1387,11 @@ export default abstract class BaseCall implements IWebRTCCall {
         msg = new Invite(tmpParams);
         break;
       case PeerType.Answer:
-        {
-          this.setState(State.Answering);
-          msg =
-            this.options.attach === true
-              ? new Attach(tmpParams)
-              : new Answer(tmpParams);
-        }
-
+        this.setState(State.Answering);
+        msg =
+          this.options.attach === true
+            ? new Attach(tmpParams)
+            : new Answer(tmpParams);
         break;
       default:
         logger.error(`${this.id} - Unknown local SDP type:`, data);

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -1389,7 +1389,6 @@ export default abstract class BaseCall implements IWebRTCCall {
       case PeerType.Answer:
         {
           this.setState(State.Answering);
-          console.log('tmpParams===>', tmpParams);
           msg =
             this.options.attach === true
               ? new Attach(tmpParams)

--- a/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
+++ b/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
@@ -66,6 +66,8 @@ class VertoHandler {
     }
 
     const _buildCall = () => {
+      debugger;
+
       const callOptions: IVertoCallOptions = {
         id: callID,
         remoteSdp: params.sdp,
@@ -92,6 +94,15 @@ class VertoHandler {
 
       if (params.client_state) {
         callOptions.clientState = params.client_state;
+      }
+      debugger;
+
+      if (
+        params.dialogParams &&
+        params.dialogParams.custom_headers &&
+        params.dialogParams.custom_headers.length
+      ) {
+        callOptions.customHeaders = params.dialogParams.custom_headers;
       }
 
       const call = new Call(session, callOptions);

--- a/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
+++ b/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
@@ -66,8 +66,6 @@ class VertoHandler {
     }
 
     const _buildCall = () => {
-      debugger;
-
       const callOptions: IVertoCallOptions = {
         id: callID,
         remoteSdp: params.sdp,
@@ -95,7 +93,6 @@ class VertoHandler {
       if (params.client_state) {
         callOptions.clientState = params.client_state;
       }
-      debugger;
 
       if (
         params.dialogParams &&

--- a/packages/js/src/Modules/Verto/webrtc/interfaces.ts
+++ b/packages/js/src/Modules/Verto/webrtc/interfaces.ts
@@ -44,12 +44,16 @@ export interface IVertoCallOptions {
   negotiateAudio?: boolean;
   negotiateVideo?: boolean;
   mediaSettings?: IMediaSettings;
-  customHeaders?: { name: string; value: string }[];
+  customHeaders?: Array<{ name: string; value: string }>;
 }
 
 export interface IStatsBinding {
   constraints: any;
   callback: Function;
+}
+
+export interface AnswerParams {
+  customHeaders?: Array<{ name: string; value: string }>;
 }
 
 export interface IWebRTCCall {
@@ -66,7 +70,7 @@ export interface IWebRTCCall {
   localStream: MediaStream;
   remoteStream: MediaStream;
   invite: () => void;
-  answer: () => void;
+  answer: (params: AnswerParams) => void;
   hangup: (params: any, execute: boolean) => void;
   transfer: (destination: string) => void;
   replace: (replaceCallID: string) => void;

--- a/packages/js/src/Modules/Verto/webrtc/interfaces.ts
+++ b/packages/js/src/Modules/Verto/webrtc/interfaces.ts
@@ -44,6 +44,7 @@ export interface IVertoCallOptions {
   negotiateAudio?: boolean;
   negotiateVideo?: boolean;
   mediaSettings?: IMediaSettings;
+  customHeaders?: { name: string; value: string }[];
 }
 
 export interface IStatsBinding {

--- a/packages/js/src/utils/interfaces.ts
+++ b/packages/js/src/utils/interfaces.ts
@@ -181,6 +181,11 @@ export interface ICallOptions {
     useSdpASBandwidthKbps?: boolean;
     sdpASBandwidthKbps?: number;
   };
+
+  /**
+   * Add custom headers to the INVITE request.
+   */
+  customHeaders?: { name: string; value: string }[];
 }
 
 /**

--- a/packages/js/src/utils/interfaces.ts
+++ b/packages/js/src/utils/interfaces.ts
@@ -183,7 +183,7 @@ export interface ICallOptions {
   };
 
   /**
-   * Add custom headers to the INVITE request.
+   * Add custom headers to the INVITE and ANSWER request.
    */
   customHeaders?: { name: string; value: string }[];
 }


### PR DESCRIPTION
 - add custom headers to invite and answer messages

## 📝 To Do

- [ ] All linters pass
- [ ] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

1. navigate to `packages/js`
2. run `yarn build` and `yarn link`
3. go to a webrtc project example and run `yarn link @telnyx/webrtc`
4. go to `call.newCall({ customHeaders: [
        {
          name: 'X-INVITE-Call',
          value: '9999999',
        },
      ]})`
5. check if this customer header shows on `telnyx.rtc_invite` WS message.
6. go to `call.answer({
              customHeaders: [
                {
                  name: 'X-Answer-Call',
                  value: '9999999',
                },
              ],
            })`
7. check if this customer header shows on `telnyx.rtc_answer` WS message.

## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## 📸 Screenshots

| Description | Screenshot |
| ----------- | ---------- |
| Desktop     |            |
| usage.gif   |            |
