### PR TITLE
Feat: socket reconnection limit (VSDK-197) + dead call cleanup (VSDK-194)

### DIFF
--- a/packages/js/src/Modules/Verto/BaseSession.ts
+++ b/packages/js/src/Modules/Verto/BaseSession.ts
@@ -15,6 +15,7 @@ import {
   LOGIN_FAILED,
   INVALID_CREDENTIALS,
   TOKEN_EXPIRING_SOON,
+  RECONNECTION_EXHAUSTED,
 } from './util/constants';
 import { createTelnyxError, createTelnyxWarning } from './util/errors';
 import type { ITelnyxErrorEvent } from './util/errors';
@@ -69,6 +70,7 @@ export default abstract class BaseSession {
   protected _reconnectTimeout: any;
   protected _autoReconnect: boolean = true;
   protected _idle: boolean = false;
+  protected _reconnectAttempts: number = 0;
 
   private _tokenExpiryTimeout: ReturnType<typeof setTimeout> | null = null;
   private static readonly TOKEN_EXPIRY_WARNING_SECONDS = 120;
@@ -203,6 +205,7 @@ export default abstract class BaseSession {
     this._clearTokenExpiryTimeout();
     this.subscriptions = {};
     this._autoReconnect = false;
+    this._reconnectAttempts = 0;
     this.relayProtocol = null;
     this._closeConnection();
     await sessionStorage.removeItem(this.signature);
@@ -327,12 +330,28 @@ export default abstract class BaseSession {
     }
 
     this._attachListeners();
+
+    // If auto-reconnect was disabled (e.g. after exhaustion or disconnect),
+    // reset the counter so a fresh retry sequence starts.
+    if (!this._autoReconnect) {
+      this._reconnectAttempts = 0;
+    }
+
     this._autoReconnect = true;
     if (!this.connection.isAlive) {
       logger.debug('Initiating connection to the server...');
       this.connection.connect();
     }
     logger.debug('Connect method called. Connection initiated.');
+  }
+
+  /**
+   * Reset the automatic reconnection attempt counter.
+   * Call this when the connection is fully established (e.g. on REGED)
+   * or when the user manually initiates a reconnect after exhaustion.
+   */
+  public resetReconnectAttempts(): void {
+    this._reconnectAttempts = 0;
   }
 
   /**
@@ -611,6 +630,30 @@ export default abstract class BaseSession {
     }
 
     if (this._autoReconnect) {
+      const maxAttempts = this.options.maxReconnectAttempts || 0;
+
+      this._reconnectAttempts += 1;
+
+      if (maxAttempts > 0 && this._reconnectAttempts > maxAttempts) {
+        logger.info(
+          `Reconnection exhausted after ${maxAttempts} attempts. Stopping automatic reconnect.`
+        );
+        this._reconnectAttempts = 0;
+        this._autoReconnect = false;
+
+        const telnyxError = createTelnyxError(RECONNECTION_EXHAUSTED);
+        trigger(
+          SwEvent.Error,
+          { error: telnyxError, sessionId: this.sessionid },
+          this.uuid
+        );
+        return;
+      }
+
+      logger.debug(
+        `Reconnect attempt ${this._reconnectAttempts}${maxAttempts > 0 ? ` of ${maxAttempts}` : ''}`
+      );
+
       this._reconnectTimeout = setTimeout(() => {
         logger.debug(
           'Calling connect due to network close and auto-reconnect enabled.'

--- a/packages/js/src/Modules/Verto/tests/DeadCallCleanup.test.ts
+++ b/packages/js/src/Modules/Verto/tests/DeadCallCleanup.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Unit tests for dead call cleanup (VSDK-194)
+ *
+ * Tests idempotent cleanup behavior: calls reaching terminal states
+ * should be properly cleaned up from the session registry, and
+ * multiple terminal events should not cause double cleanup or errors.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import Verto from '..';
+import Call from '../webrtc/Call';
+import { State } from '../webrtc/constants';
+
+// Mock dependencies
+jest.mock('../services/Connection');
+jest.mock('../services/Handler', () => ({
+  register: jest.fn(),
+  deRegister: jest.fn(),
+  trigger: jest.fn(),
+  registerOnce: jest.fn(),
+  isQueued: jest.fn(),
+  deRegisterAll: jest.fn(),
+}));
+jest.mock('../util/logger');
+jest.mock('../util/reconnect', () => ({
+  getReconnectToken: jest.fn(() => null),
+  setReconnectToken: jest.fn(),
+  clearReconnectToken: jest.fn(),
+}));
+
+// Mock Peer class
+jest.mock('../webrtc/Peer', () => {
+  return class MockPeer {
+    close = jest.fn();
+    instance = {};
+    isConnectionHealthy = jest.fn(() => true);
+    isIceRestarting = false;
+    incrementGatheredCandidates = jest.fn();
+    tryCollectTimings = jest.fn();
+    statsReporter = null;
+  };
+});
+
+// Mock webrtc utils
+jest.mock('../util/webrtc', () => ({
+  stopStream: jest.fn(),
+  getUserMedia: jest.fn(),
+  attachMediaStream: jest.fn(),
+  setMediaElementSinkId: jest.fn(),
+  getDisplayMedia: jest.fn(),
+}));
+
+// Mock CallReportCollector
+jest.mock('../webrtc/CallReportCollector', () => ({
+  CallReportCollector: jest.fn().mockImplementation(() => ({
+    start: jest.fn(),
+    stop: jest.fn().mockResolvedValue(undefined),
+    cleanup: jest.fn(),
+    flush: jest.fn(() => null),
+    postReport: jest.fn(() => Promise.resolve()),
+    sendPayload: jest.fn(() => Promise.resolve()),
+    onFlushNeeded: null,
+    onWarning: null,
+  })),
+}));
+
+// Mock WebRTCStats
+jest.mock('@peermetrics/webrtc-stats', () => {
+  return class MockWebRTCStats {
+    addConnection = jest.fn();
+    removeConnection = jest.fn();
+  };
+});
+
+// Mock uuid
+jest.mock('uuid', () => ({
+  v4: jest.fn(() => 'test-uuid-1234'),
+}));
+
+// Mock package.json
+jest.mock('../../../../package.json', () => ({
+  version: '1.0.0-test',
+}));
+
+import { deRegister as mockDeRegister, trigger as mockTrigger } from '../services/Handler';
+
+describe('BaseCall - Dead Call Cleanup (VSDK-194)', () => {
+  let session: any;
+  let call: any;
+  // Track trigger calls for notification assertions
+  const getTriggerCalls = () => (mockTrigger as jest.Mock).mock.calls;
+
+  const createSession = (): any => {
+    const s: any = new Verto({
+      host: 'example.telnyx.com',
+      login: 'testuser',
+      password: 'testpass',
+    });
+    s.connection = {
+      close: jest.fn(),
+      connect: jest.fn(),
+      send: jest.fn().mockResolvedValue({ node_id: 'test' }),
+      sendRawText: jest.fn(),
+      isAlive: true,
+      connected: true,
+      previousGatewayState: '',
+      host: 'wss://rtc.telnyx.com',
+    };
+    s._idle = false;
+    s.sessionid = 'test-session-id';
+    s.callReportId = null;
+    return s;
+  };
+
+  beforeEach(() => {
+    session = createSession();
+  });
+
+  describe('_finalize() idempotency', () => {
+    beforeEach(() => {
+      call = new Call(session, {
+        destinationNumber: '1234',
+        callerNumber: '5678',
+        audio: true,
+        video: false,
+      });
+      call.peer = {
+        close: jest.fn(),
+        instance: {
+          close: jest.fn(),
+          getStats: jest.fn(),
+        },
+      };
+      call.options.remoteStream = { getTracks: () => [], getAudioTracks: () => [], getVideoTracks: () => [] };
+      call.options.localStream = { getTracks: () => [], getAudioTracks: () => [], getVideoTracks: () => [] };
+    });
+
+    it('should mark call as finalized after _finalize()', () => {
+      expect(call.isFinalized).toBe(false);
+      call._finalize();
+      expect(call.isFinalized).toBe(true);
+    });
+
+    it('should remove call from session.calls after _finalize()', () => {
+      const callId = call.id;
+      expect(session.calls[callId]).toBeDefined();
+
+      call._finalize();
+      expect(session.calls[callId]).toBeUndefined();
+    });
+
+    it('should close peer only once when _finalize() is called multiple times', () => {
+      call._finalize();
+      call._finalize();
+      call._finalize();
+
+      expect(call.peer.close).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not throw when _finalize() is called multiple times', () => {
+      expect(() => {
+        call._finalize();
+        call._finalize();
+        call._finalize();
+      }).not.toThrow();
+    });
+
+    it('should only deRegister handlers once when _finalize() is called multiple times', () => {
+      call._finalize();
+      const deRegisterCountAfterFirst = (mockDeRegister as jest.Mock).mock.calls.length;
+
+      call._finalize();
+      const deRegisterCountAfterSecond = (mockDeRegister as jest.Mock).mock.calls.length;
+
+      expect(deRegisterCountAfterSecond).toBe(deRegisterCountAfterFirst);
+    });
+  });
+
+  describe('hangup() idempotency', () => {
+    beforeEach(() => {
+      call = new Call(session, {
+        destinationNumber: '1234',
+        callerNumber: '5678',
+        audio: true,
+        video: false,
+      });
+      call.peer = {
+        close: jest.fn(),
+        instance: {
+          close: jest.fn(),
+          getStats: jest.fn(),
+        },
+      };
+      call.options.remoteStream = { getTracks: () => [], getAudioTracks: () => [], getVideoTracks: () => [] };
+      call.options.localStream = { getTracks: () => [], getAudioTracks: () => [], getVideoTracks: () => [] };
+    });
+
+    it('should skip hangup when call is already in Hangup state', async () => {
+      call._state = State.Hangup;
+      call.state = 'hangup';
+
+      await call.hangup();
+
+      expect(call.peer.close).not.toHaveBeenCalled();
+    });
+
+    it('should skip hangup when call is already in Destroy state', async () => {
+      call._state = State.Destroy;
+      call.state = 'destroy';
+
+      await call.hangup();
+
+      expect(call.peer.close).not.toHaveBeenCalled();
+    });
+
+    it('should allow hangup when call is in Purge state (forced disconnect)', async () => {
+      call._state = State.Purge;
+      call.state = 'purge';
+
+      await call.hangup({}, false);
+
+      expect(call.peer.close).toHaveBeenCalled();
+    });
+
+    it('should skip hangup when call is already finalized', async () => {
+      call._finalized = true;
+
+      await call.hangup();
+
+      expect(call.peer.close).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('setState() and cleanup interaction', () => {
+    beforeEach(() => {
+      call = new Call(session, {
+        destinationNumber: '1234',
+        callerNumber: '5678',
+        audio: true,
+        video: false,
+      });
+      call.peer = {
+        close: jest.fn(),
+        instance: {
+          close: jest.fn(),
+          getStats: jest.fn(),
+        },
+      };
+      call.options.remoteStream = { getTracks: () => [], getAudioTracks: () => [], getVideoTracks: () => [] };
+      call.options.localStream = { getTracks: () => [], getAudioTracks: () => [], getVideoTracks: () => [] };
+    });
+
+    it('should not double-finalize when setState(Destroy) is called twice', () => {
+      call.setState(State.Destroy);
+      call.setState(State.Destroy);
+
+      // Peer should only be closed once due to _finalize() idempotency
+      expect(call.peer.close).toHaveBeenCalledTimes(1);
+      expect(call.isFinalized).toBe(true);
+    });
+
+    it('should allow setState(Purge) after Destroy (forced disconnect flow)', () => {
+      call.setState(State.Destroy);
+      call.setState(State.Purge);
+
+      // Should not throw — Purge is always allowed for forced disconnect
+      expect(call._state).toBe(State.Purge);
+    });
+  });
+
+  describe('BrowserSession.disconnect() cleanup', () => {
+    it('should clear all calls from session.calls', async () => {
+      // Create two calls with distinct IDs by overriding uuid mock
+      const { v4: uuidV4 } = jest.requireMock('uuid');
+      let callCount = 0;
+      (uuidV4 as jest.Mock).mockImplementation(() => `test-uuid-${++callCount}`);
+
+      const call1 = new Call(session, {
+        destinationNumber: '1111',
+        audio: true,
+        video: false,
+      });
+      const call2 = new Call(session, {
+        destinationNumber: '2222',
+        audio: true,
+        video: false,
+      });
+
+      expect(Object.keys(session.calls).length).toBe(2);
+
+      await session.disconnect();
+
+      expect(Object.keys(session.calls).length).toBe(0);
+    });
+  });
+});

--- a/packages/js/src/Modules/Verto/tests/ReconnectAttempts.test.ts
+++ b/packages/js/src/Modules/Verto/tests/ReconnectAttempts.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Unit tests for socket reconnection attempt limit (VSDK-197)
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import BaseSession from '../BaseSession';
+import { trigger } from '../services/Handler';
+import { SwEvent, RECONNECTION_EXHAUSTED } from '../util/constants';
+
+// Mock dependencies
+jest.mock('../services/Connection');
+jest.mock('../services/Handler');
+jest.mock('../util/logger');
+jest.mock('../util/reconnect', () => ({
+  getReconnectToken: jest.fn(() => null),
+  setReconnectToken: jest.fn(),
+  clearReconnectToken: jest.fn(),
+}));
+
+const mockTrigger = trigger as jest.MockedFunction<typeof trigger>;
+
+/**
+ * Concrete subclass for testing the abstract BaseSession
+ */
+class TestSession extends BaseSession {
+  validateOptions() {
+    return true;
+  }
+}
+
+describe('BaseSession - Reconnection Attempt Limit', () => {
+  let session: any;
+  let mockConnection: any;
+
+  const createSession = (options: any = {}) => {
+    return new TestSession({
+      login: 'testuser',
+      password: 'testpass',
+      ...options,
+    });
+  };
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockTrigger.mockClear();
+
+    session = createSession();
+    mockConnection = {
+      close: jest.fn(),
+      connect: jest.fn(),
+      isAlive: false,
+      connected: false,
+      previousGatewayState: '',
+    };
+    session.connection = mockConnection;
+    session._autoReconnect = true;
+    session._idle = false;
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('default behavior (maxReconnectAttempts = 0, unlimited)', () => {
+    it('should allow unlimited reconnection attempts when maxReconnectAttempts is 0', () => {
+      session.options.maxReconnectAttempts = 0;
+
+      for (let i = 0; i < 20; i++) {
+        session.onNetworkClose();
+        jest.runAllTimers();
+      }
+
+      expect(session._reconnectAttempts).toBe(20);
+      expect(session._autoReconnect).toBe(true);
+    });
+
+    it('should allow unlimited reconnection attempts when maxReconnectAttempts is not set', () => {
+      delete session.options.maxReconnectAttempts;
+
+      for (let i = 0; i < 15; i++) {
+        session.onNetworkClose();
+        jest.runAllTimers();
+      }
+
+      expect(session._reconnectAttempts).toBe(15);
+      expect(session._autoReconnect).toBe(true);
+    });
+  });
+
+  describe('with maxReconnectAttempts set', () => {
+    it('should increment _reconnectAttempts on each onNetworkClose call', () => {
+      session.options.maxReconnectAttempts = 5;
+
+      session.onNetworkClose();
+      expect(session._reconnectAttempts).toBe(1);
+
+      jest.runAllTimers();
+      session.onNetworkClose();
+      expect(session._reconnectAttempts).toBe(2);
+    });
+
+    it('should stop reconnecting after maxReconnectAttempts is reached', () => {
+      session.options.maxReconnectAttempts = 3;
+
+      session.onNetworkClose();
+      expect(session._reconnectAttempts).toBe(1);
+      expect(session._autoReconnect).toBe(true);
+
+      jest.runAllTimers();
+      session.onNetworkClose();
+      expect(session._reconnectAttempts).toBe(2);
+      expect(session._autoReconnect).toBe(true);
+
+      jest.runAllTimers();
+      session.onNetworkClose();
+      expect(session._reconnectAttempts).toBe(3);
+      expect(session._autoReconnect).toBe(true);
+
+      jest.runAllTimers();
+      session.onNetworkClose();
+      expect(session._autoReconnect).toBe(false);
+    });
+
+    it('should emit RECONNECTION_EXHAUSTED error when limit is reached', () => {
+      session.options.maxReconnectAttempts = 2;
+
+      session.onNetworkClose();
+      jest.runAllTimers();
+      session.onNetworkClose();
+      jest.runAllTimers();
+      session.onNetworkClose();
+
+      expect(mockTrigger).toHaveBeenCalledWith(
+        SwEvent.Error,
+        expect.objectContaining({
+          error: expect.objectContaining({ code: RECONNECTION_EXHAUSTED }),
+        }),
+        session.uuid
+      );
+    });
+
+    it('should reset _reconnectAttempts to 0 after exhaustion', () => {
+      session.options.maxReconnectAttempts = 1;
+
+      session.onNetworkClose();
+      jest.runAllTimers();
+      session.onNetworkClose();
+
+      expect(session._reconnectAttempts).toBe(0);
+      expect(session._autoReconnect).toBe(false);
+    });
+
+    it('should not schedule a reconnect timeout after exhaustion', () => {
+      session.options.maxReconnectAttempts = 1;
+
+      session.onNetworkClose();
+      jest.runAllTimers();
+      session.onNetworkClose();
+
+      expect(session._autoReconnect).toBe(false);
+    });
+
+    it('should allow manual connect() after exhaustion', () => {
+      session.options.maxReconnectAttempts = 1;
+
+      // Exhaust reconnection
+      session.onNetworkClose();
+      jest.runAllTimers();
+      session.onNetworkClose();
+      expect(session._autoReconnect).toBe(false);
+
+      // Manual connect should reset the counter and re-enable autoReconnect
+      session.connect();
+      expect(session._autoReconnect).toBe(true);
+      expect(session._reconnectAttempts).toBe(0);
+    });
+  });
+
+  describe('resetReconnectAttempts()', () => {
+    it('should reset the reconnection attempt counter', () => {
+      session.options.maxReconnectAttempts = 5;
+      session.onNetworkClose();
+      session.onNetworkClose();
+      expect(session._reconnectAttempts).toBe(2);
+
+      session.resetReconnectAttempts();
+      expect(session._reconnectAttempts).toBe(0);
+    });
+  });
+
+  describe('disconnect()', () => {
+    it('should reset _reconnectAttempts and disable autoReconnect', async () => {
+      session.options.maxReconnectAttempts = 5;
+      session.onNetworkClose();
+      session.onNetworkClose();
+      expect(session._reconnectAttempts).toBe(2);
+
+      await session.disconnect();
+      expect(session._reconnectAttempts).toBe(0);
+      expect(session._autoReconnect).toBe(false);
+    });
+  });
+
+  describe('connect()', () => {
+    it('should reset _reconnectAttempts when _autoReconnect was false', () => {
+      session._autoReconnect = false;
+      session._reconnectAttempts = 5;
+
+      session.connect();
+
+      expect(session._reconnectAttempts).toBe(0);
+      expect(session._autoReconnect).toBe(true);
+    });
+
+    it('should NOT reset _reconnectAttempts during auto-reconnect', () => {
+      session.options.maxReconnectAttempts = 5;
+      session.onNetworkClose();
+      expect(session._reconnectAttempts).toBe(1);
+
+      // connect() is called by auto-reconnect, _autoReconnect is still true
+      session.connect();
+      expect(session._reconnectAttempts).toBe(1);
+    });
+  });
+});

--- a/packages/js/src/Modules/Verto/util/interfaces.ts
+++ b/packages/js/src/Modules/Verto/util/interfaces.ts
@@ -54,6 +54,18 @@ export interface IVertoOptions {
   rtcPort?: number;
   mutedMicOnStart?: boolean;
   /**
+   * Maximum number of automatic socket reconnection attempts after an unexpected
+   * disconnect. When the limit is reached, no further automatic reconnects are
+   * scheduled and a `telnyx.error` event with code `RECONNECTION_EXHAUSTED` (45003)
+   * is emitted. A manual `connect()` call resets the counter and starts a fresh
+   * retry sequence.
+   *
+   * Set to `0` or omit to allow unlimited automatic reconnect attempts (default).
+   * @default 0 (unlimited)
+   */
+  maxReconnectAttempts?: number;
+
+  /**
    * Enable automatic call quality reporting to voice-sdk-proxy.
    * When enabled, collects WebRTC stats and debug logs during calls.
    * @default true

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -223,6 +223,20 @@ export default abstract class BaseCall implements IWebRTCCall {
 
   private _isRecovering: boolean = false;
 
+  /**
+   * Guard flag: true once _finalize() has run.
+   * Prevents double cleanup when multiple terminal events arrive for the same call.
+   */
+  private _finalized: boolean = false;
+
+  /**
+   * Returns true if this call has been finalized (resources released, removed from session).
+   * After finalization, the call is no longer usable.
+   */
+  get isFinalized(): boolean {
+    return this._finalized;
+  }
+
   private _captureHangupCallerStack(): string[] {
     const stack = new Error('Call.hangup caller').stack;
 
@@ -543,6 +557,18 @@ export default abstract class BaseCall implements IWebRTCCall {
     hangupParams?: IHangupParams,
     hangupExecute?: boolean
   ): Promise<void> {
+    // Guard: skip hangup if call is already finalized or in a terminal state
+    // (Hangup/Destroy). Allow if current state is Purge (forced disconnect).
+    if (
+      this._finalized ||
+      (this._state >= State.Hangup && this._state !== State.Purge)
+    ) {
+      logger.debug(
+        `[${this.id}] hangup() called but call is already in terminal state (${this.state}). Skipping.`
+      );
+      return;
+    }
+
     const params = hangupParams || {};
     const execute = hangupExecute === false ? false : true;
     const stateBeforeHangup = this.state;
@@ -2121,6 +2147,15 @@ export default abstract class BaseCall implements IWebRTCCall {
   }
 
   protected _finalize() {
+    // Idempotent guard: only run cleanup once
+    if (this._finalized) {
+      logger.debug(
+        `[${this.id}] _finalize() called but call is already finalized. Skipping.`
+      );
+      return;
+    }
+    this._finalized = true;
+
     this._stopStats();
 
     logger.debug(`[${this.id}] Closing peer from _finalize`);

--- a/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
+++ b/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
@@ -279,6 +279,7 @@ class VertoHandler {
               ) {
                 this.session._triggerKeepAliveTimeoutCheck();
                 this.retriedRegister = 0;
+                this.session.resetReconnectAttempts();
 
                 // Capture call_report_id for SDK call reporting
                 const callReportId = msg?.result?.params?.call_report_id;

--- a/packages/js/src/utils/interfaces.ts
+++ b/packages/js/src/utils/interfaces.ts
@@ -173,6 +173,18 @@ export interface IClientOptions {
   mutedMicOnStart?: boolean;
 
   /**
+   * Maximum number of automatic socket reconnection attempts after an unexpected
+   * disconnect. When the limit is reached, no further automatic reconnects are
+   * scheduled and a `telnyx.error` event with code `RECONNECTION_EXHAUSTED` (45003)
+   * is emitted. A manual `connect()` call resets the counter and starts a fresh
+   * retry sequence.
+   *
+   * Set to `0` or omit to allow unlimited automatic reconnect attempts (default).
+   * @default 0 (unlimited)
+   */
+  maxReconnectAttempts?: number;
+
+  /**
    * Enable automatic call quality reporting to voice-sdk-proxy.
    * When enabled, WebRTC stats are collected periodically during calls
    * and posted to the voice-sdk-proxy /call_report endpoint when the call ends.


### PR DESCRIPTION
## Changes

### VSDK-197 — Socket reconnection attempt limit
- Add `maxReconnectAttempts` option to `IVertoOptions` and `IClientOptions` (default: 0 = unlimited)
- Track automatic reconnect attempts in `_reconnectAttempts` counter
- When limit is reached: stop scheduling reconnects, emit `RECONNECTION_EXHAUSTED` error (code 45003)
- Reset counter on successful connection (REGED via `resetReconnectAttempts()`) and on manual `connect()`
- `disconnect()` resets counter and disables auto-reconnect

### VSDK-194 — Clean up dead calls
- Add `_finalized` guard flag to `BaseCall` — `_finalize()` runs only once
- `hangup()` skips if call is already finalized or in terminal state (Hangup/Destroy)
- Allow `hangup()` from Purge state (forced disconnect)
- `setState(Destroy)` is idempotent via finalize guard
- `session.disconnect()` clears all calls from registry

## Testing
- 12 new tests for VSDK-197 (ReconnectAttempts.test.ts)
- 12 new tests for VSDK-194 (DeadCallCleanup.test.ts)
- Full suite: 258/258 passing

## Linear
- VSDK-197: https://linear.app/telnyx/issue/VSDK-197/adding-limit-for-socket-reconnection-attempt
- VSDK-194: https://linear.app/telnyx/issue/VSDK-194/clean-up-dead-calls-in-sdk
