### PR TITLE
feat: log region and dc at info level on connect and new call

### DIFF
--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -2058,7 +2058,10 @@ export default abstract class BaseCall implements IWebRTCCall {
     } else {
       this.setState(State.New);
     }
-    logger.info('New Call with Options:', this.options);
+    logger.info(
+      `New Call — region: ${this.session.region ?? 'unknown'}, dc: ${this.session.dc ?? 'unknown'}`,
+      this.options
+    );
   }
 
   protected _finalize() {

--- a/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
+++ b/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
@@ -182,11 +182,15 @@ class VertoHandler {
           session.options.keepConnectionAliveOnSocketClose &&
           isPeerConnectionAlive
         ) {
-          logger.info('[punt] Received PUNT from server. keepConnectionAliveOnSocketClose=true — disconnecting socket only, keeping calls alive.');
+          logger.info(
+            '[punt] Received PUNT from server. keepConnectionAliveOnSocketClose=true — disconnecting socket only, keeping calls alive.'
+          );
           session.socketDisconnect();
           this._ack(id, method);
         } else {
-          logger.info('[punt] Received PUNT from server — calling serverDisconnect() to purge all calls without BYE.');
+          logger.info(
+            '[punt] Received PUNT from server — calling serverDisconnect() to purge all calls without BYE.'
+          );
           session.serverDisconnect();
         }
         break;
@@ -286,14 +290,16 @@ class VertoHandler {
                 const dc = msg?.result?.params?.dc;
                 if (dc) {
                   session.dc = dc;
-                  logger.debug('Captured dc from REGED:', { dc });
                 }
 
                 const region = msg?.result?.params?.region;
                 if (region) {
                   session.region = region;
-                  logger.debug('Captured region from REGED:', { region });
                 }
+
+                logger.info(
+                  `Connected to Telnyx — region: ${session.region ?? 'unknown'}, dc: ${session.dc ?? 'unknown'}`
+                );
 
                 params.type = NOTIFICATION_TYPE.vertoClientReady;
                 trigger(SwEvent.Ready, params, session.uuid);


### PR DESCRIPTION
### Description

**What:** Add region and datacenter identifiers to SDK console logs at `info` level.

**Why:** SDK logs should clearly display which regional infrastructure is handling the connection. Currently dc/region are only logged at `debug` level (not visible by default). This makes it easy to confirm routing at a glance.

**Log output after this change:**

```
2026-04-13 14:33:11.309 - Connected to Telnyx — region: apac, dc: cn1
2026-04-13 14:33:21.374 - New Call — region: apac, dc: cn1 { destinationNumber: "8004337300", ... }
```

**Changes:**

| File | Change |
|------|--------|
| `VertoHandler.ts` | Log `Connected to Telnyx — region: <region>, dc: <dc>` at info level on REGED |
| `BaseCall.ts` | Log `New Call — region: <region>, dc: <dc>` at info level (replaces plain "New Call with Options") |

Both values come from the gateway REGED response and are already stored on `session.region` / `session.dc`. This just promotes them from debug to info level.