### PR TITLE
feat: add skipLastVoiceSdkId option for voice-sdk-proxy PR #122

### DIFF
--- a/packages/js/src/Modules/Verto/services/Connection.ts
+++ b/packages/js/src/Modules/Verto/services/Connection.ts
@@ -132,6 +132,12 @@ export default class Connection {
       this._hasCanaryBeenUsed = true;
     }
 
+    // When reconnecting with a voice_sdk_id, ask VSP to route to a
+    // different b2bua-rtc instance instead of sticky-reconnecting.
+    if (websocketUrl.searchParams.has('voice_sdk_id')) {
+      websocketUrl.searchParams.set('skip_last_voice_sdk_id', 'true');
+    }
+
     try {
       this._wsClient = new WebSocketClass(websocketUrl.toString());
       this._registerSocketEvents(this._wsClient);

--- a/packages/js/src/Modules/Verto/services/Connection.ts
+++ b/packages/js/src/Modules/Verto/services/Connection.ts
@@ -132,9 +132,13 @@ export default class Connection {
       this._hasCanaryBeenUsed = true;
     }
 
-    // When reconnecting with a voice_sdk_id, ask VSP to route to a
-    // different b2bua-rtc instance instead of sticky-reconnecting.
-    if (websocketUrl.searchParams.has('voice_sdk_id')) {
+    // When explicitly requested and reconnecting with a voice_sdk_id,
+    // ask VSP to route to a different b2bua-rtc instance instead of
+    // sticky-reconnecting to the same one.
+    if (
+      this.session.options.skipLastVoiceSdkId &&
+      websocketUrl.searchParams.has('voice_sdk_id')
+    ) {
       websocketUrl.searchParams.set('skip_last_voice_sdk_id', 'true');
     }
 

--- a/packages/js/src/Modules/Verto/util/interfaces.ts
+++ b/packages/js/src/Modules/Verto/util/interfaces.ts
@@ -75,6 +75,16 @@ export interface IVertoOptions {
    */
   debugLogMaxEntries?: number;
   /**
+   * When reconnecting with a stored `voice_sdk_id`, append
+   * `?skip_last_voice_sdk_id=true` to the WebSocket URL so VSP routes
+   * the connection to a different b2bua-rtc instance instead of sticky-
+   * reconnecting to the same one.
+   *
+   * @default false
+   */
+  skipLastVoiceSdkId?: boolean;
+
+  /**
    * Configuration for media permissions recovery on inbound calls.
    * When enabled and the initial `getUserMedia` call fails while answering,
    * the SDK emits a recoverable `telnyx.error` event with `resume()` and

--- a/packages/js/src/utils/interfaces.ts
+++ b/packages/js/src/utils/interfaces.ts
@@ -146,6 +146,17 @@ export interface IClientOptions {
   useCanaryRtcServer?: boolean;
 
   /**
+   * When reconnecting with a stored `voice_sdk_id`, append
+   * `?skip_last_voice_sdk_id=true` to the WebSocket URL so VSP routes
+   * the connection to a different b2bua-rtc instance instead of sticky-
+   * reconnecting to the same one. Useful when retrying after errors
+   * caused by stale state on a specific b2bua-rtc node.
+   *
+   * @default false
+   */
+  skipLastVoiceSdkId?: boolean;
+
+  /**
    *  Environment to use for the connection.
    *  So far this property is only for internal purposes.
    */


### PR DESCRIPTION
- Add `skipLastVoiceSdkId` to `IClientOptions` and `IVertoOptions`
- Only append `?skip_last_voice_sdk_id=true` when option is enabled and `voice_sdk_id` exists
- Bump version to 2.26.4