### PR TITLE
fix: log hangup caller metadata

### DIFF
--- a/packages/js/src/Modules/Verto/BrowserSession.ts
+++ b/packages/js/src/Modules/Verto/BrowserSession.ts
@@ -174,7 +174,7 @@ export default abstract class BrowserSession extends BaseSession {
 
       call.setState(State.Purge);
       logger.info('Start hangup for ', call);
-      await call.hangup({}, true);
+      await call.hangup({ initiator: 'app:client.disconnect' }, true);
     }
 
     this.calls = {};
@@ -196,7 +196,7 @@ export default abstract class BrowserSession extends BaseSession {
       const call = this.calls[key];
 
       call.setState(State.Purge);
-      void call.hangup({}, false);
+      void call.hangup({ initiator: 'sdk:server-disconnect' }, false);
     }
 
     this.calls = {};

--- a/packages/js/src/Modules/Verto/index.ts
+++ b/packages/js/src/Modules/Verto/index.ts
@@ -34,7 +34,10 @@ export default class Verto extends BrowserSession {
         Object.keys(this.calls).forEach((callId) => {
           if (this.calls[callId]) {
             logger.info(`Hanging up call due to window unload: ${callId}`);
-            void this.calls[callId].hangup({}, true);
+            void this.calls[callId].hangup(
+              { initiator: 'sdk:beforeunload' },
+              true
+            );
           }
         });
       }

--- a/packages/js/src/Modules/Verto/tests/webrtc/Call.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/Call.test.ts
@@ -182,6 +182,7 @@ describe('Call', () => {
           prevState: 'new',
           cause: 'NORMAL_CLEARING',
           causeCode: 16,
+          initiator: 'app:call.hangup',
           isRecovering: false,
           hasDialogCustomHeaders: false,
           callerStack: expect.any(Array),
@@ -194,6 +195,23 @@ describe('Call', () => {
       const hangupLogContext = hangupLog?.[1] as { callerStack: string[] };
       expect(hangupLogContext.callerStack.length).toBeGreaterThan(0);
       expect(hangupLogContext.callerStack.join('\n')).toContain('hangup');
+
+      debugSpy.mockRestore();
+    });
+
+    it('should log explicit hangup initiator metadata', async () => {
+      const debugSpy = jest
+        .spyOn(logger, 'debug')
+        .mockImplementation(jest.fn());
+
+      await call.hangup({ initiator: 'sdk:sdp-send-failure' }, false);
+
+      expect(debugSpy).toHaveBeenCalledWith(
+        `[${call.id}] hangup() invoked`,
+        expect.objectContaining({
+          initiator: 'sdk:sdp-send-failure',
+        })
+      );
 
       debugSpy.mockRestore();
     });
@@ -307,7 +325,10 @@ describe('Call', () => {
 
       await call.invite();
 
-      expect(hangupSpy).toHaveBeenCalledWith({}, false);
+      expect(hangupSpy).toHaveBeenCalledWith(
+        { initiator: 'sdk:peer-init-failed' },
+        false
+      );
       expect(startNegotiationSpy).not.toHaveBeenCalled();
     });
 
@@ -334,7 +355,10 @@ describe('Call', () => {
 
       await answerCall.answer();
 
-      expect(hangupSpy).toHaveBeenCalledWith();
+      expect(hangupSpy).toHaveBeenCalledWith(
+        { initiator: 'sdk:peer-init-failed' },
+        true
+      );
       expect(startNegotiationSpy).not.toHaveBeenCalled();
     });
 

--- a/packages/js/src/Modules/Verto/tests/webrtc/Call.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/Call.test.ts
@@ -14,6 +14,7 @@ Object.defineProperty(global, 'performance', {
 import { isQueued, register, deRegister } from '../../services/Handler';
 import { State } from '../../webrtc/constants';
 import { SwEvent } from '../../util/constants';
+import logger from '../../util/logger';
 import Call from '../../webrtc/Call';
 import Peer from '../../webrtc/Peer';
 import Verto from '../..';
@@ -160,6 +161,41 @@ describe('Call', () => {
       expect(call.prevState).toEqual('ringing');
       call.setState(State.Hangup);
       expect(call.prevState).toEqual('active');
+    });
+  });
+
+  describe('hangup caller instrumentation', () => {
+    it('should log caller stack and state metadata when hangup is invoked', async () => {
+      const debugSpy = jest
+        .spyOn(logger, 'debug')
+        .mockImplementation(jest.fn());
+
+      call.setState(State.Active);
+      await call.hangup({ cause: 'NORMAL_CLEARING', causeCode: 16 }, false);
+
+      expect(debugSpy).toHaveBeenCalledWith(
+        `[${call.id}] hangup() invoked`,
+        expect.objectContaining({
+          callId: call.id,
+          execute: false,
+          state: 'active',
+          prevState: 'new',
+          cause: 'NORMAL_CLEARING',
+          causeCode: 16,
+          isRecovering: false,
+          hasDialogCustomHeaders: false,
+          callerStack: expect.any(Array),
+        })
+      );
+
+      const hangupLog = debugSpy.mock.calls.find(
+        ([message]) => message === `[${call.id}] hangup() invoked`
+      );
+      const hangupLogContext = hangupLog?.[1] as { callerStack: string[] };
+      expect(hangupLogContext.callerStack.length).toBeGreaterThan(0);
+      expect(hangupLogContext.callerStack.join('\n')).toContain('hangup');
+
+      debugSpy.mockRestore();
     });
   });
 

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -223,6 +223,20 @@ export default abstract class BaseCall implements IWebRTCCall {
 
   private _isRecovering: boolean = false;
 
+  private _captureHangupCallerStack(): string[] {
+    const stack = new Error('Call.hangup caller').stack;
+
+    if (!stack) {
+      return [];
+    }
+
+    return stack
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .slice(1, 11);
+  }
+
   constructor(
     protected session: BrowserSession,
     opts?: IVertoCallOptions
@@ -531,6 +545,9 @@ export default abstract class BaseCall implements IWebRTCCall {
   ): Promise<void> {
     const params = hangupParams || {};
     const execute = hangupExecute === false ? false : true;
+    const stateBeforeHangup = this.state;
+    const prevStateBeforeHangup = this.prevState;
+    const callerStack = this._captureHangupCallerStack();
 
     // State-dependent default cause code:
     // - Pre-answer states (never answered) → USER_BUSY/17 (signals rejection, prevents TeXML retries)
@@ -549,6 +566,23 @@ export default abstract class BaseCall implements IWebRTCCall {
       ...(this.options.customHeaders ?? []),
       ...(params?.dialogParams?.customHeaders ?? []),
     ];
+
+    logger.debug(`[${this.id}] hangup() invoked`, {
+      callId: this.id,
+      execute,
+      state: stateBeforeHangup,
+      prevState: prevStateBeforeHangup,
+      cause: this.cause,
+      causeCode: this.causeCode,
+      sipCode: this.sipCode,
+      sipReason: this.sipReason,
+      sipCallId: this.sipCallId,
+      isRecovering: Boolean(params.isRecovering),
+      hasDialogCustomHeaders: Boolean(
+        params.dialogParams?.customHeaders?.length
+      ),
+      callerStack,
+    });
 
     // If recovering from attach, set Recovering state and skip Bye
     if (params.isRecovering) {

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -422,7 +422,7 @@ export default abstract class BaseCall implements IWebRTCCall {
         },
         this.session.uuid
       );
-      void this.hangup({}, false);
+      void this.hangup({ initiator: 'sdk:peer-init-failed' }, false);
       return;
     }
     this._creatingPeer = false;
@@ -498,7 +498,7 @@ export default abstract class BaseCall implements IWebRTCCall {
         },
         this.session.uuid
       );
-      await this.hangup();
+      await this.hangup({ initiator: 'sdk:peer-init-failed' }, true);
       return;
     }
     this._creatingPeer = false;
@@ -548,6 +548,7 @@ export default abstract class BaseCall implements IWebRTCCall {
     const stateBeforeHangup = this.state;
     const prevStateBeforeHangup = this.prevState;
     const callerStack = this._captureHangupCallerStack();
+    const initiator = params.initiator || 'app:call.hangup';
 
     // State-dependent default cause code:
     // - Pre-answer states (never answered) → USER_BUSY/17 (signals rejection, prevents TeXML retries)
@@ -574,6 +575,7 @@ export default abstract class BaseCall implements IWebRTCCall {
       prevState: prevStateBeforeHangup,
       cause: this.cause,
       causeCode: this.causeCode,
+      initiator,
       sipCode: this.sipCode,
       sipReason: this.sipReason,
       sipCallId: this.sipCallId,
@@ -1248,7 +1250,10 @@ export default abstract class BaseCall implements IWebRTCCall {
 
         this.stopRingback();
         this.stopRingtone();
-        void this.hangup(params, false);
+        void this.hangup(
+          { ...params, initiator: 'remote:telnyx_rtc.bye' },
+          false
+        );
         break;
     }
   }
@@ -1504,6 +1509,7 @@ export default abstract class BaseCall implements IWebRTCCall {
             {
               cause: 'USER_BUSY',
               causeCode: 17,
+              initiator: 'sdk:set-remote-description-failure',
             },
             true
           );
@@ -1597,7 +1603,7 @@ export default abstract class BaseCall implements IWebRTCCall {
         break;
       default:
         logger.error(`${this.id} - Unknown local SDP type:`, data);
-        void this.hangup({}, false);
+        void this.hangup({ initiator: 'sdk:unknown-local-sdp-type' }, false);
         return;
     }
     performance.mark('send-sdp');
@@ -1629,6 +1635,7 @@ export default abstract class BaseCall implements IWebRTCCall {
             {
               cause: 'USER_BUSY',
               causeCode: 17,
+              initiator: 'sdk:sdp-send-failure',
             },
             true
           );
@@ -1644,7 +1651,7 @@ export default abstract class BaseCall implements IWebRTCCall {
   private _onTrickleIceSdp(data: RTCSessionDescription) {
     if (!data) {
       logger.error('No SDP data provided');
-      void this.hangup({}, false);
+      void this.hangup({ initiator: 'sdk:missing-local-sdp' }, false);
       return;
     }
 
@@ -1677,7 +1684,7 @@ export default abstract class BaseCall implements IWebRTCCall {
         break;
       default:
         logger.error(`${this.id} - Unknown local SDP type:`, data);
-        void this.hangup({}, false);
+        void this.hangup({ initiator: 'sdk:unknown-local-sdp-type' }, false);
         return;
     }
 
@@ -1710,6 +1717,7 @@ export default abstract class BaseCall implements IWebRTCCall {
             {
               cause: 'USER_BUSY',
               causeCode: 17,
+              initiator: 'sdk:sdp-send-failure',
             },
             true
           );
@@ -1954,7 +1962,7 @@ export default abstract class BaseCall implements IWebRTCCall {
       this.session.uuid
     );
 
-    void this.hangup({}, false);
+    void this.hangup({ initiator: 'sdk:media-error' }, false);
   }
 
   private _onPeerConnectionFailureError(data: {

--- a/packages/js/src/Modules/Verto/webrtc/Call.ts
+++ b/packages/js/src/Modules/Verto/webrtc/Call.ts
@@ -72,7 +72,9 @@ export class Call extends BaseCall {
     displayStream.getTracks().forEach((t) => {
       t.addEventListener('ended', async () => {
         if (this.screenShare) {
-          await this.screenShare.hangup();
+          await this.screenShare.hangup({
+            initiator: 'sdk:screenshare-track-ended',
+          });
         }
       });
     });
@@ -99,7 +101,7 @@ export class Call extends BaseCall {
    */
   async stopScreenShare() {
     if (this.screenShare instanceof Call) {
-      await this.screenShare.hangup();
+      await this.screenShare.hangup({ initiator: 'app:stopScreenShare' });
     }
   }
 

--- a/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
+++ b/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
@@ -219,7 +219,10 @@ class VertoHandler {
         logger.info(
           `[${new Date().toISOString()}][${callID}] closing existing call on ATTACH.`
         );
-        void existingCall.hangup({ isRecovering: true }, false);
+        void existingCall.hangup(
+          { isRecovering: true, initiator: 'sdk:attach-recovery' },
+          false
+        );
 
         logger.info(
           `[${new Date().toISOString()}][${callID}] Attach: Creating new call for recovery (recoveredCallId: ${recoveredCallId})`

--- a/packages/js/src/Modules/Verto/webrtc/interfaces.ts
+++ b/packages/js/src/Modules/Verto/webrtc/interfaces.ts
@@ -21,6 +21,8 @@ export interface IHangupParams {
   };
   /** When true, sets call to Recovering state for reconnection flow */
   isRecovering?: boolean;
+  /** Structured source label for hangup attribution in logs/call reports */
+  initiator?: string;
 }
 
 export interface IVertoCallOptions {


### PR DESCRIPTION
## Summary
- log structured `hangup()` invocation metadata before the call transitions to hangup/destroy
- include pre-hangup state, execute flag, selected cause/causeCode, SIP fields, recovery/custom-header flags, and a caller stack snapshot
- add unit coverage to confirm the instrumentation captures stack/state metadata

## Validation
- `yarn workspace @telnyx/webrtc test packages/js/src/Modules/Verto/tests/webrtc/Call.test.ts --runInBand`
- `yarn workspace @telnyx/webrtc build`
