### PR TITLE
feat: add reconnection flag to login message

### DIFF
--- a/packages/js/src/Modules/Verto/index.ts
+++ b/packages/js/src/Modules/Verto/index.ts
@@ -10,6 +10,7 @@ import Call from './webrtc/Call';
 import { TIME_CALL_INVITE } from './util/constants';
 import VertoHandler from './webrtc/VertoHandler';
 import { isValidOptions } from './util/helpers';
+import { getReconnectToken } from './util/reconnect';
 
 export const VERTO_PROTOCOL = 'verto-protocol';
 
@@ -69,12 +70,14 @@ export default class Verto extends BrowserSession {
       userVariables,
       autoReconnect = true,
     } = this.options;
+
     const msg = new Login(
       login,
       password || passwd,
       login_token,
       this.sessionid,
-      userVariables
+      userVariables,
+      !!getReconnectToken()
     );
     const response = await this.execute(msg).catch(this._handleLoginError);
     if (response) {

--- a/packages/js/src/Modules/Verto/messages/verto/Login.ts
+++ b/packages/js/src/Modules/Verto/messages/verto/Login.ts
@@ -9,7 +9,8 @@ class Login extends BaseRequest {
     passwd: string,
     login_token: string,
     sessionid: string,
-    userVariables: Object = {}
+    userVariables: Object = {},
+    reconnection: boolean
   ) {
     super();
 
@@ -19,6 +20,7 @@ class Login extends BaseRequest {
       passwd,
       login_token,
       userVariables,
+      reconnection,
       loginParams: {},
       'User-Agent': {
         sdkVersion: pkg.version,

--- a/packages/js/src/Modules/Verto/tests/messages.test.ts
+++ b/packages/js/src/Modules/Verto/tests/messages.test.ts
@@ -21,10 +21,12 @@ describe('Messages', function () {
           'login',
           'password',
           'dskbksdjbfkjsdf234y67234kjrwe98',
-          null!
+          null!,
+          {},
+          false
         ).request;
         const res = JSON.parse(
-          `{"jsonrpc":"2.0","id":"${message.id}","method":"login","params":{"User-Agent": ${userAgent},"login":"login","passwd":"password","login_token": "dskbksdjbfkjsdf234y67234kjrwe98","loginParams":{},"userVariables":{}}}`
+          `{"jsonrpc":"2.0","id":"${message.id}","method":"login","params":{"User-Agent": ${userAgent},"login":"login","passwd":"password", "reconnection": false,"login_token": "dskbksdjbfkjsdf234y67234kjrwe98","loginParams":{},"userVariables":{}}}`
         );
         expect(message).toEqual(res);
       });
@@ -34,16 +36,25 @@ describe('Messages', function () {
           'login',
           'password',
           'dskbksdjbfkjsdf234y67234kjrwe98',
-          '123456789'
+          '123456789',
+          {},
+          false
         ).request;
         const res = JSON.parse(
-          `{"jsonrpc":"2.0","id":"${message.id}","method":"login","params":{"User-Agent": ${userAgent},"login":"login","passwd":"password","login_token": "dskbksdjbfkjsdf234y67234kjrwe98","sessid":"123456789","loginParams":{},"userVariables":{}}}`
+          `{"jsonrpc":"2.0","id":"${message.id}","method":"login","params":{"User-Agent": ${userAgent},"login":"login","passwd":"password","reconnection": false, "login_token": "dskbksdjbfkjsdf234y67234kjrwe98","sessid":"123456789","loginParams":{},"userVariables":{}}}`
         );
         expect(message).toEqual(res);
       });
 
       it('Should pass User-Agent to the backend', () => {
-        const req = new Login('login', 'password', 'token', 'session').request;
+        const req = new Login(
+          'login',
+          'password',
+          'token',
+          'session',
+          {},
+          false
+        ).request;
         expect(req).toEqual(
           expect.objectContaining({
             params: expect.objectContaining({


### PR DESCRIPTION
[WEBRTC-2274](https://telnyx.atlassian.net/browse/WEBRTC-2274)


Describe your changes

Add a boolean flag to the `Login` message to indicate whether the login is for a reconnection or not. 

## 📝 To Do

- [x] All linters pass
- [x] All tests pass
- [x] Change documentation based on my changes

## ✋ Manual testing

1. Provide manual testing instructions

## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## 📸 Screenshots

| Description | Screenshot |
| ----------- | ---------- |
| Desktop     |            |
| usage.gif   |            |


[WEBRTC-2274]: https://telnyx.atlassian.net/browse/WEBRTC-2274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ