### PR TITLE
VSDK-197: Add maxReconnectAttempts option for socket reconnection limit

### DIFF
--- a/packages/js/src/Modules/Verto/BaseSession.ts
+++ b/packages/js/src/Modules/Verto/BaseSession.ts
@@ -15,6 +15,7 @@ import {
   LOGIN_FAILED,
   INVALID_CREDENTIALS,
   TOKEN_EXPIRING_SOON,
+  RECONNECTION_EXHAUSTED,
 } from './util/constants';
 import { createTelnyxError, createTelnyxWarning } from './util/errors';
 import type { ITelnyxErrorEvent } from './util/errors';
@@ -69,6 +70,7 @@ export default abstract class BaseSession {
   protected _reconnectTimeout: any;
   protected _autoReconnect: boolean = true;
   protected _idle: boolean = false;
+  protected _reconnectAttempts: number = 0;
 
   private _tokenExpiryTimeout: ReturnType<typeof setTimeout> | null = null;
   private static readonly TOKEN_EXPIRY_WARNING_SECONDS = 120;
@@ -203,6 +205,7 @@ export default abstract class BaseSession {
     this._clearTokenExpiryTimeout();
     this.subscriptions = {};
     this._autoReconnect = false;
+    this._reconnectAttempts = 0;
     this.relayProtocol = null;
     this._closeConnection();
     await sessionStorage.removeItem(this.signature);
@@ -327,12 +330,28 @@ export default abstract class BaseSession {
     }
 
     this._attachListeners();
+
+    // If auto-reconnect was disabled (e.g. after exhaustion or disconnect),
+    // reset the counter so a fresh retry sequence starts.
+    if (!this._autoReconnect) {
+      this._reconnectAttempts = 0;
+    }
+
     this._autoReconnect = true;
     if (!this.connection.isAlive) {
       logger.debug('Initiating connection to the server...');
       this.connection.connect();
     }
     logger.debug('Connect method called. Connection initiated.');
+  }
+
+  /**
+   * Reset the automatic reconnection attempt counter.
+   * Call this when the connection is fully established (e.g. on REGED)
+   * or when the user manually initiates a reconnect after exhaustion.
+   */
+  public resetReconnectAttempts(): void {
+    this._reconnectAttempts = 0;
   }
 
   /**
@@ -611,6 +630,30 @@ export default abstract class BaseSession {
     }
 
     if (this._autoReconnect) {
+      const maxAttempts = this.options.maxReconnectAttempts || 0;
+
+      this._reconnectAttempts += 1;
+
+      if (maxAttempts > 0 && this._reconnectAttempts > maxAttempts) {
+        logger.info(
+          `Reconnection exhausted after ${maxAttempts} attempts. Stopping automatic reconnect.`
+        );
+        this._reconnectAttempts = 0;
+        this._autoReconnect = false;
+
+        const telnyxError = createTelnyxError(RECONNECTION_EXHAUSTED);
+        trigger(
+          SwEvent.Error,
+          { error: telnyxError, sessionId: this.sessionid },
+          this.uuid
+        );
+        return;
+      }
+
+      logger.debug(
+        `Reconnect attempt ${this._reconnectAttempts}${maxAttempts > 0 ? ` of ${maxAttempts}` : ''}`
+      );
+
       this._reconnectTimeout = setTimeout(() => {
         logger.debug(
           'Calling connect due to network close and auto-reconnect enabled.'

--- a/packages/js/src/Modules/Verto/BaseSession.ts
+++ b/packages/js/src/Modules/Verto/BaseSession.ts
@@ -630,7 +630,7 @@ export default abstract class BaseSession {
     }
 
     if (this._autoReconnect) {
-      const maxAttempts = this.options.maxReconnectAttempts ?? 5;
+      const maxAttempts = this.options.maxReconnectAttempts ?? 10;
 
       this._reconnectAttempts += 1;
 

--- a/packages/js/src/Modules/Verto/BaseSession.ts
+++ b/packages/js/src/Modules/Verto/BaseSession.ts
@@ -630,7 +630,7 @@ export default abstract class BaseSession {
     }
 
     if (this._autoReconnect) {
-      const maxAttempts = this.options.maxReconnectAttempts || 0;
+      const maxAttempts = this.options.maxReconnectAttempts ?? 5;
 
       this._reconnectAttempts += 1;
 

--- a/packages/js/src/Modules/Verto/tests/ReconnectAttempts.test.ts
+++ b/packages/js/src/Modules/Verto/tests/ReconnectAttempts.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Unit tests for socket reconnection attempt limit (VSDK-197)
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import BaseSession from '../BaseSession';
+import { trigger } from '../services/Handler';
+import { SwEvent, RECONNECTION_EXHAUSTED } from '../util/constants';
+
+// Mock dependencies
+jest.mock('../services/Connection');
+jest.mock('../services/Handler');
+jest.mock('../util/logger');
+jest.mock('../util/reconnect', () => ({
+  getReconnectToken: jest.fn(() => null),
+  setReconnectToken: jest.fn(),
+  clearReconnectToken: jest.fn(),
+}));
+
+const mockTrigger = trigger as jest.MockedFunction<typeof trigger>;
+
+/**
+ * Concrete subclass for testing the abstract BaseSession
+ */
+class TestSession extends BaseSession {
+  validateOptions() {
+    return true;
+  }
+}
+
+describe('BaseSession - Reconnection Attempt Limit', () => {
+  let session: any;
+  let mockConnection: any;
+
+  const createSession = (options: any = {}) => {
+    return new TestSession({
+      login: 'testuser',
+      password: 'testpass',
+      ...options,
+    });
+  };
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockTrigger.mockClear();
+
+    session = createSession();
+    mockConnection = {
+      close: jest.fn(),
+      connect: jest.fn(),
+      isAlive: false,
+      connected: false,
+      previousGatewayState: '',
+    };
+    session.connection = mockConnection;
+    session._autoReconnect = true;
+    session._idle = false;
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('default behavior (maxReconnectAttempts = 0, unlimited)', () => {
+    it('should allow unlimited reconnection attempts when maxReconnectAttempts is 0', () => {
+      session.options.maxReconnectAttempts = 0;
+
+      for (let i = 0; i < 20; i++) {
+        session.onNetworkClose();
+        jest.runAllTimers();
+      }
+
+      expect(session._reconnectAttempts).toBe(20);
+      expect(session._autoReconnect).toBe(true);
+    });
+
+    it('should allow unlimited reconnection attempts when maxReconnectAttempts is not set', () => {
+      delete session.options.maxReconnectAttempts;
+
+      for (let i = 0; i < 15; i++) {
+        session.onNetworkClose();
+        jest.runAllTimers();
+      }
+
+      expect(session._reconnectAttempts).toBe(15);
+      expect(session._autoReconnect).toBe(true);
+    });
+  });
+
+  describe('with maxReconnectAttempts set', () => {
+    it('should increment _reconnectAttempts on each onNetworkClose call', () => {
+      session.options.maxReconnectAttempts = 5;
+
+      session.onNetworkClose();
+      expect(session._reconnectAttempts).toBe(1);
+
+      jest.runAllTimers();
+      session.onNetworkClose();
+      expect(session._reconnectAttempts).toBe(2);
+    });
+
+    it('should stop reconnecting after maxReconnectAttempts is reached', () => {
+      session.options.maxReconnectAttempts = 3;
+
+      session.onNetworkClose();
+      expect(session._reconnectAttempts).toBe(1);
+      expect(session._autoReconnect).toBe(true);
+
+      jest.runAllTimers();
+      session.onNetworkClose();
+      expect(session._reconnectAttempts).toBe(2);
+      expect(session._autoReconnect).toBe(true);
+
+      jest.runAllTimers();
+      session.onNetworkClose();
+      expect(session._reconnectAttempts).toBe(3);
+      expect(session._autoReconnect).toBe(true);
+
+      jest.runAllTimers();
+      session.onNetworkClose();
+      expect(session._autoReconnect).toBe(false);
+    });
+
+    it('should emit RECONNECTION_EXHAUSTED error when limit is reached', () => {
+      session.options.maxReconnectAttempts = 2;
+
+      session.onNetworkClose();
+      jest.runAllTimers();
+      session.onNetworkClose();
+      jest.runAllTimers();
+      session.onNetworkClose();
+
+      expect(mockTrigger).toHaveBeenCalledWith(
+        SwEvent.Error,
+        expect.objectContaining({
+          error: expect.objectContaining({ code: RECONNECTION_EXHAUSTED }),
+        }),
+        session.uuid
+      );
+    });
+
+    it('should reset _reconnectAttempts to 0 after exhaustion', () => {
+      session.options.maxReconnectAttempts = 1;
+
+      session.onNetworkClose();
+      jest.runAllTimers();
+      session.onNetworkClose();
+
+      expect(session._reconnectAttempts).toBe(0);
+      expect(session._autoReconnect).toBe(false);
+    });
+
+    it('should not schedule a reconnect timeout after exhaustion', () => {
+      session.options.maxReconnectAttempts = 1;
+
+      session.onNetworkClose();
+      jest.runAllTimers();
+      session.onNetworkClose();
+
+      expect(session._autoReconnect).toBe(false);
+    });
+
+    it('should allow manual connect() after exhaustion', () => {
+      session.options.maxReconnectAttempts = 1;
+
+      // Exhaust reconnection
+      session.onNetworkClose();
+      jest.runAllTimers();
+      session.onNetworkClose();
+      expect(session._autoReconnect).toBe(false);
+
+      // Manual connect should reset the counter and re-enable autoReconnect
+      session.connect();
+      expect(session._autoReconnect).toBe(true);
+      expect(session._reconnectAttempts).toBe(0);
+    });
+  });
+
+  describe('resetReconnectAttempts()', () => {
+    it('should reset the reconnection attempt counter', () => {
+      session.options.maxReconnectAttempts = 5;
+      session.onNetworkClose();
+      session.onNetworkClose();
+      expect(session._reconnectAttempts).toBe(2);
+
+      session.resetReconnectAttempts();
+      expect(session._reconnectAttempts).toBe(0);
+    });
+  });
+
+  describe('disconnect()', () => {
+    it('should reset _reconnectAttempts and disable autoReconnect', async () => {
+      session.options.maxReconnectAttempts = 5;
+      session.onNetworkClose();
+      session.onNetworkClose();
+      expect(session._reconnectAttempts).toBe(2);
+
+      await session.disconnect();
+      expect(session._reconnectAttempts).toBe(0);
+      expect(session._autoReconnect).toBe(false);
+    });
+  });
+
+  describe('connect()', () => {
+    it('should reset _reconnectAttempts when _autoReconnect was false', () => {
+      session._autoReconnect = false;
+      session._reconnectAttempts = 5;
+
+      session.connect();
+
+      expect(session._reconnectAttempts).toBe(0);
+      expect(session._autoReconnect).toBe(true);
+    });
+
+    it('should NOT reset _reconnectAttempts during auto-reconnect', () => {
+      session.options.maxReconnectAttempts = 5;
+      session.onNetworkClose();
+      expect(session._reconnectAttempts).toBe(1);
+
+      // connect() is called by auto-reconnect, _autoReconnect is still true
+      session.connect();
+      expect(session._reconnectAttempts).toBe(1);
+    });
+  });
+});

--- a/packages/js/src/Modules/Verto/tests/ReconnectAttempts.test.ts
+++ b/packages/js/src/Modules/Verto/tests/ReconnectAttempts.test.ts
@@ -63,20 +63,20 @@ describe('BaseSession - Reconnection Attempt Limit', () => {
   });
 
   describe('default behavior', () => {
-    it('should default to 5 reconnection attempts when maxReconnectAttempts is omitted', () => {
+    it('should default to 10 reconnection attempts when maxReconnectAttempts is omitted', () => {
       delete session.options.maxReconnectAttempts;
 
-      // Omitted option defaults to 5 via ?? operator
-      for (let i = 0; i < 5; i++) {
+      // Omitted option defaults to 10 via ?? operator
+      for (let i = 0; i < 10; i++) {
         session.onNetworkClose();
         jest.runAllTimers();
       }
 
-      // 5 attempts should still be within the limit
-      expect(session._reconnectAttempts).toBe(5);
+      // 10 attempts should still be within the limit
+      expect(session._reconnectAttempts).toBe(10);
       expect(session._autoReconnect).toBe(true);
 
-      // The 6th onNetworkClose should exceed the default limit of 5
+      // The 11th onNetworkClose should exceed the default limit of 10
       session.onNetworkClose();
       expect(session._autoReconnect).toBe(false);
     });

--- a/packages/js/src/Modules/Verto/tests/ReconnectAttempts.test.ts
+++ b/packages/js/src/Modules/Verto/tests/ReconnectAttempts.test.ts
@@ -62,8 +62,26 @@ describe('BaseSession - Reconnection Attempt Limit', () => {
     jest.useRealTimers();
   });
 
-  describe('default behavior (maxReconnectAttempts = 0, unlimited)', () => {
-    it('should allow unlimited reconnection attempts when maxReconnectAttempts is 0', () => {
+  describe('default behavior', () => {
+    it('should default to 5 reconnection attempts when maxReconnectAttempts is omitted', () => {
+      delete session.options.maxReconnectAttempts;
+
+      // Omitted option defaults to 5 via ?? operator
+      for (let i = 0; i < 5; i++) {
+        session.onNetworkClose();
+        jest.runAllTimers();
+      }
+
+      // 5 attempts should still be within the limit
+      expect(session._reconnectAttempts).toBe(5);
+      expect(session._autoReconnect).toBe(true);
+
+      // The 6th onNetworkClose should exceed the default limit of 5
+      session.onNetworkClose();
+      expect(session._autoReconnect).toBe(false);
+    });
+
+    it('should allow unlimited reconnection attempts when maxReconnectAttempts is explicitly 0', () => {
       session.options.maxReconnectAttempts = 0;
 
       for (let i = 0; i < 20; i++) {
@@ -72,18 +90,6 @@ describe('BaseSession - Reconnection Attempt Limit', () => {
       }
 
       expect(session._reconnectAttempts).toBe(20);
-      expect(session._autoReconnect).toBe(true);
-    });
-
-    it('should allow unlimited reconnection attempts when maxReconnectAttempts is not set', () => {
-      delete session.options.maxReconnectAttempts;
-
-      for (let i = 0; i < 15; i++) {
-        session.onNetworkClose();
-        jest.runAllTimers();
-      }
-
-      expect(session._reconnectAttempts).toBe(15);
       expect(session._autoReconnect).toBe(true);
     });
   });
@@ -159,6 +165,11 @@ describe('BaseSession - Reconnection Attempt Limit', () => {
       session.onNetworkClose();
 
       expect(session._autoReconnect).toBe(false);
+
+      // Advance timers and verify connect is NOT called again
+      const callCountBefore = mockConnection.connect.mock.calls.length;
+      jest.runAllTimers();
+      expect(mockConnection.connect.mock.calls.length).toBe(callCountBefore);
     });
 
     it('should allow manual connect() after exhaustion', () => {
@@ -174,6 +185,76 @@ describe('BaseSession - Reconnection Attempt Limit', () => {
       session.connect();
       expect(session._autoReconnect).toBe(true);
       expect(session._reconnectAttempts).toBe(0);
+    });
+  });
+
+  describe('unhealthy reconnect (socket opens but closes before REGED)', () => {
+    it('should not reset attempts when socket opens during auto-reconnect without REGED', () => {
+      session.options.maxReconnectAttempts = 3;
+
+      // Attempt 1: network closes, auto-reconnect timer fires connect()
+      session.onNetworkClose();
+      expect(session._reconnectAttempts).toBe(1);
+
+      // Auto-reconnect calls connect() — socket opens, but _autoReconnect
+      // is still true so connect() does NOT reset the counter
+      jest.runAllTimers();
+      session.connect(); // simulate reconnect connect() call
+      expect(session._reconnectAttempts).toBe(1); // unchanged
+
+      // Socket closes before REGED — this is NOT a reset, attempts continue
+      session.onNetworkClose();
+      expect(session._reconnectAttempts).toBe(2);
+
+      // Attempt 3: another connect() without REGED
+      jest.runAllTimers();
+      session.connect();
+      session.onNetworkClose();
+      expect(session._reconnectAttempts).toBe(3);
+
+      // Attempt 4 exceeds limit → exhaustion
+      jest.runAllTimers();
+      session.onNetworkClose();
+      expect(session._autoReconnect).toBe(false);
+      expect(mockTrigger).toHaveBeenCalledWith(
+        SwEvent.Error,
+        expect.objectContaining({
+          error: expect.objectContaining({ code: RECONNECTION_EXHAUSTED }),
+        }),
+        session.uuid
+      );
+    });
+
+    it('should reset attempts after confirmed REGED and start a fresh bounded sequence', () => {
+      session.options.maxReconnectAttempts = 3;
+
+      // Attempt 1-2: network closes trigger reconnects
+      session.onNetworkClose();
+      jest.runAllTimers();
+      session.onNetworkClose();
+      expect(session._reconnectAttempts).toBe(2);
+
+      // Socket opens, REGED received → resetReconnectAttempts() is called
+      // (in production this is called by VertoHandler on REGED)
+      session.resetReconnectAttempts();
+      expect(session._reconnectAttempts).toBe(0);
+
+      // Next network close starts a fresh bounded sequence
+      session.onNetworkClose();
+      expect(session._reconnectAttempts).toBe(1);
+      expect(session._autoReconnect).toBe(true);
+
+      // Can go through the full limit again
+      jest.runAllTimers();
+      session.onNetworkClose();
+      jest.runAllTimers();
+      session.onNetworkClose();
+      expect(session._reconnectAttempts).toBe(3);
+      expect(session._autoReconnect).toBe(true);
+
+      jest.runAllTimers();
+      session.onNetworkClose();
+      expect(session._autoReconnect).toBe(false);
     });
   });
 

--- a/packages/js/src/Modules/Verto/tests/webrtc/VertoHandler.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/VertoHandler.test.ts
@@ -305,6 +305,55 @@ describe('VertoHandler', () => {
     });
   });
 
+  describe('resetReconnectAttempts on gateway state', () => {
+    it('should NOT reset reconnect attempts on REGISTER', () => {
+      (instance as any)._reconnectAttempts = 3;
+      instance.connection.previousGatewayState = '';
+
+      const registerMsg = JSON.parse(
+        '{"jsonrpc":"2.0","id":"reg-1","result":{"params":{"state":"REGISTER"},"sessid":"sess1"}}'
+      );
+      handler.handleMessage(registerMsg);
+
+      expect((instance as any)._reconnectAttempts).toBe(3);
+    });
+
+    it('should reset reconnect attempts on REGED', () => {
+      (instance as any)._reconnectAttempts = 3;
+      instance.connection.previousGatewayState = '';
+
+      const regedMsg = JSON.parse(
+        '{"jsonrpc":"2.0","id":"reg-2","result":{"params":{"state":"REGED"},"sessid":"sess1"}}'
+      );
+      handler.handleMessage(regedMsg);
+
+      expect((instance as any)._reconnectAttempts).toBe(0);
+    });
+
+    it('REGISTER followed by socket close should preserve attempt count', () => {
+      (instance as any)._reconnectAttempts = 2;
+      instance.connection.previousGatewayState = '';
+
+      // REGISTER does not reset attempts
+      const registerMsg = JSON.parse(
+        '{"jsonrpc":"2.0","id":"reg-3","result":{"params":{"state":"REGISTER"},"sessid":"sess1"}}'
+      );
+      handler.handleMessage(registerMsg);
+      expect((instance as any)._reconnectAttempts).toBe(2);
+
+      // Socket closes before REGED — attempts still intact
+      instance.connection.previousGatewayState = '';
+      (instance as any)._reconnectAttempts = 3;
+
+      // Then REGED arrives — now reset
+      const regedMsg = JSON.parse(
+        '{"jsonrpc":"2.0","id":"reg-4","result":{"params":{"state":"REGED"},"sessid":"sess1"}}'
+      );
+      handler.handleMessage(regedMsg);
+      expect((instance as any)._reconnectAttempts).toBe(0);
+    });
+  });
+
   describe('should fire telnyx.ready again after socket reconnection', () => {
     it('fires telnyx.ready again when previousGatewayState is reset after socket close', () => {
       const regedMsg = JSON.parse(

--- a/packages/js/src/Modules/Verto/util/interfaces.ts
+++ b/packages/js/src/Modules/Verto/util/interfaces.ts
@@ -54,6 +54,18 @@ export interface IVertoOptions {
   rtcPort?: number;
   mutedMicOnStart?: boolean;
   /**
+   * Maximum number of automatic socket reconnection attempts after an unexpected
+   * disconnect. When the limit is reached, no further automatic reconnects are
+   * scheduled and a `telnyx.error` event with code `RECONNECTION_EXHAUSTED` (45003)
+   * is emitted. A manual `connect()` call resets the counter and starts a fresh
+   * retry sequence.
+   *
+   * Set to `0` or omit to allow unlimited automatic reconnect attempts (default).
+   * @default 0 (unlimited)
+   */
+  maxReconnectAttempts?: number;
+
+  /**
    * Enable automatic call quality reporting to voice-sdk-proxy.
    * When enabled, collects WebRTC stats and debug logs during calls.
    * @default true

--- a/packages/js/src/Modules/Verto/util/interfaces.ts
+++ b/packages/js/src/Modules/Verto/util/interfaces.ts
@@ -60,8 +60,9 @@ export interface IVertoOptions {
    * is emitted. A manual `connect()` call resets the counter and starts a fresh
    * retry sequence.
    *
-   * Set to `0` or omit to allow unlimited automatic reconnect attempts (default).
-   * @default 0 (unlimited)
+   * Set to `0` to allow unlimited automatic reconnect attempts.
+   * When omitted, defaults to `5`.
+   * @default 5
    */
   maxReconnectAttempts?: number;
 

--- a/packages/js/src/Modules/Verto/util/interfaces.ts
+++ b/packages/js/src/Modules/Verto/util/interfaces.ts
@@ -61,8 +61,8 @@ export interface IVertoOptions {
    * retry sequence.
    *
    * Set to `0` to allow unlimited automatic reconnect attempts.
-   * When omitted, defaults to `5`.
-   * @default 5
+   * When omitted, defaults to `10`.
+   * @default 10
    */
   maxReconnectAttempts?: number;
 

--- a/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
+++ b/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
@@ -279,6 +279,7 @@ class VertoHandler {
               ) {
                 this.session._triggerKeepAliveTimeoutCheck();
                 this.retriedRegister = 0;
+                this.session.resetReconnectAttempts();
 
                 // Capture call_report_id for SDK call reporting
                 const callReportId = msg?.result?.params?.call_report_id;

--- a/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
+++ b/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
@@ -279,7 +279,15 @@ class VertoHandler {
               ) {
                 this.session._triggerKeepAliveTimeoutCheck();
                 this.retriedRegister = 0;
-                this.session.resetReconnectAttempts();
+
+                // Only reset reconnect attempts on confirmed healthy
+                // registration (REGED). REGISTER alone does not guarantee
+                // the session is fully established — the socket could
+                // still close before REGED, masking an unhealthy
+                // reconnect loop if we reset too early.
+                if (gateWayState === GatewayStateType.REGED) {
+                  this.session.resetReconnectAttempts();
+                }
 
                 // Capture call_report_id for SDK call reporting
                 const callReportId = msg?.result?.params?.call_report_id;

--- a/packages/js/src/utils/interfaces.ts
+++ b/packages/js/src/utils/interfaces.ts
@@ -173,6 +173,18 @@ export interface IClientOptions {
   mutedMicOnStart?: boolean;
 
   /**
+   * Maximum number of automatic socket reconnection attempts after an unexpected
+   * disconnect. When the limit is reached, no further automatic reconnects are
+   * scheduled and a `telnyx.error` event with code `RECONNECTION_EXHAUSTED` (45003)
+   * is emitted. A manual `connect()` call resets the counter and starts a fresh
+   * retry sequence.
+   *
+   * Set to `0` or omit to allow unlimited automatic reconnect attempts (default).
+   * @default 0 (unlimited)
+   */
+  maxReconnectAttempts?: number;
+
+  /**
    * Enable automatic call quality reporting to voice-sdk-proxy.
    * When enabled, WebRTC stats are collected periodically during calls
    * and posted to the voice-sdk-proxy /call_report endpoint when the call ends.

--- a/packages/js/src/utils/interfaces.ts
+++ b/packages/js/src/utils/interfaces.ts
@@ -180,8 +180,8 @@ export interface IClientOptions {
    * retry sequence.
    *
    * Set to `0` to allow unlimited automatic reconnect attempts.
-   * When omitted, defaults to `5`.
-   * @default 5
+   * When omitted, defaults to `10`.
+   * @default 10
    */
   maxReconnectAttempts?: number;
 

--- a/packages/js/src/utils/interfaces.ts
+++ b/packages/js/src/utils/interfaces.ts
@@ -179,8 +179,9 @@ export interface IClientOptions {
    * is emitted. A manual `connect()` call resets the counter and starts a fresh
    * retry sequence.
    *
-   * Set to `0` or omit to allow unlimited automatic reconnect attempts (default).
-   * @default 0 (unlimited)
+   * Set to `0` to allow unlimited automatic reconnect attempts.
+   * When omitted, defaults to `5`.
+   * @default 5
    */
   maxReconnectAttempts?: number;
 


### PR DESCRIPTION
## Summary

Implements [VSDK-197](https://linear.app/telnyx/issue/VSDK-197/adding-limit-for-socket-reconnection-attempt): Adding limit for socket reconnection attempt.

### Changes

- **New config option**: `maxReconnectAttempts` on both `IClientOptions` and `IVertoOptions`
  - Default: `10` (omitting the option limits reconnects to 10 attempts)
  - Set to `0` explicitly to allow unlimited retries
  - When set to a positive integer, limits the number of automatic socket reconnection attempts
- **Attempt counter**: `_reconnectAttempts` tracked in `BaseSession`, incremented on each `onNetworkClose()`
- **Exhaustion handling**: When the limit is reached, auto-reconnect is disabled and a `telnyx.error` event with code `RECONNECTION_EXHAUSTED` (45003) is emitted
- **Counter reset**:
  - Reset on successful REGED only (not REGISTER) — ensures the connection is fully healthy before resetting the counter
  - Reset on manual `connect()` call after exhaustion
  - Reset on `disconnect()`
  - Public `resetReconnectAttempts()` method available
- **Default uses `??` operator**: `this.options.maxReconnectAttempts ?? 10` so explicit `0` is preserved as unlimited
- **Unit tests**: 17 tests covering default behavior, unlimited mode, bounded mode, exhaustion, manual recovery, unhealthy reconnect (socket opens but closes before REGED), REGISTER vs REGED reset, counter reset, disconnect cleanup

### Test plan
- [x] Unit tests pass (14/14 ReconnectAttempts + 3 VertoHandler regression = 17 total)
- [ ] Manual test: set `maxReconnectAttempts: 3` and verify reconnect stops after 3 attempts
- [ ] Manual test: verify `telnyx.error` with code 45003 fires on exhaustion
- [ ] Manual test: verify `connect()` after exhaustion starts fresh retry sequence
- [ ] Manual test: verify REGISTER does not reset reconnect attempts, only REGED does