### PR TITLE
Fix: address PR #607 review comments

### DIFF
--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -57,6 +57,7 @@ import {
   Role,
   State,
   VertoMethod,
+  VertoModifyAction,
 } from './constants';
 import {
   checkSubscribeResponse,
@@ -598,7 +599,7 @@ export default abstract class BaseCall implements IWebRTCCall {
   hold(): Promise<any> {
     const msg = new Modify({
       sessid: this.session.sessionid,
-      action: 'hold',
+      action: VertoModifyAction.Hold,
       dialogParams: this.options,
     });
     return this._execute(msg)
@@ -632,7 +633,7 @@ export default abstract class BaseCall implements IWebRTCCall {
   unhold(): Promise<any> {
     const msg = new Modify({
       sessid: this.session.sessionid,
-      action: 'unhold',
+      action: VertoModifyAction.Unhold,
       dialogParams: this.options,
     });
     return this._execute(msg)
@@ -661,7 +662,7 @@ export default abstract class BaseCall implements IWebRTCCall {
   toggleHold(): Promise<any> {
     const msg = new Modify({
       sessid: this.session.sessionid,
-      action: 'toggleHold',
+      action: VertoModifyAction.ToggleHold,
       dialogParams: this.options,
     });
     return this._execute(msg)
@@ -1152,6 +1153,10 @@ export default abstract class BaseCall implements IWebRTCCall {
           } else {
             this._onRemoteSdp(params.sdp);
           }
+        } else {
+          logger.error(
+            `[${this.id}] Received Modify with missing/empty SDP — action=${params?.action}, callID=${params?.callID}. A Modify message carrying SDP must include a valid SDP payload.`
+          );
         }
         break;
       }
@@ -1437,7 +1442,7 @@ export default abstract class BaseCall implements IWebRTCCall {
   private _sendIceRestartModify(sdp: string) {
     const modifyMsg = new Modify({
       sessid: this.session.sessionid,
-      action: 'updateMedia',
+      action: VertoModifyAction.UpdateMedia,
       callID: this.options.id,
       sdp,
       dialogParams: this.options,
@@ -1449,6 +1454,10 @@ export default abstract class BaseCall implements IWebRTCCall {
         this.peer?.finishIceRestart();
         if (response?.sdp) {
           await this._onRemoteSdp(response.sdp);
+        } else {
+          logger.error(
+            `[${this.id}] ICE restart Modify response missing SDP — the remote answer SDP is required to complete ICE restart. The media path may not recover.`
+          );
         }
       })
       .catch((error) => {
@@ -1482,15 +1491,61 @@ export default abstract class BaseCall implements IWebRTCCall {
       const answer = await this.peer.instance.createAnswer();
       await this.peer.instance.setLocalDescription(answer);
 
-      const modifyMsg = new Modify({
-        sessid: this.session.sessionid,
-        action: 'updateMedia',
-        callID: this.options.id,
-        sdp: answer.sdp,
-        dialogParams: this.options,
-      });
-      logger.info('Server-initiated Modify: sending answer SDP');
-      await this._execute(modifyMsg);
+      if (this.options.trickleIce) {
+        // Trickle ICE: send the answer SDP immediately; candidates follow separately.
+        const modifyMsg = new Modify({
+          sessid: this.session.sessionid,
+          action: VertoModifyAction.UpdateMedia,
+          callID: this.options.id,
+          sdp: answer.sdp,
+          dialogParams: this.options,
+        });
+        logger.info(
+          'Server-initiated Modify (trickle): sending answer SDP immediately'
+        );
+        await this._execute(modifyMsg);
+      } else {
+        // Non-trickle ICE: wait until ICE gathering completes so the
+        // Modify carries a complete SDP with all candidates. Sending the
+        // answer.sdp immediately after setLocalDescription() would send
+        // an SDP without candidates for non-trickle calls.
+        const sendModify = (sdpToSend: string) => {
+          const modifyMsg = new Modify({
+            sessid: this.session.sessionid,
+            action: VertoModifyAction.UpdateMedia,
+            callID: this.options.id,
+            sdp: sdpToSend,
+            dialogParams: this.options,
+          });
+          logger.info(
+            'Server-initiated Modify (non-trickle): sending answer SDP after ICE gathering'
+          );
+          this._execute(modifyMsg).catch((error) => {
+            logger.error(
+              'Server-initiated Modify (non-trickle) failed:',
+              error
+            );
+          });
+        };
+
+        // If ICE gathering is already complete, send immediately
+        if (this.peer.instance.iceGatheringState === 'complete') {
+          sendModify(this.peer.instance.localDescription.sdp);
+        } else {
+          // Wait for ICE gathering to complete
+          const onGatheringComplete = () => {
+            this.peer.instance.removeEventListener(
+              'icegatheringstatechange',
+              onGatheringComplete
+            );
+            sendModify(this.peer.instance.localDescription.sdp);
+          };
+          this.peer.instance.addEventListener(
+            'icegatheringstatechange',
+            onGatheringComplete
+          );
+        }
+      }
     } catch (error) {
       logger.error('Failed to handle server-initiated Modify offer:', error);
     }
@@ -1891,6 +1946,17 @@ export default abstract class BaseCall implements IWebRTCCall {
     });
   }
 
+  /**
+   * Register peer connection event handlers.
+   *
+   * Previously, trickle and non-trickle ICE had separate registration methods
+   * (_registerTrickleIcePeerEvents and _registerPeerEvents). They have been
+   * consolidated into this single method so that the `onicecandidate` handler
+   * can choose the trickle vs non-trickle path *at runtime* — this is required
+   * for ICE restart, which forces non-trickle Modify even when the call was
+   * originally trickle. The check `this.options.trickleIce && !this.peer?.isIceRestarting`
+   * determines the path dynamically per-candidate.
+   */
   private _registerPeerEvents(instance: RTCPeerConnection) {
     instance.onicecandidate = (event) => {
       const useTrickle = this.options.trickleIce && !this.peer?.isIceRestarting;

--- a/packages/js/src/Modules/Verto/webrtc/Peer.ts
+++ b/packages/js/src/Modules/Verto/webrtc/Peer.ts
@@ -76,7 +76,7 @@ export default class Peer {
   private _timingsCollected: boolean = false;
   private _iceRestartTimeoutId: ReturnType<typeof setTimeout> | null = null;
   private static readonly ICE_RESTART_TIMEOUT_MS = 15000;
-  private _wasOffline: boolean = false;
+  private _hadOfflineEvent: boolean = false;
   private _offlineHandler: (() => void) | null = null;
 
   constructor(
@@ -105,10 +105,10 @@ export default class Peer {
     this._trickleIceSdpFn = trickleIceSdpFn;
     this._registerPeerEvents = registerPeerEvents;
     // Track offline events independently so ICE restart and Attach never race.
-    // _wasOffline is only cleared on peer `connected`, not on `online`.
+    // _hadOfflineEvent is only cleared on peer `connected`, not on `online`.
     if (typeof window !== 'undefined') {
       this._offlineHandler = () => {
-        this._wasOffline = true;
+        this._hadOfflineEvent = true;
       };
       window.addEventListener('offline', this._offlineHandler);
     }
@@ -292,14 +292,15 @@ export default class Peer {
 
       // ICE restart: fire only when the browser never went offline during
       // this peer's lifetime. If `window.offline` fired, the Attach flow
-      // owns recovery exclusively. _wasOffline is only cleared on `connected`,
+      // owns recovery exclusively. _hadOfflineEvent is only cleared on `connected`,
       // not on the `online` event, so there's no race with BrowserSession's
       // online handler.
+      const canRestartIceWithoutAttach =
+        !this._hadOfflineEvent && this._session.connected;
       if (
         !this._restartedIceOnConnectionStateFailed &&
         (connectionState === 'failed' || connectionState === 'disconnected') &&
-        !this._wasOffline &&
-        this._session.connected
+        canRestartIceWithoutAttach
       ) {
         this.isIceRestarting = true;
         this._restartedIceOnConnectionStateFailed = true;
@@ -323,7 +324,7 @@ export default class Peer {
           this._iceRestartTimeoutId = null;
         }, Peer.ICE_RESTART_TIMEOUT_MS);
         logger.info(
-          `ICE restart: peer ${connectionState}, no offline event detected. Creating new offer via Modify.`
+          `ICE restart: peer ${connectionState}, canRestartIceWithoutAttach=${canRestartIceWithoutAttach}. Creating new offer via Modify.`
         );
       }
     }
@@ -366,9 +367,13 @@ export default class Peer {
       this.tryCollectTimings();
 
       // Successful (re)connection — allow future ICE restarts if we fail again.
+      // Only clear the restart-gate and offline flag here; isIceRestarting
+      // must remain true until the Modify exchange completes (see
+      // _sendIceRestartModify in BaseCall) or the safety timeout fires.
+      // Calling finishIceRestart() here would clear isIceRestarting before
+      // the Modify SDP is even sent, breaking the ICE restart flow.
       this._restartedIceOnConnectionStateFailed = false;
-      this._wasOffline = false;
-      this.finishIceRestart();
+      this._hadOfflineEvent = false;
     }
 
     if (this._isTrickleIce()) {

--- a/packages/js/src/Modules/Verto/webrtc/constants.ts
+++ b/packages/js/src/Modules/Verto/webrtc/constants.ts
@@ -120,3 +120,14 @@ export enum GatewayStateType {
   EXPIRED = 'EXPIRED',
   UNREGISTER = 'UNREGISTER',
 }
+
+/**
+ * Action strings used in Verto Modify messages.
+ * @see https://github.com/team-telnyx/webrtc/blob/main/packages/js/src/Modules/Verto/messages/Verto.ts
+ */
+export enum VertoModifyAction {
+  Hold = 'hold',
+  Unhold = 'unhold',
+  ToggleHold = 'toggleHold',
+  UpdateMedia = 'updateMedia',
+}


### PR DESCRIPTION
Addresses all 6 review comments from PR #607:

1. **ICE restart lifecycle**: Removed `finishIceRestart()` from Peer `connected` state handler. `isIceRestarting` now stays true until the Modify exchange completes (success/failure/timeout), preventing premature clearing that would break the ICE restart flow.

2. **Server-initiated Modify non-trickle**: Split `_handleServerModifyOffer()` into trickle and non-trickle paths. Non-trickle now waits for ICE gathering to complete before sending the answer SDP in Modify, preventing incomplete SDPs from being sent.

3. **SDP validation/logging**: Added error logging when incoming Modify has missing/empty `params.sdp`, and when ICE restart Modify response has missing/empty `response.sdp`.

4. **`updateMedia` constant**: Added `VertoModifyAction` enum in constants.ts with `Hold`, `Unhold`, `ToggleHold`, `UpdateMedia`. Replaced all hardcoded action strings in BaseCall.ts.

5. **Rename `_wasOffline`**: Renamed to `_hadOfflineEvent` for clarity. Extracted `canRestartIceWithoutAttach` boolean to make the ICE restart condition self-documenting.

6. **Consolidated methods comment**: Added JSDoc on `_registerPeerEvents` explaining that the previously separate trickle/non-trickle registration methods were consolidated so the `onicecandidate` handler can choose the path at runtime (required for ICE restart which forces non-trickle even on trickle calls).