### PR TITLE
fix(ENGDESK-28811): call object direction is undefined upon receiving call

### DIFF
--- a/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
+++ b/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
@@ -4,7 +4,7 @@ import Call from './Call';
 import { checkSubscribeResponse } from './helpers';
 import { Result } from '../messages/Verto';
 import { SwEvent } from '../util/constants';
-import { VertoMethod, NOTIFICATION_TYPE, GatewayStateType } from './constants';
+import { VertoMethod, NOTIFICATION_TYPE, GatewayStateType, Direction } from './constants';
 import { trigger, deRegister } from '../services/Handler';
 import { State, ConferenceAction } from './constants';
 import { MCULayoutEventHandler } from './LayoutHandler';
@@ -123,6 +123,7 @@ class VertoHandler {
         const call = _buildCall();
         call.playRingtone();
         call.setState(State.Ringing);
+        call.direction = Direction.Inbound
         this._ack(id, method);
         break;
       }


### PR DESCRIPTION

Describe your changes

The `direction` is set to `Inbound` upon receiving an Invite message.

Not sure if this is the best approach. Feedback appreciated

WIP: tests.

## 📝 To Do

- [ ] All linters pass
- [ ] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

1. Provide manual testing instructions

## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## 📸 Screenshots

| Description | Screenshot |
| ----------- | ---------- |
| Desktop     |            |
| usage.gif   |            |
