### PR TITLE
fix: log local audio source diagnostics

### DIFF
--- a/packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts
@@ -1,0 +1,118 @@
+import logger from '../../util/logger';
+import {
+  CallReportCollector,
+  ILocalAudioSourceStats,
+  ILocalAudioTrackSnapshot,
+} from '../../webrtc/CallReportCollector';
+
+type TestableCallReportCollector = {
+  peerConnection: {
+    getSenders: () => Array<{
+      track?: Partial<MediaStreamTrack> & {
+        kind?: string;
+        contentHint?: string;
+        getSettings?: () => Partial<MediaTrackSettings>;
+      };
+    }>;
+  } | null;
+  cleanup: () => void;
+  _withoutUndefined: <T extends Record<string, unknown>>(obj: T) => T;
+  _getLocalAudioTrackSnapshot: () => ILocalAudioTrackSnapshot | undefined;
+  _getOutboundAudioSourceStats: (
+    stats: RTCStatsReport,
+    outboundAudio: RTCOutboundRtpStreamStats & { mediaSourceId?: string }
+  ) => ILocalAudioSourceStats | undefined;
+  _logLocalAudioTrackSnapshot: (
+    localAudioTrack?: ILocalAudioTrackSnapshot,
+    localAudioSource?: ILocalAudioSourceStats
+  ) => void;
+};
+
+const createCollector = (): TestableCallReportCollector =>
+  new CallReportCollector({
+    enabled: true,
+    interval: 5000,
+  }) as unknown as TestableCallReportCollector;
+
+describe('CallReportCollector local audio diagnostics', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('removes undefined values without mutating the input object', () => {
+    const collector = createCollector();
+    const input = { id: 'track-id', label: undefined, enabled: true };
+
+    const cleaned = collector._withoutUndefined(input);
+
+    expect(cleaned).toEqual({ id: 'track-id', enabled: true });
+    expect(cleaned).not.toBe(input);
+    expect(input).toEqual({ id: 'track-id', label: undefined, enabled: true });
+  });
+
+  it('returns undefined for empty local audio track snapshots', () => {
+    const collector = createCollector();
+    collector.peerConnection = {
+      getSenders: () => [
+        {
+          track: {
+            kind: 'audio',
+            id: undefined,
+            label: undefined,
+            enabled: undefined,
+            muted: undefined,
+            readyState: undefined,
+            getSettings: () => ({}),
+          },
+        },
+      ],
+    };
+
+    expect(collector._getLocalAudioTrackSnapshot()).toBeUndefined();
+  });
+
+  it('deduplicates local audio track logs with stable key ordering', () => {
+    const debugSpy = jest.spyOn(logger, 'debug').mockImplementation();
+    const collector = createCollector();
+
+    collector._logLocalAudioTrackSnapshot({
+      id: 'track-id',
+      label: 'Microphone',
+      settings: { sampleRate: 48000, channelCount: 1 },
+    });
+    collector._logLocalAudioTrackSnapshot({
+      settings: { channelCount: 1, sampleRate: 48000 },
+      label: 'Microphone',
+      id: 'track-id',
+    });
+
+    expect(debugSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('resets local audio track log deduplication on cleanup', () => {
+    const debugSpy = jest.spyOn(logger, 'debug').mockImplementation();
+    const collector = createCollector();
+    const snapshot = { id: 'track-id' };
+
+    collector._logLocalAudioTrackSnapshot(snapshot);
+    collector.cleanup();
+    collector._logLocalAudioTrackSnapshot(snapshot);
+
+    expect(debugSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns undefined for empty outbound audio media-source snapshots', () => {
+    const collector = createCollector();
+    const stats = new Map<string, unknown>([
+      ['source-id', { type: 'media-source', kind: 'audio' }],
+    ]) as unknown as RTCStatsReport;
+
+    expect(
+      collector._getOutboundAudioSourceStats(stats, {
+        type: 'outbound-rtp',
+        id: 'outbound-audio',
+        mediaSourceId: 'source-id',
+      } as RTCOutboundRtpStreamStats & { mediaSourceId?: string })
+    ).toBeUndefined();
+  });
+});

--- a/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
+++ b/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
@@ -66,11 +66,52 @@ interface ExtendedOutboundRtpStreamStats extends RTCOutboundRtpStreamStats {
  * Available in Chrome 96+ via outbound-rtp.mediaSourceId
  */
 interface ExtendedMediaSourceStats {
+  id?: string;
   type: string;
   kind?: string;
+  trackIdentifier?: string;
   audioLevel?: number;
   totalAudioEnergy?: number;
   totalSamplesDuration?: number;
+  echoReturnLoss?: number;
+  echoReturnLossEnhancement?: number;
+}
+
+/**
+ * Local audio track metadata captured from the RTCRtpSender track.
+ * Useful to distinguish RTP carrying silence from muted/ended/wrong inputs.
+ */
+export interface ILocalAudioTrackSnapshot {
+  id?: string;
+  label?: string;
+  enabled?: boolean;
+  muted?: boolean;
+  readyState?: MediaStreamTrackState;
+  contentHint?: string;
+  settings?: {
+    deviceId?: string;
+    groupId?: string;
+    channelCount?: number;
+    sampleRate?: number;
+    sampleSize?: number;
+    latency?: number;
+    echoCancellation?: boolean;
+    noiseSuppression?: boolean;
+    autoGainControl?: boolean;
+  };
+}
+
+/**
+ * Local audio media-source stats backing the outbound RTP stream.
+ */
+export interface ILocalAudioSourceStats {
+  id?: string;
+  trackIdentifier?: string;
+  audioLevel?: number;
+  totalAudioEnergy?: number;
+  totalSamplesDuration?: number;
+  echoReturnLoss?: number;
+  echoReturnLossEnhancement?: number;
 }
 
 /**
@@ -156,6 +197,8 @@ export interface IStatsInterval {
       bytesSent?: number;
       audioLevelAvg?: number;
       bitrateAvg?: number;
+      localTrack?: ILocalAudioTrackSnapshot;
+      mediaSource?: ILocalAudioSourceStats;
     };
     inbound?: {
       packetsReceived?: number;
@@ -280,6 +323,9 @@ export class CallReportCollector {
   // Previous packets values for packet loss delta calculation
   private _prevPacketsReceived: number | null = null;
   private _prevPacketsLost: number | null = null;
+
+  // Last logged local audio track snapshot, used to avoid repetitive logs.
+  private _lastLocalAudioTrackSnapshotJson: string | null = null;
 
   /** Running segment counter for multi-part reports. */
   private _segmentIndex: number = 0;
@@ -752,6 +798,14 @@ export class CallReportCollector {
         );
       }
 
+      const localAudioTrack = outboundAudio
+        ? this._getLocalAudioTrackSnapshot()
+        : undefined;
+      const localAudioSource = outboundAudio
+        ? this._getOutboundAudioSourceStats(stats, outboundAudio)
+        : undefined;
+      this._logLocalAudioTrackSnapshot(localAudioTrack, localAudioSource);
+
       this.previousStats.timestamp = now.getTime();
 
       // Check if interval is complete (end of collection period).
@@ -769,7 +823,9 @@ export class CallReportCollector {
           candidatePair,
           localCandidate,
           remoteCandidate,
-          transportStats
+          transportStats,
+          localAudioTrack,
+          localAudioSource
         );
 
         // Add to buffer with size limit
@@ -962,7 +1018,9 @@ export class CallReportCollector {
     candidatePair: ExtendedCandidatePairStats | null,
     localCandidate?: ICECandidateInfo,
     remoteCandidate?: ICECandidateInfo,
-    transportStats?: ExtendedTransportStats | null
+    transportStats?: ExtendedTransportStats | null,
+    localAudioTrack?: ILocalAudioTrackSnapshot,
+    localAudioSource?: ILocalAudioSourceStats
   ): IStatsInterval {
     const entry: IStatsInterval = {
       intervalStartUtc: start.toISOString(),
@@ -978,6 +1036,8 @@ export class CallReportCollector {
         bytesSent: outboundAudio.bytesSent,
         audioLevelAvg: this._average(this.intervalAudioLevels.outbound),
         bitrateAvg: this._average(this.intervalBitrates.outbound),
+        ...(localAudioTrack ? { localTrack: localAudioTrack } : {}),
+        ...(localAudioSource ? { mediaSource: localAudioSource } : {}),
       };
     }
 
@@ -1093,6 +1153,148 @@ export class CallReportCollector {
   }
 
   /**
+   * Resolve the local audio media-source stats backing the outbound RTP stream.
+   */
+  private _getOutboundMediaSource(
+    stats: RTCStatsReport,
+    outboundAudio: ExtendedOutboundRtpStreamStats
+  ): ExtendedMediaSourceStats | undefined {
+    let mediaSource: ExtendedMediaSourceStats | undefined;
+
+    if (outboundAudio.mediaSourceId) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mediaSource = (stats as any).get(outboundAudio.mediaSourceId) as
+        | ExtendedMediaSourceStats
+        | undefined;
+    }
+
+    if (!mediaSource) {
+      stats.forEach((report) => {
+        if (
+          !mediaSource &&
+          report.type === 'media-source' &&
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (report as any).kind === 'audio'
+        ) {
+          mediaSource = report as unknown as ExtendedMediaSourceStats;
+        }
+      });
+    }
+
+    return mediaSource;
+  }
+
+  /**
+   * Capture local sender track state. This is the missing evidence for cases
+   * where RTP bytes increase but outbound audio level remains zero.
+   */
+  private _getLocalAudioTrackSnapshot(): ILocalAudioTrackSnapshot | undefined {
+    try {
+      const sender = this.peerConnection
+        ?.getSenders()
+        .find((s) => s.track?.kind === 'audio');
+      const track = sender?.track;
+      if (!track) return undefined;
+
+      const settings = track.getSettings?.();
+      const typedSettings = settings as
+        | (MediaTrackSettings & {
+            channelCount?: number;
+            sampleRate?: number;
+            sampleSize?: number;
+            latency?: number;
+            echoCancellation?: boolean;
+            noiseSuppression?: boolean;
+            autoGainControl?: boolean;
+          })
+        | undefined;
+
+      const settingsSnapshot = this._withoutUndefined({
+        deviceId: typedSettings?.deviceId,
+        groupId: typedSettings?.groupId,
+        channelCount: typedSettings?.channelCount,
+        sampleRate: typedSettings?.sampleRate,
+        sampleSize: typedSettings?.sampleSize,
+        latency: typedSettings?.latency,
+        echoCancellation: typedSettings?.echoCancellation,
+        noiseSuppression: typedSettings?.noiseSuppression,
+        autoGainControl: typedSettings?.autoGainControl,
+      });
+
+      return this._withoutUndefined({
+        id: track.id,
+        label: track.label,
+        enabled: track.enabled,
+        muted: track.muted,
+        readyState: track.readyState,
+        // contentHint is supported by modern browsers but may not exist in
+        // older TypeScript DOM typings used by consumers.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        contentHint: (track as any).contentHint,
+        ...(Object.keys(settingsSnapshot).length > 0
+          ? { settings: settingsSnapshot }
+          : {}),
+      });
+    } catch (error) {
+      logger.debug(
+        'CallReportCollector: unable to snapshot local audio track',
+        {
+          error,
+        }
+      );
+      return undefined;
+    }
+  }
+
+  /**
+   * Capture media-source counters associated with the outbound audio sender.
+   */
+  private _getOutboundAudioSourceStats(
+    stats: RTCStatsReport,
+    outboundAudio: ExtendedOutboundRtpStreamStats
+  ): ILocalAudioSourceStats | undefined {
+    const mediaSource = this._getOutboundMediaSource(stats, outboundAudio);
+    if (!mediaSource) return undefined;
+
+    const snapshot = this._withoutUndefined({
+      id: mediaSource.id,
+      trackIdentifier: mediaSource.trackIdentifier,
+      audioLevel: mediaSource.audioLevel,
+      totalAudioEnergy: mediaSource.totalAudioEnergy,
+      totalSamplesDuration: mediaSource.totalSamplesDuration,
+      echoReturnLoss: mediaSource.echoReturnLoss,
+      echoReturnLossEnhancement: mediaSource.echoReturnLossEnhancement,
+    });
+
+    return Object.keys(snapshot).length > 0 ? snapshot : undefined;
+  }
+
+  private _logLocalAudioTrackSnapshot(
+    localAudioTrack?: ILocalAudioTrackSnapshot,
+    localAudioSource?: ILocalAudioSourceStats
+  ): void {
+    if (!localAudioTrack) return;
+
+    const snapshotJson = JSON.stringify(localAudioTrack);
+    if (snapshotJson === this._lastLocalAudioTrackSnapshotJson) return;
+
+    this._lastLocalAudioTrackSnapshotJson = snapshotJson;
+    logger.debug('CallReportCollector: local audio track snapshot', {
+      localTrack: localAudioTrack,
+      mediaSource: localAudioSource,
+    });
+  }
+
+  private _withoutUndefined<T extends Record<string, unknown>>(obj: T): T {
+    Object.keys(obj).forEach((key) => {
+      if (obj[key] === undefined) {
+        delete obj[key];
+      }
+    });
+    return obj;
+  }
+
+  /**
    * Get outbound audio level from media-source stats (Chrome 96+)
    * or compute from totalAudioEnergy deltas, or fall back to deprecated track stats.
    *
@@ -1106,29 +1308,7 @@ export class CallReportCollector {
     stats: RTCStatsReport,
     outboundAudio: ExtendedOutboundRtpStreamStats
   ): number | null {
-    // 1. Try media-source stat by ID (Chrome 96+)
-    let mediaSource: ExtendedMediaSourceStats | undefined;
-
-    if (outboundAudio.mediaSourceId) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      mediaSource = (stats as any).get(outboundAudio.mediaSourceId) as
-        | ExtendedMediaSourceStats
-        | undefined;
-    }
-
-    // 2. If mediaSourceId not set or not found, iterate stats for media-source
-    if (!mediaSource) {
-      stats.forEach((report) => {
-        if (
-          !mediaSource &&
-          report.type === 'media-source' &&
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (report as any).kind === 'audio'
-        ) {
-          mediaSource = report as unknown as ExtendedMediaSourceStats;
-        }
-      });
-    }
+    const mediaSource = this._getOutboundMediaSource(stats, outboundAudio);
 
     // Try direct audioLevel on media-source
     if (mediaSource?.audioLevel !== undefined) {

--- a/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
+++ b/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
@@ -800,12 +800,15 @@ export class CallReportCollector {
         );
       }
 
-      const localAudioTrack = outboundAudio
-        ? this._getLocalAudioTrackSnapshot()
-        : undefined;
-      const localAudioSource = outboundAudio
-        ? this._getOutboundAudioSourceStats(stats, outboundAudio)
-        : undefined;
+      let localAudioTrack: ILocalAudioTrackSnapshot | undefined;
+      let localAudioSource: ILocalAudioSourceStats | undefined;
+      if (outboundAudio) {
+        localAudioTrack = this._getLocalAudioTrackSnapshot();
+        localAudioSource = this._getOutboundAudioSourceStats(
+          stats,
+          outboundAudio
+        );
+      }
       this._logLocalAudioTrackSnapshot(localAudioTrack, localAudioSource);
 
       this.previousStats.timestamp = now.getTime();

--- a/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
+++ b/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
@@ -649,6 +649,8 @@ export class CallReportCollector {
    * be using it. The next call's constructor overwrites the global anyway.
    */
   public cleanup(): void {
+    this._lastLocalAudioTrackSnapshotJson = null;
+
     if (this.logCollector) {
       this.logCollector.clear();
       this.logCollector = null;
@@ -1221,7 +1223,7 @@ export class CallReportCollector {
         autoGainControl: typedSettings?.autoGainControl,
       });
 
-      return this._withoutUndefined({
+      const snapshot = this._withoutUndefined({
         id: track.id,
         label: track.label,
         enabled: track.enabled,
@@ -1235,6 +1237,8 @@ export class CallReportCollector {
           ? { settings: settingsSnapshot }
           : {}),
       });
+
+      return Object.keys(snapshot).length > 0 ? snapshot : undefined;
     } catch (error) {
       logger.debug(
         'CallReportCollector: unable to snapshot local audio track',
@@ -1273,9 +1277,9 @@ export class CallReportCollector {
     localAudioTrack?: ILocalAudioTrackSnapshot,
     localAudioSource?: ILocalAudioSourceStats
   ): void {
-    if (!localAudioTrack) return;
+    if (!localAudioTrack || Object.keys(localAudioTrack).length === 0) return;
 
-    const snapshotJson = JSON.stringify(localAudioTrack);
+    const snapshotJson = this._stableStringify(localAudioTrack);
     if (snapshotJson === this._lastLocalAudioTrackSnapshotJson) return;
 
     this._lastLocalAudioTrackSnapshotJson = snapshotJson;
@@ -1286,12 +1290,36 @@ export class CallReportCollector {
   }
 
   private _withoutUndefined<T extends Record<string, unknown>>(obj: T): T {
-    Object.keys(obj).forEach((key) => {
-      if (obj[key] === undefined) {
-        delete obj[key];
+    return Object.keys(obj).reduce<Record<string, unknown>>((clean, key) => {
+      const value = obj[key];
+      if (value !== undefined) {
+        clean[key] = value;
       }
-    });
-    return obj;
+      return clean;
+    }, {}) as T;
+  }
+
+  private _stableStringify(value: unknown): string {
+    return JSON.stringify(this._sortObjectKeys(value));
+  }
+
+  private _sortObjectKeys(value: unknown): unknown {
+    if (Array.isArray(value)) {
+      return value.map((item) => this._sortObjectKeys(item));
+    }
+
+    if (value && typeof value === 'object') {
+      return Object.keys(value as Record<string, unknown>)
+        .sort()
+        .reduce<Record<string, unknown>>((sorted, key) => {
+          sorted[key] = this._sortObjectKeys(
+            (value as Record<string, unknown>)[key]
+          );
+          return sorted;
+        }, {});
+    }
+
+    return value;
   }
 
   /**


### PR DESCRIPTION
## Summary

- Add local audio sender track metadata to call report outbound audio intervals:
  - `id`, `label`, `enabled`, `muted`, `readyState`, `contentHint`
  - selected input settings including `deviceId`, `groupId`, `channelCount`, `sampleRate`, `echoCancellation`, `noiseSuppression`, `autoGainControl`
- Add outbound `media-source` stats to call reports:
  - `trackIdentifier`, `audioLevel`, `totalAudioEnergy`, `totalSamplesDuration`, echo return loss fields when available
- Log a `CallReportCollector: local audio track snapshot` debug entry when local audio track state changes, without repeating it every stats interval.

## Why

Muted/silent outbound investigations currently show RTP bytes/packets increasing, but not whether the local browser track was muted, ended, using the wrong input device, or producing zero-energy source audio.

From two call reports:

- CSV window: 521 client invites from `2026-05-12T12:53:15Z` to `2026-05-12T14:05:30Z`, all `Web-2.25.25`.
- Selected mics varied across the window: Sanas Virtual Audio and many Jabra device instances.
- Silent sample `db85878a-34f7-41ee-9d82-a135dc5affac` used `Microphone (10- Jabra EVOLVE 20) (0b0e:0301)` and had outbound RTP increasing while `audioLevelAvg` stayed `0`.
- Comparison sample `4e570cce-d252-4fcf-a7e8-2de3db0e132a` used `Microphone (Sanas Virtual Audio)` and had non-zero outbound audio initially.

This PR adds the missing endpoint/source evidence needed to distinguish RTP transport issues from wrong/muted/silent local input.

## Validation

- `yarn workspace @telnyx/webrtc build`
- `yarn workspace @telnyx/webrtc test src/Modules/Verto/tests/webrtc/Call.test.ts src/Modules/Verto/tests/webrtc/Call.trickle-ice.test.ts --runInBand`
