### PR TITLE
fix: concat new changelog entries to the beginning of file

### DIFF
--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -31,9 +31,10 @@ jobs:
       - name: Get release description
         working-directory: packages/js
         run: |
-          echo "## Release: ${{ github.event.release.name || github.event.inputs.title }}" >> CHANGELOG.md
-          echo "${{ github.event.release.body || github.event.inputs.description}}" >> CHANGELOG.md
-          echo "" >> CHANGELOG.md
+          sed -i '' '1i\
+          ## [${{github.event.release.tag_name}}](${{github.event.release.html_url}}) (${{github.event.release.created_at}})\
+          \
+          ${{github.event.release.body}}\' CHANGELOG.md
 
       - name: Commit and push changes
         working-directory: packages/js
@@ -41,7 +42,7 @@ jobs:
           git config user.name TelnyxIntegrations
           git config user.email integrations@telnyx.com
           git add CHANGELOG.md
-          git commit --no-verify -m "Update CHANGELOG with release ${{ github.event.release.tag_name || github.event.inputs.title }}"
+          git commit --no-verify -m "Update CHANGELOG.md with release ${{ github.event.release.tag_name || github.event.inputs.title }}"
           git push -u origin main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
[ENGDESK-44117](https://telnyx.atlassian.net/browse/ENGDESK-44117)


concat CHANGELOG.md entries to the beginning of the file

## 📝 To Do

- [ ] All linters pass
- [ ] All tests pass
- [ ] Change documentation based on my changes

## ✋ Manual testing

1. Provide manual testing instructions

## 🦊 Browser testing

### Desktop

- [ ] Edge (latest)
- [ ] Chrome
- [ ] Firefox
- [ ] Safari

## 📸 Screenshots

| Description | Screenshot |
| ----------- | ---------- |
| Desktop     |            |
| usage.gif   |            |


[ENGDESK-44117]: https://telnyx.atlassian.net/browse/ENGDESK-44117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ