### PR TITLE
fix(webrtc): Stop ringback tone when call is hung up

### DIFF
--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -337,6 +337,7 @@ export default abstract class BaseCall implements IWebRTCCall {
     };
 
     this.stopRingtone();
+    this.stopRingback();
     if (execute) {
       const bye = new Bye({
         sessid: this.session.sessionid,


### PR DESCRIPTION
## Description
Fixes WEBRTC-2443: Ringbacktone and ringtone not stopping properly after hang up

### Changes Made
- Added `stopRingback()` call in the `hangup` function to ensure ringback tone is stopped when the call ends
- This complements the existing `stopRingtone()` call to ensure all audio is properly stopped

### Testing
- Verified that ringback tone stops when call is hung up
- Tested both caller and callee hang up scenarios

### Related Issues
- Fixes WEBRTC-2443

### Additional Notes
- This is a simple fix that ensures proper cleanup of audio resources
- No breaking changes introduced