### PR TITLE
fix: expose getIsRegistered

### DIFF
--- a/packages/js/src/Modules/Verto/BaseSession.ts
+++ b/packages/js/src/Modules/Verto/BaseSession.ts
@@ -76,6 +76,10 @@ export default abstract class BaseSession {
     return this.connection && this.connection.connected;
   }
 
+  public async getIsRegistered(): Promise<boolean> {
+    return this.registerAgent.getIsRegistered();
+  }
+
   get reconnectDelay() {
     return randomInt(2, 6) * 1000;
   }
@@ -416,14 +420,5 @@ export default abstract class BaseSession {
 
   public hasAutoReconnect() {
     return this._autoReconnect;
-  }
-
-  /**
-   * Get the registration state of the client
-   * @private
-   * @return Promise<boolean>
-   */
-  private getIsRegistered() {
-    return this.registerAgent.getIsRegistered();
   }
 }

--- a/packages/js/src/Modules/Verto/BrowserSession.ts
+++ b/packages/js/src/Modules/Verto/BrowserSession.ts
@@ -71,6 +71,10 @@ export default abstract class BrowserSession extends BaseSession {
     return 1000;
   }
 
+  async getIsRegistered(): Promise<boolean> {
+    return super.getIsRegistered();
+  }
+
   /**
    * Creates a new connection for exchanging data with the WebRTC server
    *

--- a/packages/js/src/Modules/Verto/messages/verto/Gateway.ts
+++ b/packages/js/src/Modules/Verto/messages/verto/Gateway.ts
@@ -4,12 +4,12 @@ import BaseRequest from './BaseRequest';
 class Gateway extends BaseRequest {
   method: string = VertoMethod.GatewayState;
 
-  constructor() {
+  constructor(voice_sdk_id?: string | null) {
     super();
 
     const params: any = {};
 
-    this.buildRequest({ method: this.method, params });
+    this.buildRequest({ method: this.method, voice_sdk_id, params });
   }
 }
 

--- a/packages/js/src/Modules/Verto/services/RegisterAgent.ts
+++ b/packages/js/src/Modules/Verto/services/RegisterAgent.ts
@@ -5,6 +5,7 @@ import {
   DeferredPromise,
   getGatewayState,
 } from '../util/helpers';
+import { getReconnectToken } from '../util/reconnect';
 import { GatewayStateType } from '../webrtc/constants';
 
 /**
@@ -28,7 +29,7 @@ export class RegisterAgent {
   };
 
   public getIsRegistered = async () => {
-    const message = new Gateway();
+    const message = new Gateway(getReconnectToken());
     this.pendingRequestId = message.request.id;
     this.gatewayStateTask = deferredPromise<GatewayStateType>({});
 

--- a/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
+++ b/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
@@ -48,7 +48,7 @@ class VertoHandler {
 
   handleMessage(msg: any) {
     const { session } = this;
-    const { id, method, params = {} } = msg;
+    const { id, method, params = {}, voice_sdk_id } = msg;
 
     const callID = params?.callID;
     const eventChannel = params?.eventChannel;
@@ -116,7 +116,7 @@ class VertoHandler {
       return call;
     };
 
-    const messageToCheckRegisterState = new Gateway();
+    const messageToCheckRegisterState = new Gateway(voice_sdk_id);
     const messagePing = new Ping();
 
     switch (method) {


### PR DESCRIPTION
## Summary
- expose `getIsRegistered` so session consumers can read the registration state directly
- thread the `voice_sdk_id` through gateway state requests using the reconnect token
- pass the `voice_sdk_id` from incoming Verto messages when checking registration status
