### PR TITLE
chore: update workflows for prerelease bumps

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -45,7 +45,7 @@ jobs:
     env:
       TARGET_REF: ${{ github.event.inputs.ref || 'main' }}
       PRERELEASE_ARGS: ${{ github.event.inputs.prerelease && github.event.inputs.prerelease != 'none' && format(' --preRelease={0} --github.preRelease', github.event.inputs.prerelease) || '' }}
-      INCREMENT_ARG: ${{ github.event.inputs.increment && format(' --increment={0}', github.event.inputs.increment) || '' }}
+      INCREMENT_ARG: ${{ github.event.inputs.prerelease && github.event.inputs.prerelease != 'none' && ' --increment=prerelease' || github.event.inputs.increment && format(' --increment={0}', github.event.inputs.increment) || '' }}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   publish-js:
-    if: github.event.inputs.package == 'webrtc' || startsWith(github.ref, 'refs/tags/webrtc')
+    if: (github.event.inputs.package == 'webrtc' || startsWith(github.ref, 'refs/tags/webrtc')) && (github.event_name != 'release' || github.event.release.prerelease != true)
 
     name: "@telnyx/webrtc Publish release"
 
@@ -72,7 +72,7 @@ jobs:
           context: "New Telnyx WebRTC SDK Release ${{ steps.package-version.outputs.current-version}}"
 
   publish-react-client:
-    if: github.event.inputs.package == 'react-client' || startsWith(github.ref, 'refs/tags/react-client')
+    if: (github.event.inputs.package == 'react-client' || startsWith(github.ref, 'refs/tags/react-client')) && (github.event_name != 'release' || github.event.release.prerelease != true)
 
     name: "@telnyx/react-client Publish release"
 

--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -2,7 +2,7 @@ name: Update Changelog
 
 on:
   release:
-    types: [published, prereleased]
+    types: [published]
   workflow_dispatch:
     inputs:
       title:
@@ -19,6 +19,7 @@ on:
         default: "main"
 jobs:
   publish:
+    if: github.event_name != 'release' || github.event.release.prerelease != true
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
- make sure to bump correct version when prerelease is used