### PR TITLE
fix: export Call via relative path

### DIFF
--- a/packages/js/src/utils/interfaces.ts
+++ b/packages/js/src/utils/interfaces.ts
@@ -1,6 +1,5 @@
-import Call from 'src/Modules/Verto/webrtc/Call';
+import Call from '../Modules/Verto/webrtc/Call';
 import { INotificationEventData } from '../Modules/Verto/util/interfaces';
-import { Env, RTCElement } from './types';
 
 export interface ICredentials {
   username?: string;


### PR DESCRIPTION
addresses a bug introduced in v 2.22.12 where a typescript error is thrown when trying to resolve `Call` type from `interfaces.d.ts` this happens if you have path aliases configured in typescript to resolve `src/**/*`