### PR TITLE
WEBRTC-3395: remove trickleIce guard for attach method

### DIFF
--- a/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
+++ b/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
@@ -108,13 +108,7 @@ class VertoHandler {
         mediaSettings: params.mediaSettings,
         debug: session.options.debug ?? false,
         debugOutput: session.options.debugOutput ?? 'socket',
-        // b2bua-rtc's attach handler does not support trickle ICE — it expects
-        // a complete SDP with all ICE candidates. Force trickleIce off for attach
-        // to avoid CODEC NEGOTIATION ERROR. See WEBRTC-3395.
-        trickleIce:
-          method === VertoMethod.Attach
-            ? false
-            : (session.options.trickleIce ?? false),
+        trickleIce: session.options.trickleIce ?? false,
         prefetchIceCandidates: session.options.prefetchIceCandidates ?? true,
         forceRelayCandidate: session.options.forceRelayCandidate ?? false,
         keepConnectionAliveOnSocketClose:


### PR DESCRIPTION
## Summary

Removes the guard that forced `trickleIce: false` for `VertoMethod.Attach`.

Previously, trickle ICE was disabled for attach because b2bua-rtc's attach handler didn't support it — expecting a complete SDP with all ICE candidates. Now that attach supports trickle ICE, the override is no longer needed.

## Change

`trickleIce` now consistently uses `session.options.trickleIce ?? false` regardless of method.

## Testing

All existing VertoHandler tests pass.