### PR TITLE
fix: debug reports are missing initial events

### DIFF
--- a/packages/js/src/Modules/Verto/webrtc/Peer.ts
+++ b/packages/js/src/Modules/Verto/webrtc/Peer.ts
@@ -91,16 +91,16 @@ export default class Peer {
     this._webrtcStatsReporter = webRTCStatsReporter();
     this._session.execute(this._webrtcStatsReporter.start());
 
+    this._webrtcStatsReporter.debuggerInstance.on(
+      'timeline',
+      this._onDebugReportMessage
+    );
+
     this._webrtcStatsReporter.debuggerInstance.addConnection({
       pc: this.instance,
       peerId: this.options.id,
       connectionId: this.options.telnyxSessionId,
     });
-
-    this._webrtcStatsReporter.debuggerInstance.on(
-      'timeline',
-      this._onDebugReportMessage
-    );
   }
 
   public stopDebugger() {
@@ -108,8 +108,8 @@ export default class Peer {
       return;
     }
 
-    this._webrtcStatsReporter.debuggerInstance.destroy();
     this._session.execute(this._webrtcStatsReporter.stop());
+    this._webrtcStatsReporter.debuggerInstance.destroy();
   }
 
   private _logTransceivers() {


### PR DESCRIPTION
NO JIRA

Describe your changes

Attach the event listener before adding the instance to be monitored. 
This fixes initial events that are not sent to the server. 

## 📝 To Do

- [ ] All linters pass
- [ ] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

1. Provide manual testing instructions

## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## 📸 Screenshots

| Description | Screenshot |
| ----------- | ---------- |
| Desktop     |            |
| usage.gif   |            |
