### PR TITLE
ENGDESK-49799: media permissions recovery for inbound calls

### DIFF
--- a/packages/js/docs/error-handling.md
+++ b/packages/js/docs/error-handling.md
@@ -1004,7 +1004,7 @@ By following these best practices and understanding the error handling mechanism
 
 ## Structured Error Events (telnyx.error)
 
-Starting with this release, all call-related errors are surfaced via a single `telnyx.error` (`SwEvent.Error`) event carrying a `TelnyxError` instance. This replaces the previous pattern of individual `telnyx.rtc.*` events and notification-based error dispatch.
+Starting with this release, all call-related errors are surfaced via a single `telnyx.error` (`SwEvent.Error`) event carrying a structured payload. The payload always includes a `TelnyxError` instance under `event.error`. Some media-permission recovery flows also include recovery-specific fields such as `recoverable`, `retryDeadline`, `resume()`, and `reject()`.
 
 ### TelnyxError Interface
 
@@ -1012,7 +1012,7 @@ Every error emitted through `telnyx.error` implements the `ITelnyxError` interfa
 
 ```ts
 interface ITelnyxError {
-  code: number; // Numeric error code (e.g. 40001)
+  code: SdkErrorCode; // Numeric SDK error code (e.g. 40001)
   name: string; // Machine-readable name in UPPER_SNAKE_CASE (e.g. 'SDP_CREATE_OFFER_FAILED')
   description: string; // Full explanation of the error — what happened and why
   message: string; // Short human-readable message for UI alerts
@@ -1021,6 +1021,35 @@ interface ITelnyxError {
   originalError?: unknown; // The underlying error, if any
 }
 ```
+
+### telnyx.error Event Payload Types
+
+The callback passed to `client.on('telnyx.error', ...)` now receives a typed union:
+
+```ts
+interface ITelnyxStandardErrorEvent {
+  error: ITelnyxError;
+  sessionId: string;
+  callId?: string;
+  recoverable?: false;
+}
+
+interface ITelnyxMediaRecoveryErrorEvent {
+  error: ITelnyxMediaError;
+  sessionId: string;
+  callId: string;
+  recoverable: true;
+  retryDeadline: number;
+  resume: () => void;
+  reject: () => void;
+}
+
+type ITelnyxErrorEvent =
+  | ITelnyxStandardErrorEvent
+  | ITelnyxMediaRecoveryErrorEvent;
+```
+
+`ITelnyxMediaRecoveryErrorEvent` is used when an inbound call fails its initial `getUserMedia()` attempt and `mediaPermissionsRecovery` is enabled. TypeScript can narrow to this branch by checking `event.recoverable` or by using `isMediaRecoveryErrorEvent(event)`.
 
 ### Error Code Reference
 
@@ -1094,7 +1123,12 @@ interface ITelnyxWarning {
 ### Listening for Structured Errors
 
 ```ts
-import { TelnyxRTC, TelnyxError, SwEvent } from '@telnyx/webrtc';
+import {
+  TelnyxRTC,
+  TelnyxError,
+  SwEvent,
+  isMediaRecoveryErrorEvent,
+} from '@telnyx/webrtc';
 
 const client = new TelnyxRTC({
   /* credentials */
@@ -1102,6 +1136,15 @@ const client = new TelnyxRTC({
 
 client.on(SwEvent.Error, (event) => {
   const { error, callId, sessionId } = event;
+
+  if (isMediaRecoveryErrorEvent(event)) {
+    console.log('Recover by:', new Date(event.retryDeadline).toISOString());
+    showPermissionDialog({
+      onContinue: () => event.resume(),
+      onCancel: () => event.reject(),
+    });
+    return;
+  }
 
   if (error instanceof TelnyxError) {
     // error.message is a short UI-friendly string
@@ -1139,10 +1182,19 @@ client.on('telnyx.rtc.peerConnectionFailureError', (error) => {
 
 ```ts
 // Listen for errors
-client.on('telnyx.error', ({ error, callId }) => {
-  if (error.code === 42003) {
-    // Media error — show user-friendly message
-    alert(error.message);
+client.on('telnyx.error', (event) => {
+  if (event.recoverable) {
+    // Inbound media recovery flow: TS exposes resume(), reject(), and retryDeadline
+    openPermissionsModal({
+      onRetry: () => event.resume(),
+      onCancel: () => event.reject(),
+    });
+    return;
+  }
+
+  if (event.error.code === 42003) {
+    // Final media failure — show user-friendly message
+    alert(event.error.message);
   }
 });
 
@@ -1164,14 +1216,14 @@ The following events are **deprecated** and will be removed in a future major ve
 | `telnyx.rtc.mediaError`                         | `telnyx.error` with code 42001 / 42002 / 42003 |
 | `telnyx.rtc.peerConnectionFailureError`         | `telnyx.warning` with code 33004                 |
 | `telnyx.rtc.peerConnectionSignalingStateClosed` | `telnyx.error` (future)                        |
-| `NOTIFICATION_TYPE.userMediaError`              | `telnyx.error` with code 42003                 |
+| `NOTIFICATION_TYPE.userMediaError`              | `telnyx.error` with media error codes; inspect `recoverable` for inbound recovery flows |
 | `NOTIFICATION_TYPE.peerConnectionFailureError`  | `telnyx.warning` with code 33004                 |
 
 During the transition period, both the deprecated events **and** the new `telnyx.error` event are emitted for backward compatibility.
 
 ## Migration Guide
 
-1. **Add a `telnyx.error` listener** using `client.on('telnyx.error', handler)` for unrecoverable errors.
+1. **Add a `telnyx.error` listener** using `client.on('telnyx.error', handler)` for structured errors and inbound media recovery prompts.
 2. **Add a `telnyx.warning` listener** using `client.on('telnyx.warning', handler)` for degraded conditions (ICE issues, quality drops, token expiry).
 3. **Switch on `code`** instead of listening to multiple separate events — errors use `error.code`, warnings use `warning.code`.
 4. **Remove deprecated listeners** (`telnyx.rtc.mediaError`, `telnyx.rtc.peerConnectionFailureError`, etc.) once you've migrated.
@@ -1181,10 +1233,20 @@ During the transition period, both the deprecated events **and** the new `telnyx
 **Example — handling both errors and warnings:**
 
 ```ts
-// Errors: unrecoverable failures (call dropped, media denied, etc.)
-client.on('telnyx.error', ({ error, callId }) => {
-  console.error(`[${error.code}] ${error.name}: ${error.message}`);
-  showErrorAlert(error.message);
+// Errors: recoverable inbound media prompts or unrecoverable failures
+client.on('telnyx.error', (event) => {
+  if (event.recoverable) {
+    promptForPermissions({
+      onRetry: () => event.resume(),
+      onCancel: () => event.reject(),
+    });
+    return;
+  }
+
+  console.error(
+    `[${event.error.code}] ${event.error.name}: ${event.error.message}`
+  );
+  showErrorAlert(event.error.message);
 });
 
 // Warnings: degraded but recoverable conditions

--- a/packages/js/src/Modules/Verto/BaseSession.ts
+++ b/packages/js/src/Modules/Verto/BaseSession.ts
@@ -17,6 +17,7 @@ import {
   TOKEN_EXPIRING_SOON,
 } from './util/constants';
 import { createTelnyxError, createTelnyxWarning } from './util/errors';
+import type { ITelnyxErrorEvent } from './util/errors';
 import {
   isFunction,
   isValidAnonymousLoginOptions,
@@ -28,12 +29,14 @@ import {
   ILoginParams,
   IVertoOptions,
 } from './util/interfaces';
+import type { INotification } from '../../utils/interfaces';
 import logger, { setConsoleLoggerMinLevel } from './util/logger';
 import { getReconnectToken } from './util/reconnect';
 import { Ping } from './messages/verto/Ping';
 import { Login } from './messages/Verto';
 import { AnonymousLogin } from './messages/verto/AnonymousLogin';
 import { ERROR_TYPE } from './webrtc/constants';
+import type { ITelnyxWarningEvent } from './util/constants/warnings';
 
 /**
  * b2bua-rtc ping interval is 30 seconds, timeout in VSP is 60 seconds.
@@ -240,6 +243,20 @@ export default abstract class BaseSession {
    * })
    * ```
    */
+  on(
+    eventName: SwEvent.Error | 'telnyx.error',
+    callback: (event: ITelnyxErrorEvent) => void
+  ): this;
+  on(
+    eventName: SwEvent.Warning | 'telnyx.warning',
+    callback: (event: ITelnyxWarningEvent) => void
+  ): this;
+  on(
+    eventName: SwEvent.Notification | 'telnyx.notification',
+    callback: (event: INotification) => void
+  ): this;
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+  on(eventName: string, callback: Function): this;
   // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
   on(eventName: string, callback: Function) {
     register(eventName, callback, this.uuid);
@@ -275,6 +292,20 @@ export default abstract class BaseSession {
    * client.off('telnyx.error', errorHandler)
    * ```
    */
+  off(
+    eventName: SwEvent.Error | 'telnyx.error',
+    callback?: (event: ITelnyxErrorEvent) => void
+  ): this;
+  off(
+    eventName: SwEvent.Warning | 'telnyx.warning',
+    callback?: (event: ITelnyxWarningEvent) => void
+  ): this;
+  off(
+    eventName: SwEvent.Notification | 'telnyx.notification',
+    callback?: (event: INotification) => void
+  ): this;
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+  off(eventName: string, callback?: Function): this;
   // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
   off(eventName: string, callback?: Function) {
     deRegister(eventName, callback, this.uuid);

--- a/packages/js/src/Modules/Verto/util/constants/errorCodes.ts
+++ b/packages/js/src/Modules/Verto/util/constants/errorCodes.ts
@@ -43,6 +43,9 @@ export const AUTHENTICATION_REQUIRED: SdkErrorCode = 46003;
 // ── Network errors (480xx) ──────────────────────────────────────────
 export const NETWORK_OFFLINE: SdkErrorCode = 48001;
 
+// ── General / catch-all errors (490xx) ──────────────────────────────
+export const UNEXPECTED_ERROR: SdkErrorCode = 49001;
+
 // ── Network quality warnings (310xx) ────────────────────────────────
 export const HIGH_RTT: SdkWarningCode = 31001;
 export const HIGH_JITTER: SdkWarningCode = 31002;

--- a/packages/js/src/Modules/Verto/util/constants/errors.ts
+++ b/packages/js/src/Modules/Verto/util/constants/errors.ts
@@ -281,6 +281,18 @@ export const SDK_ERRORS = {
       'Disable airplane mode',
     ],
   },
+  // ── General / catch-all errors (490xx) ──────────────────────────────
+  49001: {
+    name: 'UNEXPECTED_ERROR',
+    message: 'An unexpected error occurred',
+    description:
+      'An error was thrown that does not match any known SDK error category. This is a catch-all for unclassified failures.',
+    causes: ['Unknown or unhandled error condition'],
+    solutions: [
+      'Check the originalError property for the underlying cause',
+      'Report the issue if it persists',
+    ],
+  },
 } as const;
 
 export type SdkErrorCode = keyof typeof SDK_ERRORS;

--- a/packages/js/src/Modules/Verto/util/constants/warnings.ts
+++ b/packages/js/src/Modules/Verto/util/constants/warnings.ts
@@ -29,6 +29,15 @@ export interface ITelnyxWarning {
   solutions: string[];
 }
 
+export interface ITelnyxWarningEvent {
+  /** Structured SDK warning */
+  warning: ITelnyxWarning;
+  /** Current SDK session identifier */
+  sessionId: string;
+  /** Call identifier when the warning is associated with a call */
+  callId?: string;
+}
+
 export const SDK_WARNINGS = {
   // ── Network quality warnings (310xx) ────────────────────────────────
   31001: {

--- a/packages/js/src/Modules/Verto/util/errors.ts
+++ b/packages/js/src/Modules/Verto/util/errors.ts
@@ -24,9 +24,14 @@ import {
 export { SDK_ERRORS, SdkErrorCode };
 export { SDK_WARNINGS, SdkWarningCode, ITelnyxWarning, createTelnyxWarning };
 
+export type TelnyxMediaErrorCode =
+  | typeof MEDIA_MICROPHONE_PERMISSION_DENIED
+  | typeof MEDIA_DEVICE_NOT_FOUND
+  | typeof MEDIA_GET_USER_MEDIA_FAILED;
+
 export interface ITelnyxError {
   /** Numeric error code (e.g. 40001) */
-  code: number;
+  code: SdkErrorCode;
   /** Machine-readable error name in UPPER_SNAKE_CASE (e.g. 'SDP_CREATE_OFFER_FAILED') */
   name: string;
   /** Full explanation of the error — what happened and why */
@@ -41,8 +46,45 @@ export interface ITelnyxError {
   originalError?: unknown;
 }
 
+export interface ITelnyxMediaError extends Omit<ITelnyxError, 'code'> {
+  /** Media-layer error code (420xx) */
+  code: TelnyxMediaErrorCode;
+}
+
+export interface ITelnyxStandardErrorEvent {
+  /** Structured SDK error */
+  error: ITelnyxError;
+  /** Current SDK session identifier */
+  sessionId: string;
+  /** Call identifier when the error is associated with a call */
+  callId?: string;
+  /** Non-recoverable errors omit recovery helpers */
+  recoverable?: false;
+}
+
+export interface ITelnyxMediaRecoveryErrorEvent {
+  /** Structured media error for the failed initial getUserMedia attempt */
+  error: ITelnyxMediaError;
+  /** Current SDK session identifier */
+  sessionId: string;
+  /** Inbound call being recovered */
+  callId: string;
+  /** Indicates that the app can still recover by resuming the flow */
+  recoverable: true;
+  /** Epoch timestamp in ms after which the SDK will stop waiting */
+  retryDeadline: number;
+  /** Retry media acquisition after the app resolves permissions */
+  resume: () => void;
+  /** Abort recovery and let the call fail immediately */
+  reject: () => void;
+}
+
+export type ITelnyxErrorEvent =
+  | ITelnyxStandardErrorEvent
+  | ITelnyxMediaRecoveryErrorEvent;
+
 export class TelnyxError extends Error implements ITelnyxError {
-  public readonly code: number;
+  public readonly code: SdkErrorCode;
   public readonly description: string;
   public readonly causes: string[];
   public readonly solutions: string[];
@@ -74,6 +116,12 @@ export class TelnyxError extends Error implements ITelnyxError {
       originalError: this.originalError,
     };
   }
+}
+
+export function isMediaRecoveryErrorEvent(
+  event: ITelnyxErrorEvent
+): event is ITelnyxMediaRecoveryErrorEvent {
+  return event.recoverable === true;
 }
 
 /**

--- a/packages/js/src/Modules/Verto/util/interfaces.ts
+++ b/packages/js/src/Modules/Verto/util/interfaces.ts
@@ -74,6 +74,23 @@ export interface IVertoOptions {
    * @default 1000
    */
   debugLogMaxEntries?: number;
+  /**
+   * Configuration for media permissions recovery on inbound calls.
+   * When enabled and `getUserMedia` fails during an inbound call,
+   * the SDK will emit a `userMediaError` notification with a `resume()`
+   * callback, allowing the app to prompt the user to fix permissions
+   * and then retry media acquisition.
+   */
+  mediaPermissionsRecovery?: {
+    /** Enable the recovery flow. */
+    enabled: boolean;
+    /** Maximum time in ms to wait for the app to call `resume()`. Recommended max 25000. */
+    timeout: number;
+    /** Called when the retry `getUserMedia` succeeds after `resume()`. */
+    onSuccess?: () => void;
+    /** Called when the retry `getUserMedia` fails or the timeout expires. */
+    onError?: (error: Error) => void;
+  };
 }
 export interface ILoginParams {
   login?: string;

--- a/packages/js/src/Modules/Verto/util/interfaces.ts
+++ b/packages/js/src/Modules/Verto/util/interfaces.ts
@@ -76,19 +76,19 @@ export interface IVertoOptions {
   debugLogMaxEntries?: number;
   /**
    * Configuration for media permissions recovery on inbound calls.
-   * When enabled and `getUserMedia` fails during an inbound call,
-   * the SDK will emit a `userMediaError` notification with a `resume()`
-   * callback, allowing the app to prompt the user to fix permissions
-   * and then retry media acquisition.
+   * When enabled and the initial `getUserMedia` call fails while answering,
+   * the SDK emits a recoverable `telnyx.error` event with `resume()` and
+   * `reject()` callbacks so the app can prompt the user to fix permissions
+   * before the call fails.
    */
   mediaPermissionsRecovery?: {
     /** Enable the recovery flow. */
     enabled: boolean;
-    /** Maximum time in ms to wait for the app to call `resume()`. Recommended max 25000. */
+    /** Maximum time in ms to wait for the app to call `resume()` or `reject()`. Recommended max 25000. */
     timeout: number;
     /** Called when the retry `getUserMedia` succeeds after `resume()`. */
     onSuccess?: () => void;
-    /** Called when the retry `getUserMedia` fails or the timeout expires. */
+    /** Called when retry fails, the timeout expires, or the app calls `reject()`. */
     onError?: (error: Error) => void;
   };
 }

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -389,6 +389,23 @@ export default abstract class BaseCall implements IWebRTCCall {
     } catch (error) {
       logger.error('Peer init failed, aborting call', error);
       this._creatingPeer = false;
+      const telnyxError =
+        error instanceof TelnyxError
+          ? error
+          : createTelnyxError(
+              classifyMediaErrorCode(error),
+              error instanceof Error ? error : undefined
+            );
+      trigger(
+        SwEvent.Error,
+        {
+          error: telnyxError,
+          callId: this.id,
+          sessionId: this.session.sessionid,
+          recoverable: false,
+        },
+        this.session.uuid
+      );
       void this.hangup({}, false);
       return;
     }
@@ -435,6 +452,23 @@ export default abstract class BaseCall implements IWebRTCCall {
     } catch (error) {
       logger.error('Peer init failed, aborting call', error);
       this._creatingPeer = false;
+      const telnyxError =
+        error instanceof TelnyxError
+          ? error
+          : createTelnyxError(
+              classifyMediaErrorCode(error),
+              error instanceof Error ? error : undefined
+            );
+      trigger(
+        SwEvent.Error,
+        {
+          error: telnyxError,
+          callId: this.id,
+          sessionId: this.session.sessionid,
+          recoverable: false,
+        },
+        this.session.uuid
+      );
       await this.hangup();
       return;
     }

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -24,6 +24,7 @@ import {
   SDP_SEND_FAILED,
   ONLY_HOST_ICE_CANDIDATES,
   HAS_NON_HOST_ICE_CANDIDATE_REGEX,
+  UNEXPECTED_ERROR,
 } from '../util/constants';
 import {
   classifyMediaErrorCode,
@@ -393,7 +394,7 @@ export default abstract class BaseCall implements IWebRTCCall {
         error instanceof TelnyxError
           ? error
           : createTelnyxError(
-              classifyMediaErrorCode(error),
+              UNEXPECTED_ERROR,
               error instanceof Error ? error : undefined
             );
       trigger(
@@ -456,7 +457,7 @@ export default abstract class BaseCall implements IWebRTCCall {
         error instanceof TelnyxError
           ? error
           : createTelnyxError(
-              classifyMediaErrorCode(error),
+              UNEXPECTED_ERROR,
               error instanceof Error ? error : undefined
             );
       trigger(

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -543,7 +543,7 @@ export default abstract class BaseCall implements IWebRTCCall {
             this.session.uuid
           );
         })
-        .finally(_close.bind(this));
+        .then(_close.bind(this));
     } else {
       _close();
     }

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -1727,7 +1727,7 @@ export default abstract class BaseCall implements IWebRTCCall {
       errorMessage,
     });
     logger.error(`Media error (${errorName}): ${errorMessage}`, error);
-    this.hangup({}, false);
+    this.hangup();
   }
 
   private _onPeerConnectionFailureError(error: any) {

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -543,7 +543,7 @@ export default abstract class BaseCall implements IWebRTCCall {
             this.session.uuid
           );
         })
-        .then(_close.bind(this));
+        .finally(_close.bind(this));
     } else {
       _close();
     }

--- a/packages/js/src/Modules/Verto/webrtc/Peer.ts
+++ b/packages/js/src/Modules/Verto/webrtc/Peer.ts
@@ -412,12 +412,14 @@ export default class Peer {
 
         if (recovery?.enabled && this._isAnswer()) {
           let recoveredStream: MediaStream | null = null;
+          let safetyTimeout: ReturnType<typeof setTimeout> | null = null;
 
           await new Promise<void>((resolve, reject) => {
-            const timer = setTimeout(
-              () => reject(new Error('mediaPermissionsTimeout')),
+            safetyTimeout = setTimeout(
+              () => reject(new Error('Media recovery flow timed out!')),
               recovery.timeout
             );
+
             trigger(
               SwEvent.Error,
               {
@@ -427,18 +429,32 @@ export default class Peer {
                 recoverable: true,
                 retryDeadline: Date.now() + recovery.timeout,
                 resume: () => {
-                  clearTimeout(timer);
                   resolve();
+                },
+                reject: () => {
+                  reject(
+                    new Error('Call was rejected during media recovery flow!')
+                  );
                 },
               },
               this._session.uuid
             );
           })
             .then(async () => {
+              if (safetyTimeout) {
+                clearTimeout(safetyTimeout);
+                safetyTimeout = null;
+              }
+
               recoveredStream = await this._retrieveLocalStream();
               recovery.onSuccess?.();
             })
             .catch((recoveryError) => {
+              if (safetyTimeout) {
+                clearTimeout(safetyTimeout);
+                safetyTimeout = null;
+              }
+
               capturedMediaError = recoveryError;
               recovery.onError?.(recoveryError);
             });

--- a/packages/js/src/Modules/Verto/webrtc/Peer.ts
+++ b/packages/js/src/Modules/Verto/webrtc/Peer.ts
@@ -418,26 +418,18 @@ export default class Peer {
               () => reject(new Error('mediaPermissionsTimeout')),
               recovery.timeout
             );
-
-            const retryDeadline = Date.now() + recovery.timeout;
-            const resume = () => {
-              clearTimeout(timer);
-              resolve();
-            };
-
-            const recoverableError = createTelnyxError(
-              classifyMediaErrorCode(error),
-              error
-            );
             trigger(
               SwEvent.Error,
               {
-                error: recoverableError,
+                error: createTelnyxError(classifyMediaErrorCode(error), error),
                 callId: this.options.id,
                 sessionId: this._session.sessionid,
                 recoverable: true,
-                retryDeadline,
-                resume,
+                retryDeadline: Date.now() + recovery.timeout,
+                resume: () => {
+                  clearTimeout(timer);
+                  resolve();
+                },
               },
               this._session.uuid
             );
@@ -458,15 +450,6 @@ export default class Peer {
         return null;
       }
     );
-    performance.mark('get-user-media');
-
-    if (
-      this.options.mutedMicOnStart &&
-      streamIsValid(this.options.localStream)
-    ) {
-      logger.info('Muting local audio tracks on start');
-      disableAudioTracks(this.options.localStream);
-    }
 
     if (!this.options.localStream && !isReceiveOnly) {
       const telnyxError = createTelnyxError(
@@ -476,6 +459,16 @@ export default class Peer {
         capturedMediaError ?? undefined
       );
       throw telnyxError;
+    }
+
+    performance.mark('get-user-media');
+
+    if (
+      this.options.mutedMicOnStart &&
+      streamIsValid(this.options.localStream)
+    ) {
+      logger.info('Muting local audio tracks on start');
+      disableAudioTracks(this.options.localStream);
     }
 
     performance.mark('peer-creation-end');

--- a/packages/js/src/Modules/Verto/webrtc/Peer.ts
+++ b/packages/js/src/Modules/Verto/webrtc/Peer.ts
@@ -419,17 +419,39 @@ export default class Peer {
               recovery.timeout
             );
 
+            const retryDeadline = Date.now() + recovery.timeout;
+            const resume = () => {
+              clearTimeout(timer);
+              resolve();
+            };
+
+            // Emit structured Error event with recoverable:true so apps using
+            // the new error-event API also get a signal that recovery is available.
+            const recoverableError = createTelnyxError(
+              classifyMediaErrorCode(error),
+              error
+            );
+            trigger(
+              SwEvent.Error,
+              {
+                error: recoverableError,
+                callId: this.options.id,
+                sessionId: this._session.sessionid,
+                recoverable: true,
+                retryDeadline,
+                resume,
+              },
+              this._session.uuid
+            );
+
             trigger(
               SwEvent.Notification,
               {
                 type: NOTIFICATION_TYPE.userMediaError,
                 error,
                 call: this._session.calls[this.options.id],
-                retryDeadline: Date.now() + recovery.timeout,
-                resume: () => {
-                  clearTimeout(timer);
-                  resolve();
-                },
+                retryDeadline,
+                resume,
               },
               this._session.uuid
             );
@@ -469,7 +491,10 @@ export default class Peer {
           : MEDIA_GET_USER_MEDIA_FAILED,
         capturedMediaError ?? undefined
       );
-      trigger(SwEvent.MediaError, telnyxError, this.options.id);
+      // Do NOT trigger SwEvent.MediaError here — that would invoke _onMediaError
+      // which calls hangup({}, false) before the throw reaches BaseCall, causing
+      // a double-hangup (local teardown first, then BYE attempt on a dead call).
+      // BaseCall.invite()/answer() catch blocks own error reporting and hangup.
       throw telnyxError;
     }
 

--- a/packages/js/src/Modules/Verto/webrtc/Peer.ts
+++ b/packages/js/src/Modules/Verto/webrtc/Peer.ts
@@ -37,7 +37,7 @@ import {
   streamIsValid,
   videoIsMediaTrackConstraints,
 } from '../util/webrtc';
-import { NOTIFICATION_TYPE, PeerType } from './constants';
+import { PeerType } from './constants';
 import {
   disableAudioTracks,
   getMediaConstraints,
@@ -425,8 +425,6 @@ export default class Peer {
               resolve();
             };
 
-            // Emit structured Error event with recoverable:true so apps using
-            // the new error-event API also get a signal that recovery is available.
             const recoverableError = createTelnyxError(
               classifyMediaErrorCode(error),
               error
@@ -438,18 +436,6 @@ export default class Peer {
                 callId: this.options.id,
                 sessionId: this._session.sessionid,
                 recoverable: true,
-                retryDeadline,
-                resume,
-              },
-              this._session.uuid
-            );
-
-            trigger(
-              SwEvent.Notification,
-              {
-                type: NOTIFICATION_TYPE.userMediaError,
-                error,
-                call: this._session.calls[this.options.id],
                 retryDeadline,
                 resume,
               },
@@ -468,8 +454,6 @@ export default class Peer {
           return recoveredStream;
         }
 
-        // Non-recovery path: save the raw error and return null.
-        // MediaError is triggered below after localStream assignment so it fires exactly once.
         capturedMediaError = error;
         return null;
       }
@@ -491,10 +475,6 @@ export default class Peer {
           : MEDIA_GET_USER_MEDIA_FAILED,
         capturedMediaError ?? undefined
       );
-      // Do NOT trigger SwEvent.MediaError here — that would invoke _onMediaError
-      // which calls hangup({}, false) before the throw reaches BaseCall, causing
-      // a double-hangup (local teardown first, then BYE attempt on a dead call).
-      // BaseCall.invite()/answer() catch blocks own error reporting and hangup.
       throw telnyxError;
     }
 

--- a/packages/js/src/Modules/Verto/webrtc/Peer.ts
+++ b/packages/js/src/Modules/Verto/webrtc/Peer.ts
@@ -404,6 +404,8 @@ export default class Peer {
     const isReceiveOnly =
       Boolean(this.options.receiveOnlyAudio) && !this.options.audio;
 
+    let capturedMediaError: Error | null = null;
+
     this.options.localStream = await this._retrieveLocalStream().catch(
       async (error) => {
         const recovery = this._session.options.mediaPermissionsRecovery;
@@ -437,22 +439,16 @@ export default class Peer {
               recovery.onSuccess?.();
             })
             .catch((recoveryError) => {
+              capturedMediaError = recoveryError;
               recovery.onError?.(recoveryError);
-              // Call hangup directly — _onMediaError would fire a second userMediaError notification
-              // but the app already received one (with resume) above. BaseCall.hangup() with no
-              // args sends BYE for inbound calls (execute defaults to true).
-              this._session.calls[this.options.id]?.hangup();
             });
 
           return recoveredStream;
         }
 
-        // existing path — unchanged
-        const telnyxError = createTelnyxError(
-          classifyMediaErrorCode(error),
-          error
-        );
-        trigger(SwEvent.MediaError, telnyxError, this.options.id);
+        // Non-recovery path: save the raw error and return null.
+        // MediaError is triggered below after localStream assignment so it fires exactly once.
+        capturedMediaError = error;
         return null;
       }
     );
@@ -467,7 +463,12 @@ export default class Peer {
     }
 
     if (!this.options.localStream && !isReceiveOnly) {
-      const telnyxError = createTelnyxError(MEDIA_GET_USER_MEDIA_FAILED);
+      const telnyxError = createTelnyxError(
+        capturedMediaError
+          ? classifyMediaErrorCode(capturedMediaError)
+          : MEDIA_GET_USER_MEDIA_FAILED,
+        capturedMediaError ?? undefined
+      );
       trigger(SwEvent.MediaError, telnyxError, this.options.id);
       throw telnyxError;
     }

--- a/packages/js/src/Modules/Verto/webrtc/Peer.ts
+++ b/packages/js/src/Modules/Verto/webrtc/Peer.ts
@@ -410,7 +410,7 @@ export default class Peer {
                   resolve();
                 },
               },
-              this.options.id
+              this._session.uuid
             );
           })
             .then(async () => {
@@ -419,6 +419,8 @@ export default class Peer {
             })
             .catch((recoveryError) => {
               recovery.onError?.(recoveryError);
+              // Hang up the inbound call with BYE so the remote peer isn't left waiting
+              this._session.calls[this.options.id]?.hangup({}, true);
               trigger(SwEvent.MediaError, recoveryError, this.options.id);
             });
 

--- a/packages/js/src/Modules/Verto/webrtc/Peer.ts
+++ b/packages/js/src/Modules/Verto/webrtc/Peer.ts
@@ -410,6 +410,9 @@ export default class Peer {
       async (error) => {
         const recovery = this._session.options.mediaPermissionsRecovery;
 
+        // Only run recovery for answers. We keep the invite flow simple so the
+        // caller can fix local media issues and start the call again without
+        // requiring extra recovery handling from us.
         if (recovery?.enabled && this._isAnswer()) {
           let recoveredStream: MediaStream | null = null;
           let safetyTimeout: ReturnType<typeof setTimeout> | null = null;

--- a/packages/js/src/Modules/Verto/webrtc/Peer.ts
+++ b/packages/js/src/Modules/Verto/webrtc/Peer.ts
@@ -419,9 +419,10 @@ export default class Peer {
             })
             .catch((recoveryError) => {
               recovery.onError?.(recoveryError);
-              // Hang up the inbound call with BYE so the remote peer isn't left waiting
-              this._session.calls[this.options.id]?.hangup({}, true);
-              trigger(SwEvent.MediaError, recoveryError, this.options.id);
+              // Call hangup directly — _onMediaError would fire a second userMediaError notification
+              // but the app already received one (with resume) above. BaseCall.hangup() with no
+              // args sends BYE for inbound calls (execute defaults to true).
+              this._session.calls[this.options.id]?.hangup();
             });
 
           return recoveredStream;

--- a/packages/js/src/Modules/Verto/webrtc/Peer.ts
+++ b/packages/js/src/Modules/Verto/webrtc/Peer.ts
@@ -16,7 +16,7 @@ import {
   streamIsValid,
   videoIsMediaTrackConstraints,
 } from '../util/webrtc';
-import { PeerType } from './constants';
+import { NOTIFICATION_TYPE, PeerType } from './constants';
 import {
   disableAudioTracks,
   getMediaConstraints,
@@ -386,7 +386,46 @@ export default class Peer {
     }
 
     this.options.localStream = await this._retrieveLocalStream().catch(
-      (error) => {
+      async (error) => {
+        const recovery = this._session.options.mediaPermissionsRecovery;
+
+        if (recovery?.enabled && this._isAnswer()) {
+          let recoveredStream: MediaStream | null = null;
+
+          await new Promise<void>((resolve, reject) => {
+            const timer = setTimeout(
+              () => reject(new Error('mediaPermissionsTimeout')),
+              recovery.timeout
+            );
+
+            trigger(
+              SwEvent.Notification,
+              {
+                type: NOTIFICATION_TYPE.userMediaError,
+                error,
+                call: this._session.calls[this.options.id],
+                retryDeadline: Date.now() + recovery.timeout,
+                resume: () => {
+                  clearTimeout(timer);
+                  resolve();
+                },
+              },
+              this.options.id
+            );
+          })
+            .then(async () => {
+              recoveredStream = await this._retrieveLocalStream();
+              recovery.onSuccess?.();
+            })
+            .catch((recoveryError) => {
+              recovery.onError?.(recoveryError);
+              trigger(SwEvent.MediaError, recoveryError, this.options.id);
+            });
+
+          return recoveredStream;
+        }
+
+        // existing path — unchanged
         trigger(SwEvent.MediaError, error, this.options.id);
         return null;
       }

--- a/packages/js/src/Modules/Verto/webrtc/interfaces.ts
+++ b/packages/js/src/Modules/Verto/webrtc/interfaces.ts
@@ -158,7 +158,7 @@ export interface IWebRTCCall {
   signalingStateClosed: boolean;
   invite: () => void;
   answer: (params: AnswerParams) => void;
-  hangup: (params: IHangupParams, execute: boolean) => void;
+  hangup: (params?: IHangupParams, execute?: boolean) => void;
 
   hold: () => void;
   unhold: () => void;

--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -24,7 +24,21 @@ export {
   ERROR_TYPE,
 };
 
-export type { ITelnyxError } from './Modules/Verto/util/errors';
-export type { ITelnyxWarning } from './Modules/Verto/util/constants/warnings';
+export {
+  TelnyxError,
+  isMediaRecoveryErrorEvent,
+} from './Modules/Verto/util/errors';
+export type {
+  ITelnyxError,
+  ITelnyxMediaError,
+  ITelnyxErrorEvent,
+  ITelnyxMediaRecoveryErrorEvent,
+  ITelnyxStandardErrorEvent,
+  TelnyxMediaErrorCode,
+} from './Modules/Verto/util/errors';
+export type {
+  ITelnyxWarning,
+  ITelnyxWarningEvent,
+} from './Modules/Verto/util/constants/warnings';
 
 export * from './PreCallDiagnosis';

--- a/packages/js/src/utils/interfaces.ts
+++ b/packages/js/src/utils/interfaces.ts
@@ -192,6 +192,8 @@ export interface IClientOptions {
    *
    * @example
    * ```js
+   * import {isMediaRecoveryErrorEvent} from "@telnyx/webrtc"
+   *
    * const client = new TelnyxRTC({
    *   login_token: '...',
    *   mediaPermissionsRecovery: {
@@ -203,7 +205,7 @@ export interface IClientOptions {
    * });
    *
    * client.on('telnyx.error', (event) => {
-   *   if (event.recoverable && event.resume) {
+   *   if (isMediaRecoveryErrorEvent(event)) {
    *     showPermissionDialog({
    *       onContinue: () => event.resume(),
    *       onCancel: () => event.reject?.(),

--- a/packages/js/src/utils/interfaces.ts
+++ b/packages/js/src/utils/interfaces.ts
@@ -177,6 +177,44 @@ export interface IClientOptions {
    * @default 5000 (5 seconds)
    */
   callReportInterval?: number;
+
+  /**
+   * Configuration for media permissions recovery on inbound calls.
+   * When enabled and `getUserMedia` fails during an inbound call,
+   * the SDK will emit a `userMediaError` notification with a `resume()`
+   * callback, allowing the app to prompt the user to fix permissions
+   * and then retry media acquisition.
+   *
+   * @example
+   * ```js
+   * const client = new TelnyxRTC({
+   *   login_token: '...',
+   *   mediaPermissionsRecovery: {
+   *     enabled: true,
+   *     timeout: 20000,
+   *     onSuccess: () => console.log('Media recovered'),
+   *     onError: (err) => console.error('Recovery failed', err),
+   *   },
+   * });
+   *
+   * client.on('telnyx.notification', (notification) => {
+   *   if (notification.type === 'userMediaError') {
+   *     // Show UI to fix permissions, then call resume()
+   *     showPermissionDialog(() => notification.resume());
+   *   }
+   * });
+   * ```
+   */
+  mediaPermissionsRecovery?: {
+    /** Enable the recovery flow. */
+    enabled: boolean;
+    /** Maximum time in ms to wait for the app to call `resume()`. Recommended max 25000. */
+    timeout: number;
+    /** Called when the retry `getUserMedia` succeeds after `resume()`. */
+    onSuccess?: () => void;
+    /** Called when the retry `getUserMedia` fails or the timeout expires. */
+    onError?: (error: Error) => void;
+  };
 }
 
 /**

--- a/packages/js/src/utils/interfaces.ts
+++ b/packages/js/src/utils/interfaces.ts
@@ -180,10 +180,15 @@ export interface IClientOptions {
 
   /**
    * Configuration for media permissions recovery on inbound calls.
-   * When enabled and `getUserMedia` fails during an inbound call,
-   * the SDK will emit a `userMediaError` notification with a `resume()`
-   * callback, allowing the app to prompt the user to fix permissions
-   * and then retry media acquisition.
+   * When enabled and the initial `getUserMedia` call fails while answering,
+   * the SDK emits a recoverable `telnyx.error` event with `resume()` and
+   * `reject()` callbacks so the app can prompt the user to fix permissions
+   * before the call fails.
+   *
+   * Recovery is attempted only for inbound calls. If the app calls
+   * `resume()`, the SDK retries `getUserMedia`. If the app calls `reject()`
+   * or does not respond before `timeout`, recovery fails and the call is
+   * terminated with the usual media error flow.
    *
    * @example
    * ```js
@@ -197,10 +202,12 @@ export interface IClientOptions {
    *   },
    * });
    *
-   * client.on('telnyx.notification', (notification) => {
-   *   if (notification.type === 'userMediaError') {
-   *     // Show UI to fix permissions, then call resume()
-   *     showPermissionDialog(() => notification.resume());
+   * client.on('telnyx.error', (event) => {
+   *   if (event.recoverable && event.resume) {
+   *     showPermissionDialog({
+   *       onContinue: () => event.resume(),
+   *       onCancel: () => event.reject?.(),
+   *     });
    *   }
    * });
    * ```
@@ -208,11 +215,11 @@ export interface IClientOptions {
   mediaPermissionsRecovery?: {
     /** Enable the recovery flow. */
     enabled: boolean;
-    /** Maximum time in ms to wait for the app to call `resume()`. Recommended max 25000. */
+    /** Maximum time in ms to wait for the app to call `resume()` or `reject()`. Recommended max 25000. */
     timeout: number;
     /** Called when the retry `getUserMedia` succeeds after `resume()`. */
     onSuccess?: () => void;
-    /** Called when the retry `getUserMedia` fails or the timeout expires. */
+    /** Called when retry fails, the timeout expires, or the app calls `reject()`. */
     onError?: (error: Error) => void;
   };
 }


### PR DESCRIPTION
## Summary

Adds `mediaPermissionsRecovery` option to the SDK for handling `getUserMedia` failures on **inbound calls** gracefully.

## Problem

When an inbound call arrives and `getUserMedia` fails (device not found, permissions denied, etc.), the SDK silently swallows the error and never answers the call — with no way for the app to recover.

## Solution

When `mediaPermissionsRecovery.enabled` is `true` and `getUserMedia` fails on an **inbound** (Answer) call:

1. The SDK emits a `userMediaError` notification with a `resume()` callback and `retryDeadline`
2. The app shows a permission dialog and calls `resume()` when the user fixes the issue
3. The SDK retries `getUserMedia` once
4. If the retry succeeds → call setup continues, `onSuccess` callback fires
5. If the retry fails or timeout expires → call is torn down, `onError` callback fires

**Restrictions:**
- Inbound calls only (`PeerType.Answer`)
- One retry only — second failure triggers hangup

## Usage

```js
const client = new TelnyxRTC({
  login_token: "...",
  mediaPermissionsRecovery: {
    enabled: true,
    timeout: 20000, // ms
    onSuccess: () => console.log("Media recovered"),
    onError: (err) => console.error("Recovery failed", err),
  },
});

client.on("telnyx.notification", (notification) => {
  if (notification.type === "userMediaError" && notification.resume) {
    // Show UI prompting user to grant mic permissions
    showPermissionDialog(() => notification.resume());
  }
});
```

## Changes

- `packages/js/src/Modules/Verto/util/interfaces.ts` — Added `mediaPermissionsRecovery` to `IVertoOptions`
- `packages/js/src/utils/interfaces.ts` — Added `mediaPermissionsRecovery` to `IClientOptions` (public API)
- `packages/js/src/Modules/Verto/webrtc/Peer.ts` — Recovery logic in `createPeerConnection()` catch handler

## Testing

- `yarn build` ✅
- `yarn test` ✅ (210/210 tests pass)
