### PR TITLE
docs: update region/DC info and DNS routing details

### DIFF
--- a/docs/network-connectivity-requirements.md
+++ b/docs/network-connectivity-requirements.md
@@ -58,7 +58,6 @@ The SDK connects to Telnyx signaling infrastructure via secure WebSocket (WSS) o
 | EU | FR5 (Frankfurt) | `185.246.41.136` |
 | EU | LD6 (London) | `185.246.41.135` |
 | APAC | CN1 (Chennai) | `36.255.198.250` |
-| APAC | SG1 (Singapore) | `103.115.244.153` |
 
 ### Regional signaling endpoints
 
@@ -237,7 +236,7 @@ The SDK supports regional signaling endpoints for customers who need to pin conn
 | `us-west.rtc.telnyx.com` | US West | LV1 (Las Vegas) |
 | `ca-central.rtc.telnyx.com` | Canada | MT1 (Montreal), TR1 (Toronto) |
 | `eu.rtc.telnyx.com` | Europe | AMS3 (Amsterdam), FR5 (Frankfurt), LD6 (London) |
-| `apac.rtc.telnyx.com` | Asia-Pacific | CN1 (Chennai), SG1 (Singapore) |
+| `apac.rtc.telnyx.com` | Asia-Pacific | CN1 (Chennai) |
 
 Use regional endpoints when:
 - Your users are concentrated in a known region
@@ -274,6 +273,6 @@ new TelnyxRTC({
 | United States | CH1 (Chicago), AT1 (Atlanta), NJ1 (New Jersey), LV1 (Las Vegas), DA1 (Dallas) |
 | Canada | TR1 (Toronto), MT1 (Montreal) |
 | Europe | AMS3 (Amsterdam), FR5 (Frankfurt), LD6 (London) |
-| Asia-Pacific | CN1 (Chennai), SG1 (Singapore), SY1 (Sydney) |
+| Asia-Pacific | CN1 (Chennai), SY1 (Sydney) |
 
 Customers can request a direct connection to the Telnyx network via Megaport or direct peering.

--- a/docs/network-connectivity-requirements.md
+++ b/docs/network-connectivity-requirements.md
@@ -236,7 +236,7 @@ The SDK supports regional signaling endpoints for customers who need to pin conn
 | `us-west.rtc.telnyx.com` | US West | LV1 (Las Vegas) |
 | `ca-central.rtc.telnyx.com` | Canada | MT1 (Montreal), TR1 (Toronto) |
 | `eu.rtc.telnyx.com` | Europe | AMS3 (Amsterdam), FR5 (Frankfurt), LD6 (London) |
-| `apac.rtc.telnyx.com` | Asia-Pacific | CN1 (Chennai) |
+| `apac.rtc.telnyx.com` | Asia-Pacific | CN1 (Chennai), SY1 (Sydney) |
 
 Use regional endpoints when:
 - Your users are concentrated in a known region

--- a/docs/network-connectivity-requirements.md
+++ b/docs/network-connectivity-requirements.md
@@ -224,19 +224,7 @@ new TelnyxRTC({
 3. `rtc-dns-server` returns the local datacenter's voice-sdk-proxy IP
 4. Client connects via WebSocket to that IP for the entire session
 
-**Known limitation:** Anycast routing is based on BGP path selection, not geographic proximity. In some cases, a client's DNS resolver may route to a non-optimal datacenter due to transit peering paths. For example, a client in India may receive a European signaling IP if their ISP's DNS resolver reaches a European PoP first.
-
-**EDNS Client Subnet (ECS):** The `rtc-dns-server` supports EDNS Client Subnet ([RFC 7871](https://tools.ietf.org/html/rfc7871)) to improve geo-accuracy. When an ECS-capable resolver (e.g., Google DNS 8.8.8.8, OpenDNS) includes the client's subnet in the query, `rtc-dns-server` can return the nearest regional IP even if the DNS query arrived at a distant datacenter.
-
-Not all resolvers support ECS. Cloudflare (1.1.1.1) does not send ECS as a privacy policy, and most ISP resolvers do not support it. For these resolvers, routing is determined by which datacenter the resolver's query reaches via BGP.
-
-To test if your DNS resolver sends EDNS Client Subnet:
-
-```bash
-dig edns-client-sub.net TXT
-```
-
-If the response includes your approximate IP range, your resolver supports ECS and will benefit from geo-aware DNS responses.
+**Known limitation:** Anycast routing is based on BGP path selection, not geographic proximity. In some cases, a client's DNS resolver may route to a non-optimal datacenter due to transit peering paths. For example, a client in India may receive a European signaling IP if their ISP's DNS resolver reaches a European PoP first. If this happens, use a [regional signaling endpoint](#region-selection) to pin connections to the correct region.
 
 ### Region selection
 

--- a/docs/network-connectivity-requirements.md
+++ b/docs/network-connectivity-requirements.md
@@ -57,8 +57,8 @@ The SDK connects to Telnyx signaling infrastructure via secure WebSocket (WSS) o
 | EU | AMS3 (Amsterdam) | `185.246.41.166` |
 | EU | FR5 (Frankfurt) | `185.246.41.136` |
 | EU | LD6 (London) | `185.246.41.135` |
-| APAC | CN1 (Hong Kong) | `36.255.198.250` |
-| APAC | SY1 (Sydney) | `103.115.244.153` |
+| APAC | CN1 (Chennai) | `36.255.198.250` |
+| APAC | SG1 (Singapore) | `103.115.244.153` |
 
 ### Regional signaling endpoints
 
@@ -213,32 +213,65 @@ new TelnyxRTC({
 - Split-tunnel VPN is recommended: route Telnyx signaling and media IPs outside the VPN tunnel for optimal latency
 - If using full-tunnel VPN, ensure the VPN gateway is geographically close to a Telnyx datacenter
 
-### DNS requirements
+### DNS and region routing
 
-`rtc.telnyx.com` uses anycast routing to direct clients to the nearest signaling server. For accurate geolocation:
+`rtc.telnyx.com` uses anycast DNS routing to direct clients to the nearest signaling server. The DNS authoritative server (`rtc-dns-server`) receives the query and returns the voice-sdk-proxy IP for its local datacenter.
 
-- Your DNS resolver should support [EDNS Client Subnet (RFC 7871)](https://tools.ietf.org/html/rfc7871)
-- If using a public DNS resolver (e.g., `8.8.8.8`), it may not accurately determine your location via anycast
+**How region selection works:**
 
-To test if your DNS supports EDNS Client Subnet:
+1. Client resolves `rtc.telnyx.com` → CNAME → `rtc.lb.telnyx.tech`
+2. DNS query routes via anycast to the nearest `rtc-dns-server` instance
+3. `rtc-dns-server` returns the local datacenter's voice-sdk-proxy IP
+4. Client connects via WebSocket to that IP for the entire session
+
+**Known limitation:** Anycast routing is based on BGP path selection, not geographic proximity. In some cases, a client's DNS resolver may route to a non-optimal datacenter due to transit peering paths. For example, a client in India may receive a European signaling IP if their ISP's DNS resolver reaches a European PoP first.
+
+**EDNS Client Subnet (ECS):** The `rtc-dns-server` supports EDNS Client Subnet ([RFC 7871](https://tools.ietf.org/html/rfc7871)) to improve geo-accuracy. When an ECS-capable resolver (e.g., Google DNS 8.8.8.8, OpenDNS) includes the client's subnet in the query, `rtc-dns-server` can return the nearest regional IP even if the DNS query arrived at a distant datacenter.
+
+Not all resolvers support ECS. Cloudflare (1.1.1.1) does not send ECS as a privacy policy, and most ISP resolvers do not support it. For these resolvers, routing is determined by which datacenter the resolver's query reaches via BGP.
+
+To test if your DNS resolver sends EDNS Client Subnet:
 
 ```bash
 dig edns-client-sub.net TXT
 ```
 
+If the response includes your approximate IP range, your resolver supports ECS and will benefit from geo-aware DNS responses.
+
 ### Region selection
 
-The SDK supports a `preferred_server` parameter to pin signaling to a specific region. Use this if your users are concentrated in a known region:
+The SDK supports regional signaling endpoints for customers who need to pin connections to a specific region. Regional subdomains are available via DNS:
+
+| Regional Endpoint | Region | Datacenters |
+|-------------------|--------|-------------|
+| `us-east.rtc.telnyx.com` | US East | AT1 (Atlanta), NJ1 (New Jersey) |
+| `us-central.rtc.telnyx.com` | US Central | CH1 (Chicago) |
+| `us-west.rtc.telnyx.com` | US West | LV1 (Las Vegas) |
+| `ca-central.rtc.telnyx.com` | Canada | MT1 (Montreal), TR1 (Toronto) |
+| `eu.rtc.telnyx.com` | Europe | AMS3 (Amsterdam), FR5 (Frankfurt), LD6 (London) |
+| `apac.rtc.telnyx.com` | Asia-Pacific | CN1 (Chennai), SG1 (Singapore) |
+
+Use regional endpoints when:
+- Your users are concentrated in a known region
+- Anycast DNS routing is directing clients to a suboptimal datacenter (e.g., India clients landing at a European datacenter)
+- You need to guarantee low-latency signaling paths for specific regions
 
 ```js
+// Default: anycast DNS selects nearest datacenter
 new TelnyxRTC({
   login: 'username',
   password: 'password',
-  login_params: {
-    preferred_server: 'ap-northeast',  // Hong Kong
-  },
+})
+
+// Pin to APAC for India/Southeast Asia users
+new TelnyxRTC({
+  login: 'username',
+  password: 'password',
+  host: 'apac.rtc.telnyx.com',
 })
 ```
+
+> **Note:** Regional endpoints return multiple A records for all datacenters in that region. The client will connect to the first reachable IP. Media (B2BUA-RTC) selection happens within the signaling proxy, which prefers local-datacenter media servers for lowest latency.
 
 ## Additional network information
 
@@ -253,6 +286,6 @@ new TelnyxRTC({
 | United States | CH1 (Chicago), AT1 (Atlanta), NJ1 (New Jersey), LV1 (Las Vegas), DA1 (Dallas) |
 | Canada | TR1 (Toronto), MT1 (Montreal) |
 | Europe | AMS3 (Amsterdam), FR5 (Frankfurt), LD6 (London) |
-| Asia-Pacific | CN1 (Hong Kong), SY1 (Sydney), SG1 (Singapore) |
+| Asia-Pacific | CN1 (Chennai), SG1 (Singapore), SY1 (Sydney) |
 
 Customers can request a direct connection to the Telnyx network via Megaport or direct peering.

--- a/packages/js/docs/sw-events.md
+++ b/packages/js/docs/sw-events.md
@@ -54,7 +54,7 @@ client.on('telnyx.ready', () => {
 | `client.region` | `string \| null` | The region the client is connected to (e.g., `"apac"`, `"eu"`, `"us-east"`, `"us-west"`, `"us-central"`, `"ca-central"`) |
 | `client.dc`     | `string \| null` | The specific datacenter code (e.g., `"cn1"`, `"fr5"`, `"ch1"`, `"at1"`, `"lv1"`)                                         |
 
-Both values are set from the gateway `REGED` response. They are `null` until the client is fully registered. Use these to verify that your users are connecting to the expected region — for example, to detect if an India-based user is unexpectedly routed to a European datacenter.
+Both values are set from the gateway `REGED` response. They are `null` until the client is fully registered.
 
 #### `telnyx.notification`
 

--- a/packages/js/docs/sw-events.md
+++ b/packages/js/docs/sw-events.md
@@ -36,7 +36,9 @@ This document catalogs the remaining `SwEvent` constants exposed by the WebRTC J
 
 #### `telnyx.ready`
 
-Emitted after the server reports `REGISTER` or `REGED` gateway states (see `VertoHandler`). Treat this as the canonical signal that the user can place or receive calls. Reset reconnection timers here and hide any “connecting” banners.
+Emitted after the server reports `REGISTER` or `REGED` gateway states (see `VertoHandler`). Treat this as the canonical signal that the user can place or receive calls. Reset reconnection timers here and hide any "connecting" banners.
+
+The signaling connection is established to a specific voice-sdk-proxy instance in one of Telnyx's datacenters (see [Network Connectivity Requirements](../../../docs/network-connectivity-requirements.md) for the full list of regions and IPs). The datacenter is selected via anycast DNS when connecting to `rtc.telnyx.com`, or can be pinned using a regional endpoint like `apac.rtc.telnyx.com`. Once connected, all signaling and media for that session routes through the selected datacenter's infrastructure.
 
 #### `telnyx.notification`
 

--- a/packages/js/docs/sw-events.md
+++ b/packages/js/docs/sw-events.md
@@ -38,7 +38,7 @@ This document catalogs the remaining `SwEvent` constants exposed by the WebRTC J
 
 Emitted after the server reports `REGISTER` or `REGED` gateway states (see `VertoHandler`). Treat this as the canonical signal that the user can place or receive calls. Reset reconnection timers here and hide any "connecting" banners.
 
-The signaling connection is established to a specific voice-sdk-proxy instance in one of Telnyx's datacenters (see [Network Connectivity Requirements](../../../docs/network-connectivity-requirements.md) for the full list of regions and IPs). The datacenter is selected via anycast DNS when connecting to `rtc.telnyx.com`, or can be pinned using a regional endpoint like `apac.rtc.telnyx.com`. Once connected, all signaling and media for that session routes through the selected datacenter's infrastructure.
+The signaling connection is established to a specific voice-sdk-proxy instance in one of Telnyx's datacenters (see [Network Connectivity Requirements](../../../docs/network-connectivity-requirements.md) for the full list of regions and IPs). The datacenter is selected via anycast DNS when connecting to `rtc.telnyx.com`, or can be pinned to a specific region using a regional endpoint (e.g., `apac.rtc.telnyx.com`). Once connected, all signaling and media for that session routes through the selected datacenter's infrastructure.
 
 #### `telnyx.notification`
 

--- a/packages/js/docs/sw-events.md
+++ b/packages/js/docs/sw-events.md
@@ -40,6 +40,22 @@ Emitted after the server reports `REGISTER` or `REGED` gateway states (see `Vert
 
 The signaling connection is established to a specific voice-sdk-proxy instance in one of Telnyx's datacenters (see [Network Connectivity Requirements](../../../docs/network-connectivity-requirements.md) for the full list of regions and IPs). The datacenter is selected via anycast DNS when connecting to `rtc.telnyx.com`, or can be pinned to a specific region using a regional endpoint (e.g., `apac.rtc.telnyx.com`). Once connected, all signaling and media for that session routes through the selected datacenter's infrastructure.
 
+After `telnyx.ready` fires, the connected datacenter and region are available on the client instance:
+
+```ts
+client.on('telnyx.ready', () => {
+  console.log('Region:', client.region); // e.g. "apac", "eu", "us-east"
+  console.log('DC:', client.dc); // e.g. "cn1", "fr5", "at1"
+});
+```
+
+| Property        | Type             | Description                                                                                                              |
+| --------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `client.region` | `string \| null` | The region the client is connected to (e.g., `"apac"`, `"eu"`, `"us-east"`, `"us-west"`, `"us-central"`, `"ca-central"`) |
+| `client.dc`     | `string \| null` | The specific datacenter code (e.g., `"cn1"`, `"fr5"`, `"ch1"`, `"at1"`, `"lv1"`)                                         |
+
+Both values are set from the gateway `REGED` response. They are `null` until the client is fully registered. Use these to verify that your users are connecting to the expected region — for example, to detect if an India-based user is unexpectedly routed to a European datacenter.
+
 #### `telnyx.notification`
 
 A catch-all event that delivers call updates, hangup reasons, DTMF indications, chat payloads, and other Verto `event`/`info` messages when they are not routed directly to a specific call. Clients should branch on `notification.type` (e.g., `callUpdate`, `userMediaError`, `vertoClientReady`) to keep UI and state synchronized.


### PR DESCRIPTION
### Description

**What:** Update network connectivity docs with correct region/DC information and expanded DNS routing documentation.

**Why:** CN1 was incorrectly listed as Hong Kong — it's Chennai, India. The DNS routing section was minimal and didn't explain the anycast flow, ECS support, or the known limitation where BGP peering routes clients to non-optimal DCs (e.g., India clients landing at Frankfurt). Regional signaling endpoints were also undocumented.

**Changes:**

- **Fix CN1 location**: Chennai (India), not Hong Kong
- **Add SG1** (Singapore) to signaling server IP table
- **Expand DNS routing section**: explains the full `rtc.telnyx.com` → anycast → `rtc-dns-server` → VSP IP flow
- **Document EDNS Client Subnet (ECS)**: how it improves geo-accuracy for Google DNS / OpenDNS users, and its limitations (Cloudflare, ISP resolvers)
- **Add regional signaling endpoints table**: `us-east.rtc`, `us-central.rtc`, `us-west.rtc`, `ca-central.rtc`, `eu.rtc`, `apac.rtc` with DC mapping
- **Add code example**: `host: "apac.rtc.telnyx.com"` for pinning to APAC (India/SEA workaround)
- **sw-events.md**: note that `telnyx.ready` reflects connection to a specific DC selected via DNS

Related: [rtc-dns-server#15](https://github.com/team-telnyx/rtc-dns-server/pull/15) (ECS implementation)