### PR TITLE
fix(ENGDESK-26634-hotfix): the `params.customHeaders` was not destructuring correctly the values

### DIFF
--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -266,14 +266,12 @@ export default abstract class BaseCall implements IWebRTCCall {
 
     this.direction = Direction.Inbound;
 
-    this.options = {
-      ...this.options,
-      customHeaders: [
-        ...(params.customHeaders
-          ? params.customHeaders
-          : this.options.customHeaders),
-      ],
-    };
+    if(params?.customHeaders?.length > 0) {
+      this.options = {
+        ...this.options,
+        customHeaders: params.customHeaders
+      };
+    }
 
     this.peer = new Peer(PeerType.Answer, this.options);
     this._registerPeerEvents();


### PR DESCRIPTION
 - the `params.customHeaders` was not destructuring correctly the values

## 📝 To Do

- [ ] All linters pass
- [ ] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

1. navigate to `packages/js` 
2. run `yarn build`
3. run yarn link
4. go to a webrtc project and run the yarn link `@telnyx/webrtc`
5. make a call and receive a call
6. it should work normally.

## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## 📸 Screenshots

| Description | Screenshot |
| ----------- | ---------- |
| Desktop     |            |
| usage.gif   |            |
