### PR TITLE
feat: expose clearReconnectToken() to break b2bua-rtc stickiness on retry

### DIFF
--- a/packages/js/CHANGELOG.md
+++ b/packages/js/CHANGELOG.md
@@ -1,31 +1,8 @@
-## [2.26.3-beta.0](https://github.com/team-telnyx/webrtc/compare/webrtc/v2.26.0...webrtc/v2.26.3-beta.0) (2026-04-22)
+## [2.26.3-beta.0](https://github.com/team-telnyx/webrtc/compare/webrtc/v2.26.2...webrtc/v2.26.3-beta.0) (2026-04-22)
 
 - docs: update ts docs
 - feat: expose clearReconnectToken() to allow consumers to break b2bua-rtc stickiness
-- chore: release webrtc@2.26.2 (#606)
-- chore: add workflow to deprecate/undeprecate npm package versions (#568)
-- feat: log region and dc at info level on connect and new call (#605)
-- docs: update region/DC info and DNS routing details (#604)
-- chore: release webrtc@2.26.1 (#603)
-- Chore: improve errors docs and import error/warning codecs (#602)
-- Fix: separate client.disconnect() and PUNT disconnect paths with correct BYE behavior (#580)
-- docs: Voice SDK Network Connectivity Requirements (#564)
-- fix: remove trickleIce guard for attach method (WEBRTC-3395) (#584)
-- fix(types): point types field at lib/src/index.d.ts (#601)
-- feat: store source datacenter identifier from REGED message (#583)
-- fix(ci): push release branch before pinning draft release target (#597)
-- fix(ci): pin draft target to bump SHA, publish from tag (#596)
-- fix(ci): single release-it call for bump + tag + draft (#594)
-- fix(ci): single release-it call for bump + tag + draft (#593)
-- fix(ci): allow non-immutable installs for draft release tagging step (#592)
-- fix(ci): drop lockfile update step, set YARN_ENABLE_IMMUTABLE_INSTALLS=false (#591)
-- fix(ci): use --mode update-lockfile to avoid upgrading all deps (#589)
-- fix(ci): update lockfile after version bump in draft-release (#587)
-- fix(ci): create release tag after version bump commit (#586)
-- Fix: interrupt call negotiation on media failure for non-receive-only peers (#582)
-- feat: make hangup async, properly await BYE execution (#581)
-- Feat: wire structured errors and warnings across SDK (#548)
-- chore: include README.md in npm packages and remove Slack notifications (#578)
+
 ## [2.26.2](https://github.com/team-telnyx/webrtc/compare/webrtc/v2.26.1...webrtc/v2.26.2) (2026-04-13)
 
 ### Region & Datacenter Visibility

--- a/packages/js/CHANGELOG.md
+++ b/packages/js/CHANGELOG.md
@@ -1,3 +1,31 @@
+## [2.26.3-beta.0](https://github.com/team-telnyx/webrtc/compare/webrtc/v2.26.0...webrtc/v2.26.3-beta.0) (2026-04-22)
+
+- docs: update ts docs
+- feat: expose clearReconnectToken() to allow consumers to break b2bua-rtc stickiness
+- chore: release webrtc@2.26.2 (#606)
+- chore: add workflow to deprecate/undeprecate npm package versions (#568)
+- feat: log region and dc at info level on connect and new call (#605)
+- docs: update region/DC info and DNS routing details (#604)
+- chore: release webrtc@2.26.1 (#603)
+- Chore: improve errors docs and import error/warning codecs (#602)
+- Fix: separate client.disconnect() and PUNT disconnect paths with correct BYE behavior (#580)
+- docs: Voice SDK Network Connectivity Requirements (#564)
+- fix: remove trickleIce guard for attach method (WEBRTC-3395) (#584)
+- fix(types): point types field at lib/src/index.d.ts (#601)
+- feat: store source datacenter identifier from REGED message (#583)
+- fix(ci): push release branch before pinning draft release target (#597)
+- fix(ci): pin draft target to bump SHA, publish from tag (#596)
+- fix(ci): single release-it call for bump + tag + draft (#594)
+- fix(ci): single release-it call for bump + tag + draft (#593)
+- fix(ci): allow non-immutable installs for draft release tagging step (#592)
+- fix(ci): drop lockfile update step, set YARN_ENABLE_IMMUTABLE_INSTALLS=false (#591)
+- fix(ci): use --mode update-lockfile to avoid upgrading all deps (#589)
+- fix(ci): update lockfile after version bump in draft-release (#587)
+- fix(ci): create release tag after version bump commit (#586)
+- Fix: interrupt call negotiation on media failure for non-receive-only peers (#582)
+- feat: make hangup async, properly await BYE execution (#581)
+- Feat: wire structured errors and warnings across SDK (#548)
+- chore: include README.md in npm packages and remove Slack notifications (#578)
 ## [2.26.2](https://github.com/team-telnyx/webrtc/compare/webrtc/v2.26.1...webrtc/v2.26.2) (2026-04-13)
 
 ### Region & Datacenter Visibility

--- a/packages/js/docs/ts/classes/TelnyxRTC.md
+++ b/packages/js/docs/ts/classes/TelnyxRTC.md
@@ -55,6 +55,7 @@ client.off('telnyx.notification');
 ### Methods
 
 - [checkPermissions](#checkpermissions)
+- [clearReconnectToken](#clearreconnecttoken)
 - [connect](#connect)
 - [disableMicrophone](#disablemicrophone)
 - [disconnect](#disconnect)
@@ -397,6 +398,24 @@ client.checkPermissions(false, true);
 #### Inherited from
 
 TelnyxRTCClient.checkPermissions
+
+---
+
+### clearReconnectToken
+
+▸ **clearReconnectToken**(): `void`
+
+Clears the reconnect token from sessionStorage.
+This forces the next connection to pick a new b2bua-rtc instance
+via weighted round-robin instead of sticking to the same one.
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+TelnyxRTCClient.clearReconnectToken
 
 ---
 

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telnyx/webrtc",
-  "version": "2.26.2",
+  "version": "2.26.3-beta.0",
   "description": "Telnyx WebRTC Client",
   "keywords": [
     "telnyx",

--- a/packages/js/src/Modules/Verto/BaseSession.ts
+++ b/packages/js/src/Modules/Verto/BaseSession.ts
@@ -31,7 +31,7 @@ import {
 } from './util/interfaces';
 import type { INotification } from '../../utils/interfaces';
 import logger, { setConsoleLoggerMinLevel } from './util/logger';
-import { getReconnectToken } from './util/reconnect';
+import { getReconnectToken, clearReconnectToken } from './util/reconnect';
 import { Ping } from './messages/verto/Ping';
 import { Login } from './messages/Verto';
 import { AnonymousLogin } from './messages/verto/AnonymousLogin';
@@ -347,6 +347,15 @@ export default abstract class BaseSession {
       { error: telnyxError, sessionId: this.sessionid },
       this.uuid
     );
+  }
+
+  /**
+   * Clears the reconnect token from sessionStorage.
+   * This forces the next connection to pick a new b2bua-rtc instance
+   * via weighted round-robin instead of sticking to the same one.
+   */
+  public clearReconnectToken(): void {
+    clearReconnectToken();
   }
 
   /**

--- a/packages/js/src/Modules/Verto/BaseSession.ts
+++ b/packages/js/src/Modules/Verto/BaseSession.ts
@@ -359,6 +359,62 @@ export default abstract class BaseSession {
   }
 
   /**
+   * Re-sends the login message on the existing WebSocket connection.
+   * Useful for retrying after a transient "Login Incorrect" error
+   * without closing and reopening the socket.
+   *
+   * @returns Promise that resolves when login succeeds
+   */
+  public async relogin(): Promise<void> {
+    if (isValidAnonymousLoginOptions(this.options)) {
+      const msg = new AnonymousLogin({
+        target_id: this.options.anonymous_login.target_id,
+        target_type: this.options.anonymous_login.target_type,
+        target_version_id: this.options.anonymous_login.target_version_id,
+        target_params: this.options.anonymous_login.target_params,
+        sessionId: this.sessionid,
+        userVariables: this.options.userVariables,
+        reconnection: !!getReconnectToken(),
+      });
+
+      const response = await this.execute(msg).catch((error) => {
+        this._handleLoginError(error);
+        throw error;
+      });
+
+      if (response) {
+        this.sessionid = response.sessid;
+        this._checkTokenExpiry();
+      }
+      return;
+    }
+
+    if (isValidLoginOptions(this.options)) {
+      const msg = new Login(
+        this.options.login,
+        this.options.password || this.options.passwd,
+        this.options.login_token,
+        this.sessionid,
+        this.options.userVariables,
+        !!getReconnectToken()
+      );
+
+      const response = await this.execute(msg).catch((error) => {
+        this._handleLoginError(error);
+        throw error;
+      });
+
+      if (response) {
+        this.sessionid = response.sessid;
+        this._checkTokenExpiry();
+      }
+      return;
+    }
+
+    throw new Error('No valid login options found for relogin');
+  }
+
+  /**
    * Check if the login_token is a JWT and schedule a warning
    * if it's expiring within TOKEN_EXPIRY_WARNING_SECONDS.
    */

--- a/packages/js/src/Modules/Verto/BaseSession.ts
+++ b/packages/js/src/Modules/Verto/BaseSession.ts
@@ -359,62 +359,6 @@ export default abstract class BaseSession {
   }
 
   /**
-   * Re-sends the login message on the existing WebSocket connection.
-   * Useful for retrying after a transient "Login Incorrect" error
-   * without closing and reopening the socket.
-   *
-   * @returns Promise that resolves when login succeeds
-   */
-  public async relogin(): Promise<void> {
-    if (isValidAnonymousLoginOptions(this.options)) {
-      const msg = new AnonymousLogin({
-        target_id: this.options.anonymous_login.target_id,
-        target_type: this.options.anonymous_login.target_type,
-        target_version_id: this.options.anonymous_login.target_version_id,
-        target_params: this.options.anonymous_login.target_params,
-        sessionId: this.sessionid,
-        userVariables: this.options.userVariables,
-        reconnection: !!getReconnectToken(),
-      });
-
-      const response = await this.execute(msg).catch((error) => {
-        this._handleLoginError(error);
-        throw error;
-      });
-
-      if (response) {
-        this.sessionid = response.sessid;
-        this._checkTokenExpiry();
-      }
-      return;
-    }
-
-    if (isValidLoginOptions(this.options)) {
-      const msg = new Login(
-        this.options.login,
-        this.options.password || this.options.passwd,
-        this.options.login_token,
-        this.sessionid,
-        this.options.userVariables,
-        !!getReconnectToken()
-      );
-
-      const response = await this.execute(msg).catch((error) => {
-        this._handleLoginError(error);
-        throw error;
-      });
-
-      if (response) {
-        this.sessionid = response.sessid;
-        this._checkTokenExpiry();
-      }
-      return;
-    }
-
-    throw new Error('No valid login options found for relogin');
-  }
-
-  /**
    * Check if the login_token is a JWT and schedule a warning
    * if it's expiring within TOKEN_EXPIRY_WARNING_SECONDS.
    */


### PR DESCRIPTION
## Problem

When a WebSocket connection receives "Login Incorrect" (e.g. due to RMQ propagation lag on a specific b2bua-rtc instance), the widget auto-reconnects using the same `voice_sdk_id`. This makes the reconnection sticky to the same lagging b2bua-rtc instance, so retries are likely to fail again.

## Solution

Expose `clearReconnectToken()` on `BaseSession` so consumers can clear the `voice_sdk_id` stored in sessionStorage before reconnecting. Without a `voice_sdk_id`, VSP falls back to weighted round-robin and may route to a healthier b2bua-rtc instance.

## Related

- team-telnyx/voice-sdk-proxy#112
- ENGDESK-51102