### PR TITLE
feat: skip_last_voice_sdk_id on reconnections to avoid sticky b2bua-rtc

### DIFF
--- a/packages/js/src/Modules/Verto/services/Connection.ts
+++ b/packages/js/src/Modules/Verto/services/Connection.ts
@@ -132,6 +132,12 @@ export default class Connection {
       this._hasCanaryBeenUsed = true;
     }
 
+    // When reconnecting with a voice_sdk_id, ask VSP to route to a
+    // different b2bua-rtc instance instead of sticky-reconnecting.
+    if (websocketUrl.searchParams.has('voice_sdk_id')) {
+      websocketUrl.searchParams.set('skip_last_voice_sdk_id', 'true');
+    }
+
     try {
       this._wsClient = new WebSocketClass(websocketUrl.toString());
       this._registerSocketEvents(this._wsClient);


### PR DESCRIPTION
## Problem
When reconnecting after a socket drop, the widget sticks to the same b2bua-rtc instance via the stored `voice_sdk_id`. This can trigger 'Login Incorrect' race conditions if that specific b2bua-rtc node has stale session state.

## Solution
On reconnections (when `voice_sdk_id` is present in sessionStorage), append `?skip_last_voice_sdk_id=true` to the WebSocket URL. VSP will then route the connection to a different b2bua-rtc instance.

The new `voice_sdk_id` returned by VSP in gateway messages continues to be stored via `setReconnectToken()` for the next reconnection cycle, creating a round-robin hop across instances.

## Changes
- `packages/js/src/Modules/Verto/services/Connection.ts`: add `skip_last_voice_sdk_id=true` query param when reconnecting with a voice_sdk_id

## Testing
- Build passes
- All 225 tests pass

## Related
- VSP counterpart: `feat/skip-last-b2bua-on-reconnect` in voice-sdk-proxy
- telnyx-webrtc-signaling investigation: anonymous login race condition