### PR TITLE
fix: precall diagnosis runs forever

### DIFF
--- a/packages/js/src/Modules/Verto/util/debug.ts
+++ b/packages/js/src/Modules/Verto/util/debug.ts
@@ -72,7 +72,7 @@ export function createWebRTCStatsReporter(
 
   const stop = async (debugOutput: string) => {
     const timeline = stats.getTimeline();
-    trigger(SwEvent.StatsReport, timeline);
+    trigger(SwEvent.StatsReport, timeline, session.uuid);
     if (debugOutput === 'file') {
       const filename = `webrtc-stats-${reportId}-${Date.now()}`;
       saveToFile(timeline, filename);

--- a/packages/js/src/Modules/Verto/webrtc/Peer.ts
+++ b/packages/js/src/Modules/Verto/webrtc/Peer.ts
@@ -462,7 +462,8 @@ export default class Peer {
     return config;
   }
 
-  public close() {
+  public async close() {
+    await this.statsReporter?.stop(this.debugOutput);
     if (this.instance) {
       this.instance.close();
       this.instance = null;


### PR DESCRIPTION
Bugfix: 
 The `Report` event is not emitted globally