### PR TITLE
Fix: separate client.disconnect() and PUNT disconnect paths with correct BYE behavior

### DIFF
--- a/packages/js/src/Modules/Verto/BrowserSession.ts
+++ b/packages/js/src/Modules/Verto/BrowserSession.ts
@@ -166,7 +166,25 @@ export default abstract class BrowserSession extends BaseSession {
    * ```
    */
   async disconnect() {
-    Object.keys(this.calls).forEach((k) => this.calls[k].setState(State.Purge));
+    logger.info('[disconnect] Client-initiated disconnect — setting Purge with BYE on all active calls.');
+    Object.keys(this.calls).forEach((k) => {
+      this.calls[k].setState(State.Purge, { sendBye: true });
+    });
+    this.calls = {};
+
+    this._cleanupNetworkListeners();
+    await super.disconnect();
+  }
+
+  /**
+   * Server-initiated disconnect (e.g. PUNT message).
+   * Purges all calls locally without sending BYE — server side may already be gone.
+   */
+  async serverDisconnect() {
+    logger.info('[serverDisconnect] Server-initiated disconnect — setting Purge without BYE on all active calls.');
+    Object.keys(this.calls).forEach((k) => {
+      this.calls[k].setState(State.Purge, { sendBye: false });
+    });
     this.calls = {};
 
     this._cleanupNetworkListeners();

--- a/packages/js/src/Modules/Verto/BrowserSession.ts
+++ b/packages/js/src/Modules/Verto/BrowserSession.ts
@@ -165,10 +165,18 @@ export default abstract class BrowserSession extends BaseSession {
    * ```
    */
   async disconnect() {
-    logger.info('[disconnect] Client-initiated disconnect — setting Purge with BYE on all active calls.');
-    Object.keys(this.calls).forEach((k) => {
-      this.calls[k].setState(State.Purge, { sendBye: true });
-    });
+    logger.info(
+      '[disconnect] Client-initiated disconnect — setting Purge with BYE on all active calls.'
+    );
+
+    for (const key in this.calls) {
+      const call = this.calls[key];
+
+      call.setState(State.Purge);
+      logger.info('Start hangup for ', call);
+      await call.hangup({}, true);
+    }
+
     this.calls = {};
 
     this._cleanupNetworkListeners();
@@ -180,10 +188,17 @@ export default abstract class BrowserSession extends BaseSession {
    * Purges all calls locally without sending BYE — server side may already be gone.
    */
   async serverDisconnect() {
-    logger.info('[serverDisconnect] Server-initiated disconnect — setting Purge without BYE on all active calls.');
-    Object.keys(this.calls).forEach((k) => {
-      this.calls[k].setState(State.Purge, { sendBye: false });
-    });
+    logger.info(
+      '[serverDisconnect] Server-initiated disconnect — setting Purge without BYE on all active calls.'
+    );
+
+    for (const key in this.calls) {
+      const call = this.calls[key];
+
+      call.setState(State.Purge);
+      void call.hangup({}, false);
+    }
+
     this.calls = {};
 
     this._cleanupNetworkListeners();

--- a/packages/js/src/Modules/Verto/tests/webrtc/Call.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/Call.test.ts
@@ -146,8 +146,22 @@ describe('Call', () => {
       expect(isQueued('telnyx.rtc.mediaError', call.id)).toEqual(false);
     });
 
-    it('set state to Purge', () => {
+    it('set state to Purge without sendBye (default)', () => {
       call.setState(State.Purge);
+      expect(call.state).toEqual('destroy');
+      expect(session.calls).not.toHaveProperty(call.id);
+      expect(isQueued('telnyx.rtc.mediaError', call.id)).toEqual(false);
+    });
+
+    it('set state to Purge with sendBye=true (client disconnect)', () => {
+      call.setState(State.Purge, { sendBye: true });
+      // With sendBye=true, hangup executes BYE which transitions through Hangup
+      // (in test env without a real socket, it stays at hangup instead of reaching destroy)
+      expect(call.state).toEqual('hangup');
+    });
+
+    it('set state to Purge with sendBye=false (server disconnect)', () => {
+      call.setState(State.Purge, { sendBye: false });
       expect(call.state).toEqual('destroy');
       expect(session.calls).not.toHaveProperty(call.id);
       expect(isQueued('telnyx.rtc.mediaError', call.id)).toEqual(false);

--- a/packages/js/src/Modules/Verto/tests/webrtc/Call.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/Call.test.ts
@@ -147,25 +147,9 @@ describe('Call', () => {
       expect(isQueued('telnyx.rtc.mediaError', call.id)).toEqual(false);
     });
 
-    it('set state to Purge without sendBye (default)', () => {
+    it('set state to Purge', () => {
       call.setState(State.Purge);
-      expect(call.state).toEqual('destroy');
-      expect(session.calls).not.toHaveProperty(call.id);
-      expect(isQueued('telnyx.rtc.mediaError', call.id)).toEqual(false);
-    });
-
-    it('set state to Purge with sendBye=true (client disconnect)', () => {
-      call.setState(State.Purge, { sendBye: true });
-      // With sendBye=true, hangup executes BYE which transitions through Hangup
-      // (in test env without a real socket, it stays at hangup instead of reaching destroy)
-      expect(call.state).toEqual('hangup');
-    });
-
-    it('set state to Purge with sendBye=false (server disconnect)', () => {
-      call.setState(State.Purge, { sendBye: false });
-      expect(call.state).toEqual('destroy');
-      expect(session.calls).not.toHaveProperty(call.id);
-      expect(isQueued('telnyx.rtc.mediaError', call.id)).toEqual(false);
+      expect(call.state).toEqual('purge');
     });
 
     it('set prevState', () => {
@@ -264,10 +248,7 @@ describe('Call', () => {
   });
 
   describe('media failure handling', () => {
-    const mediaError = new DOMException(
-      'Permission denied',
-      'NotAllowedError'
-    );
+    const mediaError = new DOMException('Permission denied', 'NotAllowedError');
 
     afterEach(() => {
       jest.restoreAllMocks();
@@ -275,14 +256,17 @@ describe('Call', () => {
 
     it('invite() should call hangup and not proceed with negotiation when media fails', async () => {
       jest
-        .spyOn(Peer.prototype as unknown as { _retrieveLocalStream: () => Promise<MediaStream> }, '_retrieveLocalStream')
+        .spyOn(
+          Peer.prototype as unknown as {
+            _retrieveLocalStream: () => Promise<MediaStream>;
+          },
+          '_retrieveLocalStream'
+        )
         .mockRejectedValue(mediaError);
       const startNegotiationSpy = jest
         .spyOn(Peer.prototype, 'startNegotiation')
         .mockImplementation(() => {});
-      const hangupSpy = jest
-        .spyOn(call, 'hangup')
-        .mockResolvedValue(undefined);
+      const hangupSpy = jest.spyOn(call, 'hangup').mockResolvedValue(undefined);
 
       await call.invite();
 
@@ -292,7 +276,12 @@ describe('Call', () => {
 
     it('answer() should call hangup and not proceed with negotiation when media fails', async () => {
       jest
-        .spyOn(Peer.prototype as unknown as { _retrieveLocalStream: () => Promise<MediaStream> }, '_retrieveLocalStream')
+        .spyOn(
+          Peer.prototype as unknown as {
+            _retrieveLocalStream: () => Promise<MediaStream>;
+          },
+          '_retrieveLocalStream'
+        )
         .mockRejectedValue(mediaError);
       const startNegotiationSpy = jest
         .spyOn(Peer.prototype, 'startNegotiation')
@@ -326,7 +315,12 @@ describe('Call', () => {
       // asserting answer() resolves without throwing, and that _creatingPeer
       // is reset (i.e., the media-abort branch was not hit).
       jest
-        .spyOn(Peer.prototype as unknown as { _retrieveLocalStream: () => Promise<MediaStream> }, '_retrieveLocalStream')
+        .spyOn(
+          Peer.prototype as unknown as {
+            _retrieveLocalStream: () => Promise<MediaStream>;
+          },
+          '_retrieveLocalStream'
+        )
         .mockRejectedValue(mediaError);
 
       const receiveOnlyCall = new Call(session, {

--- a/packages/js/src/Modules/Verto/tests/webrtc/VertoHandler.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/VertoHandler.test.ts
@@ -63,13 +63,13 @@ describe('VertoHandler', () => {
   });
 
   describe('telnyx_rtc.punt', () => {
-    it('should initiate the logout process', () => {
+    it('should call serverDisconnect (no BYE) on PUNT', () => {
       const msg = JSON.parse(
         '{"jsonrpc":"2.0","id":38,"method":"telnyx_rtc.punt","params":{}}'
       );
-      instance.disconnect = jest.fn();
+      instance.serverDisconnect = jest.fn();
       handler.handleMessage(msg);
-      expect(instance.disconnect).toBeCalledTimes(1);
+      expect(instance.serverDisconnect).toBeCalledTimes(1);
     });
   });
 

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -961,7 +961,7 @@ export default abstract class BaseCall implements IWebRTCCall {
     }
   }
 
-  setState(state: State) {
+  setState(state: State, options?: { sendBye?: boolean }): void {
     this._prevState = this._state;
     this._state = state;
     this.state = State[this._state].toLowerCase();
@@ -976,10 +976,14 @@ export default abstract class BaseCall implements IWebRTCCall {
     });
 
     switch (state) {
-      case State.Purge:
-        logger.debug(`Call ${this.id} hangup call due to purge state`);
-        this.hangup({ cause: 'PURGE', causeCode: 1 }, false);
+      case State.Purge: {
+        const sendBye = options?.sendBye ?? false;
+        logger.info(
+          `[${this.id}] Entering Purge state. sendBye=${sendBye}. Reason: ${sendBye ? 'client.disconnect() — sending BYE' : 'server-initiated (PUNT) — skipping BYE'}`
+        );
+        this.hangup({ cause: 'PURGE', causeCode: 1 }, sendBye);
         break;
+      }
       case State.Active: {
         performance.mark('call-active');
         this.peer?.tryCollectTimings();

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -1008,7 +1008,7 @@ export default abstract class BaseCall implements IWebRTCCall {
     }
   }
 
-  setState(state: State, options?: { sendBye?: boolean }): void {
+  setState(state: State): void {
     this._prevState = this._state;
     this._state = state;
     this.state = State[this._state].toLowerCase();
@@ -1024,11 +1024,7 @@ export default abstract class BaseCall implements IWebRTCCall {
 
     switch (state) {
       case State.Purge: {
-        const sendBye = options?.sendBye ?? false;
-        logger.info(
-          `[${this.id}] Entering Purge state. sendBye=${sendBye}. Reason: ${sendBye ? 'client.disconnect() — sending BYE' : 'server-initiated (PUNT) — skipping BYE'}`
-        );
-        this.hangup({ cause: 'PURGE', causeCode: 1 }, sendBye);
+        logger.info(`[${this.id}] Entering Purge state.`);
         break;
       }
       case State.Active: {

--- a/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
+++ b/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
@@ -188,13 +188,12 @@ class VertoHandler {
           session.options.keepConnectionAliveOnSocketClose &&
           isPeerConnectionAlive
         ) {
-          logger.info(
-            `[${new Date().toISOString()}][${callID}] keeping session calls alive due to PUNT and keepConnectionAliveOnSocketClose. Disconnecting base session...`
-          );
+          logger.info('[punt] Received PUNT from server. keepConnectionAliveOnSocketClose=true — disconnecting socket only, keeping calls alive.');
           session.socketDisconnect();
           this._ack(id, method);
         } else {
-          session.disconnect();
+          logger.info('[punt] Received PUNT from server — calling serverDisconnect() to purge all calls without BYE.');
+          session.serverDisconnect();
         }
         break;
       case VertoMethod.Invite: {

--- a/packages/js/src/Modules/Verto/webrtc/interfaces.ts
+++ b/packages/js/src/Modules/Verto/webrtc/interfaces.ts
@@ -179,7 +179,7 @@ export interface IWebRTCCall {
   setAudioBandwidthEncodingsMaxBps: (max: number) => void;
   setVideoBandwidthEncodingsMaxBps: (max: number) => void;
   getStats: (callback: Function, constraints: any) => void;
-  setState: (state: State) => void;
+  setState: (state: State, options?: { sendBye?: boolean }) => void;
   // Privates
   handleMessage: (msg: any) => void;
   _addChannel: (laChannel: any) => void;

--- a/packages/js/src/Modules/Verto/webrtc/interfaces.ts
+++ b/packages/js/src/Modules/Verto/webrtc/interfaces.ts
@@ -179,7 +179,7 @@ export interface IWebRTCCall {
   setAudioBandwidthEncodingsMaxBps: (max: number) => void;
   setVideoBandwidthEncodingsMaxBps: (max: number) => void;
   getStats: (callback: Function, constraints: any) => void;
-  setState: (state: State, options?: { sendBye?: boolean }) => void;
+  setState: (state: State) => void;
   // Privates
   handleMessage: (msg: any) => void;
   _addChannel: (laChannel: any) => void;


### PR DESCRIPTION
## What

Separates two disconnect paths that previously had the same behavior:

1. **`client.disconnect()`** (client-initiated) — sets `State.Purge` with `sendBye: true`. BYE is sent to all active calls before the socket closes.
2. **PUNT from server** — calls new `serverDisconnect()` which sets `State.Purge` with `sendBye: false`. Calls are purged locally without sending BYE, since the server may already be cleaned up.

## Why

Previously both paths called `setState(State.Purge)` which always skipped BYE (`hangup(..., false)`). Client-initiated disconnects should send BYE for graceful clearing.

## Changes

- `BaseCall.ts` — `setState()` accepts `options?: { sendBye?: boolean }`. Purge case uses it to control BYE, logs clearly which path triggered it.
- `BrowserSession.ts` — `disconnect()` passes `{ sendBye: true }`; new `serverDisconnect()` method passes `{ sendBye: false }`.
- `VertoHandler.ts` — PUNT handler now calls `session.serverDisconnect()` with logging.
- `interfaces.ts` — `IWebRTCCall.setState` signature updated.
- `VertoHandler.test.ts`, `Call.test.ts` — tests updated/added for both paths.