### PR TITLE
chore: release webrtc@2.27.0-beta.0

### DIFF
--- a/packages/js/CHANGELOG.md
+++ b/packages/js/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.27.0-beta.0](https://github.com/team-telnyx/webrtc/compare/webrtc/v2.26.4...webrtc/v2.27.0-beta.0) (2026-05-11)
+
+- fix: include call id on debug report data (#619)
+
 ## [2.26.4](https://github.com/team-telnyx/webrtc/compare/webrtc/v2.26.0...webrtc/v2.26.4) (2026-04-29)
 
 - docs: update ts docs

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telnyx/webrtc",
-  "version": "2.26.4",
+  "version": "2.27.0-beta.0",
   "description": "Telnyx WebRTC Client",
   "keywords": [
     "telnyx",


### PR DESCRIPTION
## Release webrtc@2.27.0-beta.0

Beta minor prerelease for PR #619.

- Version bump in `packages/js/package.json`
- Updated `packages/js/CHANGELOG.md`
- Draft GitHub prerelease created: https://github.com/team-telnyx/webrtc/releases/tag/webrtc/v2.27.0-beta.0

**After merging**, publish the draft prerelease from the releases page to publish `@telnyx/webrtc@2.27.0-beta.0` with the `beta` npm dist-tag.

## Testing
- `yarn workspace @telnyx/webrtc test src/Modules/Verto/tests/messages.test.ts`
- `yarn exec tsc --noEmit --pretty false -p packages/js/tsconfig.json`
- `yarn docs`
