### PR TITLE
feat: support caller codec preference

### DIFF
--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -274,6 +274,9 @@ export default abstract class BaseCall implements IWebRTCCall {
         customHeaders: params.customHeaders,
       };
     }
+    if (params.preferred_codecs?.length > 0) {
+      this.options.preferred_codecs = params.preferred_codecs;
+    }
 
     this.peer = new Peer(PeerType.Answer, this.options, this.session);
     await this.peer.iceGatheringComplete.promise;

--- a/packages/js/src/Modules/Verto/webrtc/Peer.ts
+++ b/packages/js/src/Modules/Verto/webrtc/Peer.ts
@@ -173,7 +173,10 @@ export default class Peer {
   }
 
   private handleIceCandidate = (event: RTCPeerConnectionIceEvent) => {
-    if (event.candidate && ['relay', 'srflx'].includes(event.candidate.type)) {
+    if (
+      event.candidate &&
+      ['relay', 'srflx', 'prflx'].includes(event.candidate.type)
+    ) {
       // Found enough candidates to establish a connection
       // This is a workaround for the issue where iceGatheringState is always 'gathering'
       this.iceGatheringComplete.resolve(true);
@@ -219,19 +222,19 @@ export default class Peer {
       // FIXME: use transceivers way only for offer - when answer gotta match mid from the ones from SRD
       if (this.isOffer && typeof this.instance.addTransceiver === 'function') {
         // Use addTransceiver
-
-        audioTracks.forEach((track) => {
-          this.options.userVariables.microphoneLabel = track.label;
-          this.instance.addTransceiver(track, {
-            direction: 'sendrecv',
-            streams: [localStream],
-          });
-        });
-
         const transceiverParams: RTCRtpTransceiverInit = {
           direction: 'sendrecv',
           streams: [localStream],
         };
+
+        audioTracks.forEach((track) => {
+          this.options.userVariables.microphoneLabel = track.label;
+          const transceiver = this.instance.addTransceiver(
+            track,
+            transceiverParams
+          );
+          this._setAudioCodec(transceiver);
+        });
 
         console.debug('Applying video transceiverParams', transceiverParams);
         videoTracks.forEach((track) => {
@@ -245,6 +248,9 @@ export default class Peer {
           this.options.userVariables.microphoneLabel = track.label;
           this.instance.addTrack(track, localStream);
         });
+        this.instance
+          .getTransceivers()
+          .forEach((trans) => this._setAudioCodec(trans));
 
         videoTracks.forEach((track) => {
           this.options.userVariables.cameraLabel = track.label;
@@ -391,6 +397,14 @@ export default class Peer {
     return this.instance.setLocalDescription(sessionDescription);
   }
 
+  private _setAudioCodec = (transceiver: RTCRtpTransceiver) => {
+    if (!this.options.codecs || this.options.codecs.length === 0) {
+      return;
+    }
+    if (transceiver.setCodecPreferences) {
+      return transceiver.setCodecPreferences(this.options.codecs);
+    }
+  };
   /** Workaround for ReactNative: first time SDP has no candidates */
   private _sdpReady(): void {
     if (isFunction(this.onSdpReadyTwice)) {
@@ -438,7 +452,6 @@ export default class Peer {
     if (!this.options.debug) {
       return;
     }
-    debugger
 
     if (this.options.debugOutput === 'file') {
       const timeline = this._webrtcStatsReporter.debuggerInstance.getTimeline();

--- a/packages/js/src/Modules/Verto/webrtc/Peer.ts
+++ b/packages/js/src/Modules/Verto/webrtc/Peer.ts
@@ -398,11 +398,11 @@ export default class Peer {
   }
 
   private _setAudioCodec = (transceiver: RTCRtpTransceiver) => {
-    if (!this.options.codecs || this.options.codecs.length === 0) {
+    if (!this.options.preferred_codecs || this.options.preferred_codecs.length === 0) {
       return;
     }
     if (transceiver.setCodecPreferences) {
-      return transceiver.setCodecPreferences(this.options.codecs);
+      return transceiver.setCodecPreferences(this.options.preferred_codecs);
     }
   };
   /** Workaround for ReactNative: first time SDP has no candidates */

--- a/packages/js/src/Modules/Verto/webrtc/interfaces.ts
+++ b/packages/js/src/Modules/Verto/webrtc/interfaces.ts
@@ -47,6 +47,7 @@ export interface IVertoCallOptions {
   customHeaders?: Array<{ name: string; value: string }>;
   debug?: boolean;
   debugOutput?: 'socket' | 'file';
+  codecs?: RTCRtpCodecCapability[];
 }
 
 export interface IStatsBinding {

--- a/packages/js/src/Modules/Verto/webrtc/interfaces.ts
+++ b/packages/js/src/Modules/Verto/webrtc/interfaces.ts
@@ -47,7 +47,7 @@ export interface IVertoCallOptions {
   customHeaders?: Array<{ name: string; value: string }>;
   debug?: boolean;
   debugOutput?: 'socket' | 'file';
-  codecs?: RTCRtpCodecCapability[];
+  preferred_codecs?: RTCRtpCodecCapability[];
 }
 
 export interface IStatsBinding {
@@ -57,6 +57,7 @@ export interface IStatsBinding {
 
 export interface AnswerParams {
   customHeaders?: Array<{ name: string; value: string }>;
+  preferred_codecs?: Array<RTCRtpCodecCapability>;
 }
 
 export interface IWebRTCCall {

--- a/packages/js/src/utils/interfaces.ts
+++ b/packages/js/src/utils/interfaces.ts
@@ -186,6 +186,21 @@ export interface ICallOptions {
    * Add custom headers to the INVITE and ANSWER request.
    */
   customHeaders?: { name: string; value: string }[];
+
+  /**
+   * Enable debug mode for this call.
+   */
+  debug?: boolean;
+
+  /**
+   * Output debug logs to a file.
+   */
+  debugOutput?: 'socket' | 'file';
+
+  /**
+   * Preferred codecs for the call.
+   */
+  preferred_codecs?: RTCRtpCodecCapability[];
 }
 
 /**


### PR DESCRIPTION
[WEBRTC-2221](https://telnyx.atlassian.net/browse/WEBRTC-2221)

Allow setting preferred audio codec upon creating / answering a call 

## 📝 To Do

- [ ] All linters pass
- [ ] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

1. Provide manual testing instructions

## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## 📸 Screenshots

| Description | Screenshot |
| ----------- | ---------- |
| Desktop     |            |
| usage.gif   |            |


[WEBRTC-2221]: https://telnyx.atlassian.net/browse/WEBRTC-2221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ