### PR TITLE
Feat: add structured audio diagnostics logging for E2E test debugging

### DIFF
--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -15,6 +15,70 @@ import {
   Invite,
   Modify,
 } from '../messages/Verto';
+
+/**
+ * Structured audio diagnostics returned by `call.getAudioDiagnostics()`.
+ * Provides a snapshot of the audio state for debugging audio detection failures.
+ */
+export interface AudioDiagnostics {
+  /** Timestamp of the diagnostics snapshot (ISO 8601) */
+  timestamp: string;
+  /** Call ID */
+  callId: string;
+  /** Call direction: 'inbound' | 'outbound' */
+  direction: string;
+  /** Call state at time of diagnostics */
+  callState: string;
+  /** Local audio tracks info */
+  localAudioTracks: Array<{
+    id: string;
+    kind: string;
+    enabled: boolean;
+    muted: boolean;
+    readyState: MediaStreamTrackState;
+    label: string;
+  }>;
+  /** Remote audio tracks info */
+  remoteAudioTracks: Array<{
+    id: string;
+    kind: string;
+    enabled: boolean;
+    muted: boolean;
+    readyState: MediaStreamTrackState;
+    label: string;
+  }>;
+  /** RTCPeerConnection state */
+  peerConnection: {
+    connectionState: RTCPeerConnectionState | null;
+    iceConnectionState: RTCIceConnectionState | null;
+    signalingState: RTCSignalingState | null;
+    iceGatheringState: RTCIceGatheringState | null;
+  };
+  /** Audio transceivers info */
+  audioTransceivers: Array<{
+    mid: string | null;
+    direction: RTCRtpTransceiverDirection;
+    currentDirection: RTCRtpTransceiverDirection | null;
+    senderTrack: { id: string; kind: string; enabled: boolean; muted: boolean; readyState: MediaStreamTrackState } | null;
+    receiverTrack: { id: string; kind: string; enabled: boolean; muted: boolean; readyState: MediaStreamTrackState } | null;
+  }>;
+  /** WebRTC stats snapshot for audio */
+  webrtcStats: {
+    inboundAudio: Array<{
+      bytesReceived: number;
+      packetsReceived: number;
+      packetsLost: number;
+      audioLevel: number | null;
+      codecId: string | null;
+    }>;
+    outboundAudio: Array<{
+      bytesSent: number;
+      packetsSent: number;
+      audioLevel: number | null;
+      codecId: string | null;
+    }>;
+  };
+}
 import { deRegister, register, trigger } from '../services/Handler';
 import {
   SwEvent,
@@ -1004,6 +1068,131 @@ export default abstract class BaseCall implements IWebRTCCall {
     toggleAudioTracks(this.options.remoteStream);
   }
 
+  /**
+   * Collects a structured snapshot of the current audio state for debugging.
+   *
+   * Useful for diagnosing audio detection failures in E2E tests (e.g., BBT
+   * bidirectional audio checks). Returns track states, transceiver info,
+   * peer connection state, and WebRTC stats for inbound/outbound audio RTP.
+   *
+   * @returns Promise that resolves with the audio diagnostics snapshot
+   */
+  async getAudioDiagnostics(): Promise<AudioDiagnostics> {
+    const diagnostics: AudioDiagnostics = {
+      timestamp: new Date().toISOString(),
+      callId: this.id,
+      direction: this.direction ?? 'unknown',
+      callState: this.state,
+      localAudioTracks: [],
+      remoteAudioTracks: [],
+      peerConnection: {
+        connectionState: null,
+        iceConnectionState: null,
+        signalingState: null,
+        iceGatheringState: null,
+      },
+      audioTransceivers: [],
+      webrtcStats: {
+        inboundAudio: [],
+        outboundAudio: [],
+      },
+    };
+
+    // Collect local audio track info
+    if (this.options.localStream) {
+      diagnostics.localAudioTracks = this.options.localStream
+        .getAudioTracks()
+        .map((track) => ({
+          id: track.id,
+          kind: track.kind,
+          enabled: track.enabled,
+          muted: track.muted,
+          readyState: track.readyState,
+          label: track.label,
+        }));
+    }
+
+    // Collect remote audio track info
+    if (this.options.remoteStream) {
+      diagnostics.remoteAudioTracks = this.options.remoteStream
+        .getAudioTracks()
+        .map((track) => ({
+          id: track.id,
+          kind: track.kind,
+          enabled: track.enabled,
+          muted: track.muted,
+          readyState: track.readyState,
+          label: track.label,
+        }));
+    }
+
+    // Collect peer connection state
+    const pc = this.peer?.instance;
+    if (pc) {
+      diagnostics.peerConnection = {
+        connectionState: pc.connectionState,
+        iceConnectionState: pc.iceConnectionState,
+        signalingState: pc.signalingState,
+        iceGatheringState: pc.iceGatheringState,
+      };
+
+      // Collect audio transceiver info
+      diagnostics.audioTransceivers = pc.getTransceivers()
+        .filter((tr) => tr.receiver?.track?.kind === 'audio' || tr.sender?.track?.kind === 'audio')
+        .map((tr) => ({
+          mid: tr.mid,
+          direction: tr.direction,
+          currentDirection: tr.currentDirection ?? null,
+          senderTrack: tr.sender?.track
+            ? {
+                id: tr.sender.track.id,
+                kind: tr.sender.track.kind,
+                enabled: tr.sender.track.enabled,
+                muted: tr.sender.track.muted,
+                readyState: tr.sender.track.readyState,
+              }
+            : null,
+          receiverTrack: tr.receiver?.track
+            ? {
+                id: tr.receiver.track.id,
+                kind: tr.receiver.track.kind,
+                enabled: tr.receiver.track.enabled,
+                muted: tr.receiver.track.muted,
+                readyState: tr.receiver.track.readyState,
+              }
+            : null,
+        }));
+
+      // Collect WebRTC stats for audio
+      try {
+        const stats = await pc.getStats();
+        stats.forEach((report) => {
+          if (report.type === 'inbound-rtp' && report.kind === 'audio') {
+            diagnostics.webrtcStats.inboundAudio.push({
+              bytesReceived: report.bytesReceived ?? 0,
+              packetsReceived: report.packetsReceived ?? 0,
+              packetsLost: report.packetsLost ?? 0,
+              audioLevel: report.audioLevel ?? null,
+              codecId: report.codecId ?? null,
+            });
+          }
+          if (report.type === 'outbound-rtp' && report.kind === 'audio') {
+            diagnostics.webrtcStats.outboundAudio.push({
+              bytesSent: report.bytesSent ?? 0,
+              packetsSent: report.packetsSent ?? 0,
+              audioLevel: report.audioLevel ?? null,
+              codecId: report.codecId ?? null,
+            });
+          }
+        });
+      } catch (error) {
+        logger.warn('Failed to collect WebRTC stats for audio diagnostics:', error);
+      }
+    }
+
+    return diagnostics;
+  }
+
   async setBandwidthEncodingsMaxBps(max: number, _kind: string) {
     if (!this || !this.peer) {
       logger.error(
@@ -1137,6 +1326,10 @@ export default abstract class BaseCall implements IWebRTCCall {
         ) {
           this._callReportCollector.start(this.peer.instance);
         }
+
+        // Log audio diagnostics when call becomes active for debugging
+        // audio detection failures (especially in BBT E2E tests)
+        this._logAudioStateOnActive();
         break;
       }
       case State.Destroy:
@@ -1963,6 +2156,58 @@ export default abstract class BaseCall implements IWebRTCCall {
     );
 
     void this.hangup({ initiator: 'sdk:media-error' }, false);
+  }
+
+  /**
+   * Logs audio state when call becomes active.
+   * Provides key diagnostic info for debugging audio detection failures.
+   */
+  private _logAudioStateOnActive() {
+    const localAudioTracks = this.options.localStream?.getAudioTracks() ?? [];
+    const remoteAudioTracks = this.options.remoteStream?.getAudioTracks() ?? [];
+    const pc = this.peer?.instance;
+
+    logger.info(`[${this.id}] Audio state on call active:`, {
+      localAudioTracks: localAudioTracks.length,
+      remoteAudioTracks: remoteAudioTracks.length,
+      localAudioTrackDetails: localAudioTracks.map((t) => ({
+        id: t.id,
+        enabled: t.enabled,
+        muted: t.muted,
+        readyState: t.readyState,
+        label: t.label,
+      })),
+      remoteAudioTrackDetails: remoteAudioTracks.map((t) => ({
+        id: t.id,
+        enabled: t.enabled,
+        muted: t.muted,
+        readyState: t.readyState,
+        label: t.label,
+      })),
+      peerConnectionState: pc
+        ? {
+            connectionState: pc.connectionState,
+            iceConnectionState: pc.iceConnectionState,
+            signalingState: pc.signalingState,
+          }
+        : 'no peer connection',
+      audioTransceivers: pc
+        ? pc
+            .getTransceivers()
+            .filter(
+              (tr) =>
+                tr.receiver?.track?.kind === 'audio' ||
+                tr.sender?.track?.kind === 'audio'
+            )
+            .map((tr) => ({
+              mid: tr.mid,
+              direction: tr.direction,
+              currentDirection: tr.currentDirection,
+              senderTrackEnabled: tr.sender?.track?.enabled ?? null,
+              receiverTrackEnabled: tr.receiver?.track?.enabled ?? null,
+            }))
+        : [],
+    });
   }
 
   private _onPeerConnectionFailureError(data: {

--- a/packages/js/src/Modules/Verto/webrtc/Peer.ts
+++ b/packages/js/src/Modules/Verto/webrtc/Peer.ts
@@ -236,6 +236,24 @@ export default class Peer {
     const { remoteElement, screenShare } = this.options;
     this.options.remoteStream = first;
 
+    // Log remote track details for audio debugging
+    if (event.track.kind === 'audio') {
+      logger.info(
+        `[${this.options.id}] Remote audio track received:`,
+        {
+          trackId: event.track.id,
+          enabled: event.track.enabled,
+          muted: event.track.muted,
+          readyState: event.track.readyState,
+          label: event.track.label,
+          streamsCount: event.streams.length,
+          streamId: first?.id ?? 'none',
+          streamActive: first?.active ?? false,
+          streamAudioTrackCount: first?.getAudioTracks().length ?? 0,
+        }
+      );
+    }
+
     if (screenShare === false) {
       attachMediaStream(remoteElement, this.options.remoteStream);
     }
@@ -613,6 +631,19 @@ export default class Peer {
       let tracks = [...audioTracks];
 
       logger.info('Local audio tracks: ', audioTracks);
+      // Log detailed local audio track info for debugging audio detection failures
+      audioTracks.forEach((track) => {
+        logger.info(
+          `[${this.options.id}] Local audio track detail:`,
+          {
+            trackId: track.id,
+            enabled: track.enabled,
+            muted: track.muted,
+            readyState: track.readyState,
+            label: track.label,
+          }
+        );
+      });
 
       if (audioIsMediaTrackConstraints(this.options.audio)) {
         // tells whether the constraints used to get the audio track took effect. Browsers may ignore unsupported constraints silently

--- a/packages/js/src/Modules/Verto/webrtc/interfaces.ts
+++ b/packages/js/src/Modules/Verto/webrtc/interfaces.ts
@@ -1,4 +1,5 @@
 import { State } from './constants';
+import type { AudioDiagnostics } from './BaseCall';
 
 export interface IMediaSettings {
   useSdpASBandwidthKbps?: boolean;
@@ -181,6 +182,14 @@ export interface IWebRTCCall {
   setAudioBandwidthEncodingsMaxBps: (max: number) => void;
   setVideoBandwidthEncodingsMaxBps: (max: number) => void;
   getStats: (callback: Function, constraints: any) => void;
+  /**
+   * Collects a structured snapshot of the current audio state for debugging
+   * audio detection failures (e.g., in E2E test frameworks like BBT).
+   *
+   * Includes local/remote audio track states, peer connection state,
+   * audio transceiver details, and WebRTC inbound/outbound RTP stats.
+   */
+  getAudioDiagnostics: () => Promise<AudioDiagnostics>;
   setState: (state: State) => void;
   // Privates
   handleMessage: (msg: any) => void;

--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -48,3 +48,4 @@ export type {
 } from './Modules/Verto/util/constants/warnings';
 
 export * from './PreCallDiagnosis';
+export type { AudioDiagnostics } from './Modules/Verto/webrtc/BaseCall';


### PR DESCRIPTION
## What changed

Added `getAudioDiagnostics()` method to `Call`/`BaseCall` that collects a structured snapshot of the current audio state for debugging audio detection failures in E2E tests (e.g., BBT bidirectional audio checks).

### New public API
- `call.getAudioDiagnostics(): Promise<AudioDiagnostics>` — returns structured audio state snapshot
- `AudioDiagnostics` type exported from package

### AudioDiagnostics includes
- **Local audio tracks**: count, id, enabled, muted, readyState, label
- **Remote audio tracks**: count, id, enabled, muted, readyState, label
- **RTCPeerConnection state**: connectionState, iceConnectionState, signalingState, iceGatheringState
- **Audio transceivers**: mid, direction, currentDirection, sender/receiver track details
- **WebRTC stats**: inbound-rtp audio (bytesReceived, packetsReceived, packetsLost, audioLevel, codecId) and outbound-rtp audio (bytesSent, packetsSent, audioLevel, codecId)

### Automatic logging
- Audio state is logged when call becomes active (`_logAudioStateOnActive`)
- Remote audio track details logged on receipt (`Peer.handleTrackEvent`)
- Local audio track details logged on creation (`Peer.init`)

### Why
When BBT's bidirectional audio check fails with `audio_detection` error, the error report only contains generic browser console messages and WebSocket messages. There's no way to tell **why** audio detection failed — whether it was:
- Missing/muted local tracks (getUserMedia failed silently)
- Remote audio track not received (ICE/DTLS issue despite connected state)
- Audio flowing but below detection threshold (codec mismatch, silence suppression)
- No inbound RTP packets at all
- RTCPeerConnection audio-level stats not available (browser quirk)
- Audio output/sink error (like Firefox `NS_ERROR_DOM_MEDIA_MEDIASINK_ERR`)

This change makes it possible to pinpoint the exact cause.

### Files changed
- `packages/js/src/Modules/Verto/webrtc/BaseCall.ts` — added `AudioDiagnostics` interface, `getAudioDiagnostics()` method, `_logAudioStateOnActive()` private method
- `packages/js/src/Modules/Verto/webrtc/Peer.ts` — enhanced logging for remote audio track events and local audio track details
- `packages/js/src/Modules/Verto/webrtc/interfaces.ts` — added `getAudioDiagnostics` to `IWebRTCCall` interface
- `packages/js/src/index.ts` — exported `AudioDiagnostics` type