### PR TITLE
feat: regional subdomains for voice-sdk

### DIFF
--- a/packages/js/src/Modules/Verto/services/Connection.ts
+++ b/packages/js/src/Modules/Verto/services/Connection.ts
@@ -36,14 +36,18 @@ export default class Connection {
   public downDur: number = null;
 
   constructor(public session: BaseSession) {
-    const { host, env } = session.options;
+    const { host, env, region } = session.options;
+
+    if (env) {
+      this._host = env === 'development' ? DEV_HOST : PROD_HOST;
+    }
 
     if (host) {
       this._host = checkWebSocketHost(host);
     }
 
-    if (env) {
-      this._host = env === 'development' ? DEV_HOST : PROD_HOST;
+    if (region) {
+      this._host = this._host.replace(/rtc(dev)?/, `${region}.rtc$1`);
     }
   }
 

--- a/packages/js/src/Modules/Verto/util/interfaces.ts
+++ b/packages/js/src/Modules/Verto/util/interfaces.ts
@@ -25,6 +25,7 @@ export interface IVertoOptions {
   debugOutput?: 'socket' | 'file';
   prefetchIceCandidates?: boolean;
   forceRelayCandidate?: boolean;
+  region?: string;
 }
 export interface SubscribeParams {
   channels?: string[];

--- a/packages/js/src/utils/interfaces.ts
+++ b/packages/js/src/utils/interfaces.ts
@@ -73,6 +73,11 @@ export interface IClientOptions {
    * Force the use of a relay ICE candidate.
    */
   forceRelayCandidate?: boolean;
+
+  /**
+   * Region to use for the connection.
+   */
+  region?: string;
 }
 
 export interface ISIPCallOptions {


### PR DESCRIPTION
[XXXX-YYY](https://telnyx.atlassian.net/browse/XXXX-YYY)


Describe your changes

Added a new client option to select which region of voice sdk proxy to connect to 

## 📝 To Do

- [ ] All linters pass
- [ ] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

1. Provide manual testing instructions

## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## 📸 Screenshots

| Description | Screenshot |
| ----------- | ---------- |
| Desktop     |            |
| usage.gif   |            |
