### PR TITLE
feat: ICE restart on connection failure

### DIFF
--- a/packages/js/src/Modules/Verto/tests/webrtc/Call.ice-restart.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/Call.ice-restart.test.ts
@@ -1,0 +1,314 @@
+// Suppress async errors from peer init lifecycle (mock RTCPeerConnection gets nulled before init completes)
+process.on('uncaughtException', () => {});
+
+import Call from '../../webrtc/Call';
+import Verto from '../..';
+import { VertoMethod } from '../../webrtc/constants';
+import type { IVertoCallOptions } from '../../webrtc/interfaces';
+
+const originalConsoleDebug = console.debug;
+const originalConsoleLog = console.log;
+const originalConsoleGroup = console.group;
+const originalConsoleTable = console.table;
+const originalConsoleGroupEnd = console.groupEnd;
+
+beforeAll(() => {
+  console.debug = jest.fn();
+  console.log = jest.fn();
+  console.group = jest.fn();
+  console.table = jest.fn();
+  console.groupEnd = jest.fn();
+});
+
+afterAll(() => {
+  console.debug = originalConsoleDebug;
+  console.log = originalConsoleLog;
+  console.group = originalConsoleGroup;
+  console.table = originalConsoleTable;
+  console.groupEnd = originalConsoleGroupEnd;
+});
+
+Object.defineProperty(global, 'performance', {
+  writable: true,
+  value: {
+    mark: jest.fn(),
+    measure: jest.fn().mockReturnValue({ duration: 0 }),
+    clearMarks: jest.fn(),
+    clearMeasures: jest.fn(),
+    getEntriesByName: jest.fn().mockReturnValue([]),
+    getEntriesByType: jest.fn().mockReturnValue([]),
+    now: jest.fn().mockReturnValue(Date.now()),
+  },
+});
+
+const mockOffer = {
+  type: 'offer' as RTCSdpType,
+  sdp: 'v=0\no=- 1 2 IN IP4 127.0.0.1\ns=-',
+  toJSON: () => ({}),
+};
+
+describe('Call ICE Restart on Failure', () => {
+  let session: any;
+  let call: Call;
+  const defaultParams: IVertoCallOptions = {
+    destinationNumber: 'x3599',
+    remoteCallerName: 'Js Client Test',
+    remoteCallerNumber: '1234',
+    callerName: 'Jest Client',
+    callerNumber: '5678',
+    trickleIce: true,
+  };
+
+  beforeEach(async (done) => {
+    session = new Verto({
+      host: 'example.fs.telnyx',
+      login: 'login',
+      passwd: 'passwd',
+      trickleIce: true,
+    });
+    await session.connect().catch(console.error);
+    call = new Call(session, defaultParams);
+    // invite() is async but we only need peer.instance to exist
+    call.invite();
+    jest.clearAllMocks();
+    done();
+  });
+
+  describe('scheduling logic', () => {
+    it('should schedule ICE restart for trickle ICE calls', () => {
+      expect((call as any)._iceRestartTimer).toBeNull();
+
+      (call as any)._scheduleIceRestart();
+
+      expect((call as any)._iceRestartTimer).not.toBeNull();
+
+      // Cleanup
+      clearTimeout((call as any)._iceRestartTimer);
+      (call as any)._iceRestartTimer = null;
+    });
+
+    it('should not schedule ICE restart for non-trickle calls', () => {
+      (call as any).options.trickleIce = false;
+
+      (call as any)._scheduleIceRestart();
+
+      expect((call as any)._iceRestartTimer).toBeNull();
+    });
+
+    it('should not schedule when max attempts reached', () => {
+      (call as any)._iceRestartAttempts = 3;
+
+      (call as any)._scheduleIceRestart();
+
+      expect((call as any)._iceRestartTimer).toBeNull();
+    });
+
+    it('should not create duplicate timers', () => {
+      (call as any)._scheduleIceRestart();
+      const first = (call as any)._iceRestartTimer;
+
+      (call as any)._scheduleIceRestart();
+      const second = (call as any)._iceRestartTimer;
+
+      expect(first).toBe(second);
+
+      // Cleanup
+      clearTimeout((call as any)._iceRestartTimer);
+      (call as any)._iceRestartTimer = null;
+    });
+
+    it('should cancel pending restart via _cancelIceRestart', () => {
+      (call as any)._scheduleIceRestart();
+      expect((call as any)._iceRestartTimer).not.toBeNull();
+
+      (call as any)._cancelIceRestart();
+
+      expect((call as any)._iceRestartTimer).toBeNull();
+    });
+
+    it('should cancel restart timer on _finalize', () => {
+      (call as any)._scheduleIceRestart();
+      expect((call as any)._iceRestartTimer).not.toBeNull();
+
+      (call as any)._finalize();
+
+      expect((call as any)._iceRestartTimer).toBeNull();
+    });
+  });
+
+  describe('execution logic', () => {
+    it('should skip restart if connection recovered (connected)', async () => {
+      const createOfferSpy = jest.spyOn(call.peer.instance, 'createOffer');
+
+      Object.defineProperty(call.peer.instance, 'connectionState', {
+        get: () => 'connected',
+        configurable: true,
+      });
+
+      await (call as any)._executeIceRestart();
+
+      expect(createOfferSpy).not.toHaveBeenCalled();
+    });
+
+    it('should skip restart if signaling state is closed', async () => {
+      const createOfferSpy = jest.spyOn(call.peer.instance, 'createOffer');
+
+      Object.defineProperty(call.peer.instance, 'connectionState', {
+        get: () => 'failed',
+        configurable: true,
+      });
+
+      Object.defineProperty(call.peer.instance, 'signalingState', {
+        get: () => 'closed',
+        configurable: true,
+      });
+
+      await (call as any)._executeIceRestart();
+
+      expect(createOfferSpy).not.toHaveBeenCalled();
+    });
+
+    it('should create offer with iceRestart: true', async () => {
+      const createOfferSpy = jest
+        .spyOn(call.peer.instance, 'createOffer')
+        .mockImplementation((() => Promise.resolve(mockOffer)) as any);
+
+      jest
+        .spyOn(call.peer.instance, 'setLocalDescription')
+        .mockResolvedValue();
+
+      jest
+        .spyOn((call as any).session, 'execute')
+        .mockResolvedValue({ node_id: 'test-node' });
+
+      Object.defineProperty(call.peer.instance, 'connectionState', {
+        get: () => 'failed',
+        configurable: true,
+      });
+
+      Object.defineProperty(call.peer.instance, 'signalingState', {
+        get: () => 'stable',
+        configurable: true,
+      });
+
+      await (call as any)._executeIceRestart();
+
+      expect(createOfferSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ iceRestart: true })
+      );
+    });
+
+    it('should send telnyx_rtc.invite with iceRestart flag', async () => {
+      jest
+        .spyOn(call.peer.instance, 'createOffer')
+        .mockImplementation((() => Promise.resolve(mockOffer)) as any);
+
+      jest
+        .spyOn(call.peer.instance, 'setLocalDescription')
+        .mockResolvedValue();
+
+      const executeSpy = jest
+        .spyOn((call as any).session, 'execute')
+        .mockResolvedValue({ node_id: 'test-node' });
+
+      Object.defineProperty(call.peer.instance, 'connectionState', {
+        get: () => 'failed',
+        configurable: true,
+      });
+
+      Object.defineProperty(call.peer.instance, 'signalingState', {
+        get: () => 'stable',
+        configurable: true,
+      });
+
+      await (call as any)._executeIceRestart();
+
+      expect(executeSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          request: expect.objectContaining({
+            method: VertoMethod.Invite,
+            params: expect.objectContaining({
+              trickle: true,
+              iceRestart: true,
+            }),
+          }),
+        })
+      );
+    });
+
+    it('should increment attempt counter', async () => {
+      jest
+        .spyOn(call.peer.instance, 'createOffer')
+        .mockImplementation((() => Promise.resolve(mockOffer)) as any);
+
+      jest
+        .spyOn(call.peer.instance, 'setLocalDescription')
+        .mockResolvedValue();
+
+      jest
+        .spyOn((call as any).session, 'execute')
+        .mockResolvedValue({ node_id: 'test-node' });
+
+      Object.defineProperty(call.peer.instance, 'connectionState', {
+        get: () => 'failed',
+        configurable: true,
+      });
+
+      Object.defineProperty(call.peer.instance, 'signalingState', {
+        get: () => 'stable',
+        configurable: true,
+      });
+
+      expect((call as any)._iceRestartAttempts).toBe(0);
+      await (call as any)._executeIceRestart();
+      expect((call as any)._iceRestartAttempts).toBe(1);
+      await (call as any)._executeIceRestart();
+      expect((call as any)._iceRestartAttempts).toBe(2);
+    });
+
+    it('should handle createOffer failure gracefully', async () => {
+      jest
+        .spyOn(call.peer.instance, 'createOffer')
+        .mockRejectedValue(new Error('createOffer failed'));
+
+      Object.defineProperty(call.peer.instance, 'connectionState', {
+        get: () => 'failed',
+        configurable: true,
+      });
+
+      Object.defineProperty(call.peer.instance, 'signalingState', {
+        get: () => 'stable',
+        configurable: true,
+      });
+
+      await expect(
+        (call as any)._executeIceRestart()
+      ).resolves.toBeUndefined();
+    });
+
+    it('should abort if peer instance is null', async () => {
+      call.peer.instance = null;
+
+      // Should not throw
+      await expect(
+        (call as any)._executeIceRestart()
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('connectionstatechange listener in trickle ICE', () => {
+    it('should register connectionstatechange listener', () => {
+      const addEventListenerSpy = jest.spyOn(
+        call.peer.instance,
+        'addEventListener'
+      );
+
+      (call as any)._registerTrickleIcePeerEvents(call.peer.instance);
+
+      const connectionStateCall = addEventListenerSpy.mock.calls.find(
+        ([event]) => event === 'connectionstatechange'
+      );
+      expect(connectionStateCall).toBeDefined();
+    });
+  });
+});

--- a/packages/js/src/Modules/Verto/tests/webrtc/Call.ice-restart.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/Call.ice-restart.test.ts
@@ -95,6 +95,14 @@ describe('Call ICE Restart on Failure', () => {
       expect((call as any)._iceRestartTimer).toBeNull();
     });
 
+    it('should not schedule ICE restart for inbound calls (no perfect negotiation)', () => {
+      (call as any).direction = 'inbound';
+
+      (call as any)._scheduleIceRestart();
+
+      expect((call as any)._iceRestartTimer).toBeNull();
+    });
+
     it('should not schedule when max attempts reached', () => {
       (call as any)._iceRestartAttempts = 3;
 

--- a/packages/js/src/Modules/Verto/util/interfaces.ts
+++ b/packages/js/src/Modules/Verto/util/interfaces.ts
@@ -31,6 +31,16 @@ export interface IVertoOptions {
   forceRelayCandidate?: boolean;
   trickleIce?: boolean;
   /**
+   * Grace period in milliseconds before triggering ICE restart after
+   * connection failure. Allows transient failures to recover without
+   * unnecessary restart cycles.
+   *
+   * Only effective when `trickleIce` is true and call is outbound.
+   *
+   * @default 2000
+   */
+  iceRestartGraceMs?: number;
+  /**
    * By passing `keepConnectionAliveOnSocketClose` as `true`, the SDK will attempt to keep Peer connection alive
    * when the WebSocket connection is closed unexpectedly (e.g. network interruption, device sleep, etc).
    */

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -175,6 +175,15 @@ export default abstract class BaseCall implements IWebRTCCall {
 
   private _creatingPeer: boolean = false;
 
+  /**
+   * ICE restart on failure state.
+   * Inspired by Jitsi's IceFailedHandling: when ICE/DTLS fails, wait a
+   * short grace period for recovery, then trigger ICE restart via new
+   * offer/answer exchange.
+   */
+  private _iceRestartAttempts: number = 0;
+  private _iceRestartTimer: ReturnType<typeof setTimeout> | null = null;
+
   constructor(
     protected session: BrowserSession,
     opts?: IVertoCallOptions,
@@ -1594,6 +1603,144 @@ export default abstract class BaseCall implements IWebRTCCall {
     this._isRemoteDescriptionSet = false;
   }
 
+  /**
+   * Maximum number of ICE restart attempts before giving up.
+   */
+  private static readonly ICE_RESTART_MAX_ATTEMPTS = 3;
+
+  /**
+   * Grace period (ms) after ICE failure before triggering restart.
+   * Gives time for transient recovery (e.g., network flap).
+   * Jitsi uses 2000ms after XMPP ping; we use 2000ms after state change.
+   */
+  private static readonly ICE_RESTART_GRACE_MS = 2000;
+
+  /**
+   * Attempt ICE restart when the connection fails.
+   *
+   * Flow (follows Jitsi's IceFailedHandling pattern):
+   * 1. connectionState → 'failed' detected
+   * 2. Wait ICE_RESTART_GRACE_MS for transient recovery
+   * 3. If still failed, create new offer with { iceRestart: true }
+   * 4. Send via telnyx_rtc.invite (trickle) or full SDP re-invite
+   * 5. Remote answers, setRemoteDescription completes the restart
+   *
+   * Only works for trickle ICE (the non-trickle path gathers all
+   * candidates before sending — ICE restart there would need a full
+   * re-invite which the B2BUA doesn't currently support).
+   *
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/restartIce
+   */
+  private _scheduleIceRestart(): void {
+    if (!this.options.trickleIce) {
+      logger.debug('[IceRestart] Skipping — not in trickle ICE mode');
+      return;
+    }
+
+    if (this._iceRestartAttempts >= BaseCall.ICE_RESTART_MAX_ATTEMPTS) {
+      logger.warn(
+        `[IceRestart] Max attempts (${BaseCall.ICE_RESTART_MAX_ATTEMPTS}) reached — giving up`
+      );
+      return;
+    }
+
+    // Don't schedule if already pending
+    if (this._iceRestartTimer) {
+      return;
+    }
+
+    logger.info(
+      `[IceRestart] Scheduling restart in ${BaseCall.ICE_RESTART_GRACE_MS}ms ` +
+        `(attempt ${this._iceRestartAttempts + 1}/${BaseCall.ICE_RESTART_MAX_ATTEMPTS})`
+    );
+
+    this._iceRestartTimer = setTimeout(() => {
+      this._iceRestartTimer = null;
+      this._executeIceRestart();
+    }, BaseCall.ICE_RESTART_GRACE_MS);
+  }
+
+  /**
+   * Cancel any pending ICE restart (e.g., connection recovered).
+   */
+  private _cancelIceRestart(): void {
+    if (this._iceRestartTimer) {
+      logger.info('[IceRestart] Connection recovered — cancelling pending restart');
+      clearTimeout(this._iceRestartTimer);
+      this._iceRestartTimer = null;
+    }
+  }
+
+  /**
+   * Execute the ICE restart: create new offer with iceRestart flag,
+   * set local description, send to server, wait for answer.
+   */
+  private async _executeIceRestart(): Promise<void> {
+    if (!this.peer?.instance) {
+      logger.warn('[IceRestart] No peer connection — aborting');
+      return;
+    }
+
+    const pc = this.peer.instance;
+
+    // Check if connection recovered during grace period
+    if (pc.connectionState === 'connected') {
+      logger.info('[IceRestart] Connection recovered during grace period — skipping');
+      return;
+    }
+
+    if (pc.signalingState === 'closed') {
+      logger.warn('[IceRestart] Signaling state is closed — aborting');
+      return;
+    }
+
+    this._iceRestartAttempts++;
+    logger.info(
+      `[IceRestart] Executing ICE restart (attempt ${this._iceRestartAttempts})`
+    );
+
+    try {
+      // Reset trickle state for the new gathering cycle
+      this._resetTrickleIceCandidateState();
+
+      // Create new offer with ICE restart flag
+      // This generates new ICE ufrag/pwd, triggering fresh candidate gathering
+      const offer = await pc.createOffer({
+        iceRestart: true,
+        offerToReceiveAudio: true,
+        offerToReceiveVideo: !!this.options.video,
+      });
+
+      await pc.setLocalDescription(offer);
+
+      logger.info('[IceRestart] New offer created, sending to server');
+
+      // Send the new offer through the signaling channel
+      // Uses the same path as initial trickle ICE negotiation
+      const tmpParams = {
+        sessid: this.session.sessionid,
+        sdp: offer.sdp,
+        dialogParams: this.options,
+        trickle: true,
+        iceRestart: true,
+        'User-Agent': `Web-${SDK_VERSION}`,
+      };
+
+      const msg = new Invite(tmpParams);
+      if (this.nodeId) {
+        msg.targetNodeId = this.nodeId;
+      }
+
+      const response = await this.session.execute(msg);
+      const { node_id = null } = response;
+      this._targetNodeId = node_id;
+
+      logger.info('[IceRestart] Server accepted ICE restart offer');
+    } catch (error) {
+      logger.error('[IceRestart] Failed:', error);
+    }
+  }
+
   private _flushPendingTrickleIceCandidates() {
     if (!this._pendingIceCandidates.length) {
       return;
@@ -1657,6 +1804,21 @@ export default abstract class BaseCall implements IWebRTCCall {
         this.peer.statsReporter.reportIceCandidateError(details);
       }
     };
+
+    // ICE restart on connection failure — inspired by Jitsi's IceFailedHandling.
+    // When the connection fails, wait a grace period for transient recovery,
+    // then trigger ICE restart with new offer/answer exchange.
+    instance.addEventListener('connectionstatechange', () => {
+      const state = instance.connectionState;
+
+      if (state === 'failed') {
+        this._scheduleIceRestart();
+      } else if (state === 'connected') {
+        // Connection recovered — cancel pending restart and reset attempts
+        this._cancelIceRestart();
+        this._iceRestartAttempts = 0;
+      }
+    });
 
     // addstream and MediaStreamEvent are deprecated
     //@ts-expect-error MediaStreamEvent is not defined
@@ -1814,6 +1976,7 @@ export default abstract class BaseCall implements IWebRTCCall {
 
   protected _finalize() {
     this._stopStats();
+    this._cancelIceRestart();
 
     logger.debug(`[${this.id}] Closing peer from _finalize`);
     this.peer?.close();

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -225,6 +225,7 @@ export default abstract class BaseCall implements IWebRTCCall {
         debug: options.debug,
         debugOutput: options.debugOutput,
         trickleIce: options.trickleIce,
+        iceRestartGraceMs: options.iceRestartGraceMs,
         prefetchIceCandidates: options.prefetchIceCandidates,
         forceRelayCandidate: options.forceRelayCandidate,
         keepConnectionAliveOnSocketClose:
@@ -1609,31 +1610,38 @@ export default abstract class BaseCall implements IWebRTCCall {
   private static readonly ICE_RESTART_MAX_ATTEMPTS = 3;
 
   /**
-   * Grace period (ms) after ICE failure before triggering restart.
+   * Default grace period (ms) after ICE failure before triggering restart.
    * Gives time for transient recovery (e.g., network flap).
-   * Jitsi uses 2000ms after XMPP ping; we use 2000ms after state change.
+   * Can be overridden via `iceRestartGraceMs` option.
    */
-  private static readonly ICE_RESTART_GRACE_MS = 2000;
+  private static readonly ICE_RESTART_DEFAULT_GRACE_MS = 2000;
 
   /**
    * Attempt ICE restart when the connection fails.
    *
    * Flow (follows Jitsi's IceFailedHandling pattern):
    * 1. connectionState → 'failed' detected
-   * 2. Wait ICE_RESTART_GRACE_MS for transient recovery
+   * 2. Wait grace period for transient recovery
    * 3. If still failed, create new offer with { iceRestart: true }
-   * 4. Send via telnyx_rtc.invite (trickle) or full SDP re-invite
+   * 4. Send via telnyx_rtc.invite (trickle)
    * 5. Remote answers, setRemoteDescription completes the restart
    *
-   * Only works for trickle ICE (the non-trickle path gathers all
-   * candidates before sending — ICE restart there would need a full
-   * re-invite which the B2BUA doesn't currently support).
+   * Limitations:
+   * - Only works for outbound trickle ICE calls. ICE restart creates a
+   *   new offer, which requires the SDK to be the offerer (outbound).
+   *   Inbound calls have the SDK as the answerer, and we don't have
+   *   perfect negotiation (role switch) implemented yet.
    *
    * @see https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/restartIce
    */
   private _scheduleIceRestart(): void {
     if (!this.options.trickleIce) {
       logger.debug('[IceRestart] Skipping — not in trickle ICE mode');
+      return;
+    }
+
+    if (this.direction !== Direction.Outbound) {
+      logger.debug('[IceRestart] Skipping — only supported for outbound calls (no perfect negotiation)');
       return;
     }
 
@@ -1649,15 +1657,17 @@ export default abstract class BaseCall implements IWebRTCCall {
       return;
     }
 
+    const graceMs = this.options.iceRestartGraceMs ?? BaseCall.ICE_RESTART_DEFAULT_GRACE_MS;
+
     logger.info(
-      `[IceRestart] Scheduling restart in ${BaseCall.ICE_RESTART_GRACE_MS}ms ` +
+      `[IceRestart] Scheduling restart in ${graceMs}ms ` +
         `(attempt ${this._iceRestartAttempts + 1}/${BaseCall.ICE_RESTART_MAX_ATTEMPTS})`
     );
 
     this._iceRestartTimer = setTimeout(() => {
       this._iceRestartTimer = null;
       this._executeIceRestart();
-    }, BaseCall.ICE_RESTART_GRACE_MS);
+    }, graceMs);
   }
 
   /**

--- a/packages/js/src/Modules/Verto/webrtc/interfaces.ts
+++ b/packages/js/src/Modules/Verto/webrtc/interfaces.ts
@@ -81,6 +81,16 @@ export interface IVertoCallOptions {
   prefetchIceCandidates?: boolean;
   forceRelayCandidate?: boolean;
   trickleIce?: boolean;
+  /**
+   * Grace period in milliseconds before triggering ICE restart after
+   * connection failure. Allows transient failures to recover without
+   * unnecessary restart cycles.
+   *
+   * Only effective when `trickleIce` is true and call is outbound.
+   *
+   * @default 2000
+   */
+  iceRestartGraceMs?: number;
   // Depricated: use only IVertoOptions.keepConnectionAliveOnSocketClose
   keepConnectionAliveOnSocketClose?: boolean;
   mutedMicOnStart?: boolean;


### PR DESCRIPTION
## Problem

When ICE/DTLS fails during a trickle ICE call (e.g., NAT rebinding, transient network loss, multi-NIC nomination mismatch), the call has zero audio with no recovery mechanism. The existing ICE restart code was commented out in PR #492 by Artem with a FIXME because the SDP exchange after `restartIce()` was never properly implemented.

### History of the FIXME

1. **Oct 2024 (PR #383)** — Haythem added bare `restartIce()` + `onNetworkClose()`. The `restartIce()` was a no-op: it only sets a flag, doesnt create a new offer or exchange SDP.
2. **Dec 2025 (PRs #478+)** — Multiple attempts to make it work with sleep detection and guards, but `startNegotiation()` created a regular offer instead of an ICE restart offer, so fresh credentials were never used.
3. **Jan 5 2026** — `_createIceRestartOffer()` added with proper `createOffer({ iceRestart: true })`, but it raced with the attach/reconnect flow causing conflicts.
4. **Jan 6 2026** — Reverted to bare `restartIce()` to avoid race conditions with attach.
5. **Feb 2 2026 (PR #492)** — Artem commented it out entirely: *"Restart ICE is not working since we do not handle SDP exchange after ICE restart."*

## Solution

Implements ICE restart on connection failure, following [Jitsi's `IceFailedHandling` pattern](https://github.com/jitsi/lib-jitsi-meet/blob/master/modules/connectivity/IceFailedHandling.ts):

1. `connectionState` transitions to `failed`
2. Wait configurable grace period (`iceRestartGraceMs`, default 2000ms) for transient recovery
3. If still failed, create new offer with `{ iceRestart: true }` (generates fresh `ufrag`/`pwd`)
4. Send via `telnyx_rtc.invite` with `trickle: true, iceRestart: true`
5. Server answers, `setRemoteDescription` completes the restart
6. New ICE candidates are gathered and trickled normally

### Why this avoids the old problems

The previous implementation lived in `Peer.ts` and raced with the WebSocket reconnect/attach flow. This implementation:
- Lives in **BaseCall** with direct access to `session.execute`
- Only triggers on **outbound trickle ICE calls** — no conflict with attach flow
- Has a **grace period** — no race with initial connection establishment
- Sends a fresh `telnyx_rtc.invite` with `iceRestart: true` — server knows it's a restart, not a new call

### Limitations

- **Outbound calls only.** ICE restart creates a new offer, requiring the SDK to be the offerer. Inbound calls have the SDK as answerer, and we don't have perfect negotiation (role switch) yet. When perfect negotiation is implemented, this can be extended to inbound calls.

### Configuration

```js
new TelnyxRTC({
  trickleIce: true,
  iceRestartGraceMs: 3000, // optional, default 2000ms
})
```

### Safety guards
- Configurable grace period (default 2000ms) for transient recovery
- Max 3 attempts before giving up
- Cancel on connection recovery (resets attempt counter)
- Skip if signaling state closed
- Skip if inbound call (no perfect negotiation)
- Timer cleanup on call teardown

## Changes

| File | Description |
|---|---|
| `BaseCall.ts` | `_scheduleIceRestart`, `_cancelIceRestart`, `_executeIceRestart`; outbound guard; configurable grace; wired into trickle ICE `connectionstatechange`; cleanup in `_finalize` |
| `interfaces.ts` (webrtc) | Added `iceRestartGraceMs` option |
| `interfaces.ts` (util) | Added `iceRestartGraceMs` option |
| `Call.ice-restart.test.ts` | 15 unit tests |

## Testing

- 15 new tests (scheduling, outbound guard, inbound skip, execution, cancellation, error handling, cleanup)
- All 222 tests pass
- TypeScript compiles clean