### PR TITLE
fix: use originator cancel for outbound pre-answer hangup

### DIFF
--- a/packages/js/src/Modules/Verto/tests/webrtc/Call.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/Call.test.ts
@@ -12,7 +12,7 @@ Object.defineProperty(global, 'performance', {
 });
 
 import { isQueued, register, deRegister } from '../../services/Handler';
-import { State } from '../../webrtc/constants';
+import { Direction, State } from '../../webrtc/constants';
 import {
   ANSWER_WHILE_PEER_ACTIVE,
   DUPLICATE_INBOUND_ANSWER,
@@ -300,11 +300,21 @@ describe('Call', () => {
       expect(call.causeCode).toEqual(17);
     });
 
-    it('should use USER_BUSY/17 for a new (pre-answer) call', async () => {
+    it('should use USER_BUSY/17 for a new call without outbound direction', async () => {
       // call starts in State.New
       await call.hangup({}, false);
       expect(call.cause).toEqual('USER_BUSY');
       expect(call.causeCode).toEqual(17);
+    });
+
+    it('should use ORIGINATOR_CANCEL/487 when canceling an outbound call before answer', async () => {
+      call.direction = Direction.Outbound;
+      call.setState(State.Requesting);
+
+      await call.hangup({}, false);
+
+      expect(call.cause).toEqual('ORIGINATOR_CANCEL');
+      expect(call.causeCode).toEqual(487);
     });
 
     it('should use NORMAL_CLEARING/16 when hanging up an active call', async () => {

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -556,13 +556,7 @@ export default abstract class BaseCall implements IWebRTCCall {
     const callerStack = this._captureHangupCallerStack();
     const initiator = params.initiator || 'app:call.hangup';
 
-    // State-dependent default cause code:
-    // - Pre-answer states (never answered) → USER_BUSY/17 (signals rejection, prevents TeXML retries)
-    // - Post-answer states (active call) → NORMAL_CLEARING/16
-    const defaults =
-      this._state < State.Active
-        ? { cause: 'USER_BUSY', causeCode: 17 }
-        : { cause: 'NORMAL_CLEARING', causeCode: 16 };
+    const defaults = this._getDefaultHangupCause();
 
     this.cause = params.cause || defaults.cause;
     this.causeCode = params.causeCode || defaults.causeCode;
@@ -1097,6 +1091,18 @@ export default abstract class BaseCall implements IWebRTCCall {
       const STATS_INTERVAL = 2000;
       this._startStats(STATS_INTERVAL);
     }
+  }
+
+  private _getDefaultHangupCause(): { cause: string; causeCode: number } {
+    if (this._state >= State.Active) {
+      return { cause: 'NORMAL_CLEARING', causeCode: 16 };
+    }
+
+    if (this.direction === Direction.Outbound) {
+      return { cause: 'ORIGINATOR_CANCEL', causeCode: 487 };
+    }
+
+    return { cause: 'USER_BUSY', causeCode: 17 };
   }
 
   setState(state: State): void {


### PR DESCRIPTION
## Summary

- use `ORIGINATOR_CANCEL/487` for outbound calls canceled before answer instead of overloading `USER_BUSY/17`
- keep inbound pre-answer rejection and calls without outbound direction as `USER_BUSY/17`

## Context

This is the cause-code half of the original PR #623 split. It targets outbound pre-answer local cancels like:

```text
SEND telnyx_rtc.invite
state requesting -> hangup
SEND telnyx_rtc.bye cause=USER_BUSY causeCode=17
```

For outbound caller-side cancellation before answer, the SDK should send `ORIGINATOR_CANCEL/487`. Inbound pre-answer rejection remains `USER_BUSY/17`.

The separate late invite/answer ACK state-race fix has been moved to its own PR.

## Validation

- `yarn jest packages/js/src/Modules/Verto/tests/webrtc/Call.test.ts --runInBand`
