### PR TITLE
fix: include call id on debug report data

### DIFF
--- a/packages/js/src/Modules/Verto/messages/WebRTCStats.ts
+++ b/packages/js/src/Modules/Verto/messages/WebRTCStats.ts
@@ -27,12 +27,13 @@ export class DebugReportStopMessage extends BaseMessage {
 }
 
 export class DebugReportDataMessage extends BaseMessage {
-  constructor(id: string, data: any) {
+  constructor(id: string, callID: string, data: unknown) {
     super();
     this.buildRequest({
       type: 'debug_report_data',
       debug_report_id: id,
       debug_report_version: DEBUG_REPORT_VERSION,
+      call_id: callID,
       debug_report_data: data,
     });
   }

--- a/packages/js/src/Modules/Verto/tests/messages.test.ts
+++ b/packages/js/src/Modules/Verto/tests/messages.test.ts
@@ -1,4 +1,9 @@
 import { Login, Invite, Answer, Bye, Modify, Info } from '../messages/Verto';
+import {
+  DebugReportDataMessage,
+  DebugReportStartMessage,
+  DebugReportStopMessage,
+} from '../messages/WebRTCStats';
 import { Ping } from '../messages/verto/Ping';
 import { version } from '../../../../package.json';
 
@@ -141,6 +146,57 @@ describe('Messages', function () {
           `{"jsonrpc":"2.0","id":"${message.id}","method":"telnyx_rtc.ping","params":{}}`
         );
         expect(message).toEqual(res);
+      });
+    });
+
+    describe('WebRTCStats', function () {
+      it('should include call_id on debug_report_start', function () {
+        const message = new DebugReportStartMessage(
+          'debug-report-id',
+          'call-id'
+        ).request;
+
+        expect(message).toEqual({
+          jsonrpc: '2.0',
+          id: message.id,
+          type: 'debug_report_start',
+          debug_report_id: 'debug-report-id',
+          debug_report_version: 1,
+          call_id: 'call-id',
+        });
+      });
+
+      it('should include call_id on debug_report_stop', function () {
+        const message = new DebugReportStopMessage('debug-report-id', 'call-id')
+          .request;
+
+        expect(message).toEqual({
+          jsonrpc: '2.0',
+          id: message.id,
+          type: 'debug_report_stop',
+          debug_report_id: 'debug-report-id',
+          debug_report_version: 1,
+          call_id: 'call-id',
+        });
+      });
+
+      it('should include call_id on debug_report_data', function () {
+        const debugReportData = { event: 'stats' };
+        const message = new DebugReportDataMessage(
+          'debug-report-id',
+          'call-id',
+          debugReportData
+        ).request;
+
+        expect(message).toEqual({
+          jsonrpc: '2.0',
+          id: message.id,
+          type: 'debug_report_data',
+          debug_report_id: 'debug-report-id',
+          debug_report_version: 1,
+          call_id: 'call-id',
+          debug_report_data: debugReportData,
+        });
       });
     });
   });

--- a/packages/js/src/Modules/Verto/util/debug.ts
+++ b/packages/js/src/Modules/Verto/util/debug.ts
@@ -208,7 +208,7 @@ export function createWebRTCStatsReporter(
     if (message.event === 'stats') {
       trigger(SwEvent.StatsFrame, toRealtimeMetrics(message), session.uuid);
     }
-    await session.execute(new DebugReportDataMessage(reportId, message));
+    await session.execute(new DebugReportDataMessage(reportId, callID, message));
   };
 
   const start = async (


### PR DESCRIPTION
## Summary
- include call_id on debug_report_data messages, matching debug_report_start and debug_report_stop
- add message assertions for debug report start, stop, and data envelopes

Companion proxy PR: team-telnyx/voice-sdk-proxy#135
Companion voice-sdk-debug PR: team-telnyx/voice-sdk-debug#37

## Testing
- ✅ `yarn workspace @telnyx/webrtc test src/Modules/Verto/tests/messages.test.ts`
- ✅ `yarn exec tsc --noEmit --pretty false -p packages/js/tsconfig.json`
