### PR TITLE
fix(ENGDESK-26922): Make `login_token` optional

### DIFF
--- a/packages/js/src/utils/interfaces.ts
+++ b/packages/js/src/utils/interfaces.ts
@@ -32,7 +32,7 @@ export interface IClientOptions {
    * The JSON Web Token (JWT) to authenticate with your SIP Connection.
    * This is the recommended authentication strategy. [See how to create one](https://developers.telnyx.com/docs/v2/webrtc/quickstart).
    */
-  login_token: string;
+  login_token?: string;
   /**
    * The `username` to authenticate with your SIP Connection.
    * `login` and `password` will take precedence over


### PR DESCRIPTION
Creating a client no longer requires `login_token`to be passed. This is to allow users to login with username and password without TypeScripts errors.

Describe your changes

## 📝 To Do

- [ ] All linters pass
- [ ] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

1. Provide manual testing instructions

## 🦊 Browser testing
1. navigate to packages/js
2. run yarn build
3. run yarn link
4. go to a webrtc project and run the yarn link @telnyx/webrtc
5. This code should not throw typecheck errors.

```ts
const client = new TelnyxRTC({
login: "login",
password: "password"
})
```
### Desktop

- [ ] Edge (latest)
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## 📸 Screenshots

| Description | Screenshot |
| ----------- | ---------- |
| Desktop     |            |
| usage.gif   |            |
