### PR TITLE
feat: attach reconnection token to host

### DIFF
--- a/packages/js/src/Modules/Verto/util/reconnect.ts
+++ b/packages/js/src/Modules/Verto/util/reconnect.ts
@@ -1,0 +1,18 @@
+const STORAGE_KEY = 'telnyx-voice-sdk-id';
+
+export function getReconnectToken(): string | null {
+  const token = sessionStorage.getItem(STORAGE_KEY);
+  return token;
+}
+
+export function setReconnectToken(token: string): void {
+  sessionStorage.setItem(STORAGE_KEY, token);
+}
+
+export function clearReconnectToken(): void {
+  sessionStorage.removeItem(STORAGE_KEY);
+}
+
+window.addEventListener('beforeunload', () => {
+  clearReconnectToken();
+});


### PR DESCRIPTION
[WEBRTC-2246](https://telnyx.atlassian.net/browse/WEBRTC-2246)

## 📝 To Do
voice-sdk-proxy now returns a token used to re-establish ws connection to the b2bua-rtc instance in case the ws disconnects. 

this change saves the token to session storage and attaches it (if it exists) to the websocket host. 

- [ ] All linters pass
- [ ] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

1. Provide manual testing instructions

## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## 📸 Screenshots

| Description | Screenshot |
| ----------- | ---------- |
| Desktop     |            |
| usage.gif   |            |


[WEBRTC-2246]: https://telnyx.atlassian.net/browse/WEBRTC-2246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ