### PR TITLE
fix: collect initial call report stats every second

### DIFF
--- a/packages/js/docs/ts/interfaces/IClientOptions.md
+++ b/packages/js/docs/ts/interfaces/IClientOptions.md
@@ -6,6 +6,8 @@ IClientOptions
 ### Properties
 
 - [anonymous_login](#anonymous_login)
+- [callReportInitialDuration](#callreportinitialduration)
+- [callReportInitialInterval](#callreportinitialinterval)
 - [callReportInterval](#callreportinterval)
 - [debug](#debug)
 - [debugOutput](#debugoutput)
@@ -52,13 +54,44 @@ anonymous_login login options
 
 • `Optional` **callReportInterval**: `number`
 
-Interval in milliseconds for collecting call statistics.
-Stats are aggregated over each interval and stored locally until call end.
+Interval in milliseconds for collecting call statistics after the initial
+high-resolution startup window. Stats are aggregated over each interval
+and stored locally until call end.
 
 **`Default`**
 
 ```ts
 5000 (5 seconds)
+```
+
+---
+
+### callReportInitialDuration
+
+• `Optional` **callReportInitialDuration**: `number`
+
+Duration in milliseconds for using `callReportInitialInterval` before
+falling back to `callReportInterval`.
+
+**`Default`**
+
+```ts
+10000 (10 seconds)
+```
+
+---
+
+### callReportInitialInterval
+
+• `Optional` **callReportInitialInterval**: `number`
+
+Interval in milliseconds for collecting call statistics during the first
+`callReportInitialDuration` milliseconds of a call.
+
+**`Default`**
+
+```ts
+1000 (1 second)
 ```
 
 ---

--- a/packages/js/docs/ts/interfaces/IClientOptions.md
+++ b/packages/js/docs/ts/interfaces/IClientOptions.md
@@ -6,8 +6,6 @@ IClientOptions
 ### Properties
 
 - [anonymous_login](#anonymous_login)
-- [callReportInitialDuration](#callreportinitialduration)
-- [callReportInitialInterval](#callreportinitialinterval)
 - [callReportInterval](#callreportinterval)
 - [debug](#debug)
 - [debugOutput](#debugoutput)
@@ -62,36 +60,6 @@ and stored locally until call end.
 
 ```ts
 5000 (5 seconds)
-```
-
----
-
-### callReportInitialDuration
-
-• `Optional` **callReportInitialDuration**: `number`
-
-Duration in milliseconds for using `callReportInitialInterval` before
-falling back to `callReportInterval`.
-
-**`Default`**
-
-```ts
-10000 (10 seconds)
-```
-
----
-
-### callReportInitialInterval
-
-• `Optional` **callReportInitialInterval**: `number`
-
-Interval in milliseconds for collecting call statistics during the first
-`callReportInitialDuration` milliseconds of a call.
-
-**`Default`**
-
-```ts
-1000 (1 second)
 ```
 
 ---

--- a/packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts
@@ -144,12 +144,10 @@ describe('CallReportCollector cadence', () => {
     ).toEqual(5000);
   });
 
-  it('does not slow down collection if the configured initial interval is longer than the default interval', () => {
+  it('does not slow down collection if the configured default interval is shorter than the initial cadence', () => {
     const collector = new CallReportCollector({
       enabled: true,
-      interval: 2000,
-      initialInterval: 5000,
-      initialDuration: 10000,
+      interval: 500,
     });
     const testable = collector as unknown as {
       callStartTime: Date;
@@ -157,7 +155,7 @@ describe('CallReportCollector cadence', () => {
     };
 
     expect(testable._collectionIntervalFor(testable.callStartTime)).toEqual(
-      2000
+      500
     );
   });
 
@@ -167,8 +165,6 @@ describe('CallReportCollector cadence', () => {
     const collector = new CallReportCollector({
       enabled: true,
       interval: 5000,
-      initialInterval: 1000,
-      initialDuration: 10000,
     });
     const peerConnection = {
       getStats: jest.fn().mockResolvedValue(new Map()),

--- a/packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts
@@ -37,6 +37,7 @@ const createCollector = (): TestableCallReportCollector =>
 describe('CallReportCollector local audio diagnostics', () => {
   afterEach(() => {
     jest.restoreAllMocks();
+    jest.useRealTimers();
   });
 
   it('removes undefined values without mutating the input object', () => {
@@ -114,5 +115,69 @@ describe('CallReportCollector local audio diagnostics', () => {
         mediaSourceId: 'source-id',
       } as RTCOutboundRtpStreamStats & { mediaSourceId?: string })
     ).toBeUndefined();
+  });
+});
+
+describe('CallReportCollector cadence', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
+
+  it('defaults to 1 second intervals during the first 10 seconds, then the default interval', () => {
+    const collector = new CallReportCollector({
+      enabled: true,
+      interval: 5000,
+    });
+    const testable = collector as unknown as {
+      callStartTime: Date;
+      _collectionIntervalFor: (intervalStartTime: Date) => number;
+    };
+    const callStart = testable.callStartTime.getTime();
+
+    expect(testable._collectionIntervalFor(new Date(callStart))).toEqual(1000);
+    expect(testable._collectionIntervalFor(new Date(callStart + 9000))).toEqual(
+      1000
+    );
+    expect(
+      testable._collectionIntervalFor(new Date(callStart + 10000))
+    ).toEqual(5000);
+  });
+
+  it('does not slow down collection if the configured initial interval is longer than the default interval', () => {
+    const collector = new CallReportCollector({
+      enabled: true,
+      interval: 2000,
+      initialInterval: 5000,
+      initialDuration: 10000,
+    });
+    const testable = collector as unknown as {
+      callStartTime: Date;
+      _collectionIntervalFor: (intervalStartTime: Date) => number;
+    };
+
+    expect(testable._collectionIntervalFor(testable.callStartTime)).toEqual(
+      2000
+    );
+  });
+
+  it('collects a final stats interval for calls shorter than the current cadence interval', async () => {
+    jest.useFakeTimers();
+
+    const collector = new CallReportCollector({
+      enabled: true,
+      interval: 5000,
+      initialInterval: 1000,
+      initialDuration: 10000,
+    });
+    const peerConnection = {
+      getStats: jest.fn().mockResolvedValue(new Map()),
+    } as unknown as RTCPeerConnection;
+
+    collector.start(peerConnection);
+    await collector.stop();
+
+    expect(peerConnection.getStats).toHaveBeenCalledTimes(1);
+    expect(collector.getStatsBuffer()).toHaveLength(1);
   });
 });

--- a/packages/js/src/Modules/Verto/util/interfaces.ts
+++ b/packages/js/src/Modules/Verto/util/interfaces.ts
@@ -60,10 +60,23 @@ export interface IVertoOptions {
    */
   enableCallReports?: boolean;
   /**
-   * Interval in milliseconds for collecting call statistics.
+   * Interval in milliseconds for collecting call statistics after the initial
+   * high-resolution startup window.
    * @default 5000 (5 seconds)
    */
   callReportInterval?: number;
+  /**
+   * Interval in milliseconds for collecting call statistics during the first
+   * `callReportInitialDuration` milliseconds of a call.
+   * @default 1000 (1 second)
+   */
+  callReportInitialInterval?: number;
+  /**
+   * Duration in milliseconds for using `callReportInitialInterval` before
+   * falling back to `callReportInterval`.
+   * @default 10000 (10 seconds)
+   */
+  callReportInitialDuration?: number;
   /**
    * Minimum log level to capture for call reports.
    * @default 'debug'

--- a/packages/js/src/Modules/Verto/util/interfaces.ts
+++ b/packages/js/src/Modules/Verto/util/interfaces.ts
@@ -66,18 +66,6 @@ export interface IVertoOptions {
    */
   callReportInterval?: number;
   /**
-   * Interval in milliseconds for collecting call statistics during the first
-   * `callReportInitialDuration` milliseconds of a call.
-   * @default 1000 (1 second)
-   */
-  callReportInitialInterval?: number;
-  /**
-   * Duration in milliseconds for using `callReportInitialInterval` before
-   * falling back to `callReportInterval`.
-   * @default 10000 (10 seconds)
-   */
-  callReportInitialDuration?: number;
-  /**
    * Minimum log level to capture for call reports.
    * @default 'debug'
    */

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -2073,6 +2073,10 @@ export default abstract class BaseCall implements IWebRTCCall {
     // Initialize call report collector (stats + debug logs)
     const enableCallReports = this.session.options.enableCallReports !== false; // Default: true
     const callReportInterval = this.session.options.callReportInterval || 5000; // Default: 5 seconds
+    const callReportInitialInterval =
+      this.session.options.callReportInitialInterval ?? 1000; // Default: 1 second
+    const callReportInitialDuration =
+      this.session.options.callReportInitialDuration ?? 10000; // Default: 10 seconds
     const debugLogLevel = this.session.options.debugLogLevel || 'debug';
     const debugLogMaxEntries = this.session.options.debugLogMaxEntries || 1000;
 
@@ -2081,6 +2085,8 @@ export default abstract class BaseCall implements IWebRTCCall {
         {
           enabled: true,
           interval: callReportInterval,
+          initialInterval: callReportInitialInterval,
+          initialDuration: callReportInitialDuration,
         },
         {
           enabled: true, // Debug logs enabled when call reports are enabled

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -2073,10 +2073,6 @@ export default abstract class BaseCall implements IWebRTCCall {
     // Initialize call report collector (stats + debug logs)
     const enableCallReports = this.session.options.enableCallReports !== false; // Default: true
     const callReportInterval = this.session.options.callReportInterval || 5000; // Default: 5 seconds
-    const callReportInitialInterval =
-      this.session.options.callReportInitialInterval ?? 1000; // Default: 1 second
-    const callReportInitialDuration =
-      this.session.options.callReportInitialDuration ?? 10000; // Default: 10 seconds
     const debugLogLevel = this.session.options.debugLogLevel || 'debug';
     const debugLogMaxEntries = this.session.options.debugLogMaxEntries || 1000;
 
@@ -2085,8 +2081,6 @@ export default abstract class BaseCall implements IWebRTCCall {
         {
           enabled: true,
           interval: callReportInterval,
-          initialInterval: callReportInitialInterval,
-          initialDuration: callReportInitialDuration,
         },
         {
           enabled: true, // Debug logs enabled when call reports are enabled

--- a/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
+++ b/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
@@ -5,7 +5,7 @@
  * at the end of the call for quality analysis and debugging.
  *
  * Stats Collection Strategy (based on Twilio/Jitsi best practices):
- * - Collects stats at regular intervals (default 5 seconds)
+ * - Collects stats every second for the first 10 seconds, then at a regular interval (default 5 seconds)
  * - Stores cumulative values (packets, bytes) from WebRTC API
  * - Calculates averages for variable metrics (audio level, jitter, RTT)
  * - Uses in-memory buffer with size limits for long calls
@@ -180,6 +180,10 @@ export interface ITransportStats {
 export interface ICallReportOptions {
   enabled: boolean;
   interval: number;
+  /** @default 1000 (1 second) */
+  initialInterval?: number;
+  /** @default 10000 (10 seconds) */
+  initialDuration?: number;
 }
 
 export interface ILogCollectorOptions {
@@ -253,7 +257,7 @@ export class CallReportCollector {
   private options: ICallReportOptions;
   private logCollectorOptions: ILogCollectorOptions;
   private peerConnection: RTCPeerConnection | null = null;
-  private intervalId: ReturnType<typeof setInterval> | null = null;
+  private intervalId: ReturnType<typeof setTimeout> | null = null;
   private statsBuffer: IStatsInterval[] = [];
   private intervalStartTime: Date | null = null;
   private callStartTime: Date;
@@ -291,7 +295,7 @@ export class CallReportCollector {
   private previousCandidatePairId: string | null = null;
 
   // Maximum buffer size to prevent memory issues on long calls
-  private readonly MAX_BUFFER_SIZE = 360; // 30 minutes at 5-second intervals
+  private readonly MAX_BUFFER_SIZE = 360; // 30 minutes at 5-second intervals, plus denser startup samples
 
   // ── Size-aware flush ──────────────────────────────────────────────
   // Flush when stats or logs approach their buffer limits to avoid
@@ -333,6 +337,9 @@ export class CallReportCollector {
   /** Whether a flush is already in progress (prevents re-entrant flushes). */
   private _flushing: boolean = false;
 
+  /** Whether stop() has been requested (prevents timer re-scheduling). */
+  private _stopped: boolean = false;
+
   // ── Retry configuration ───────────────────────────────────────────
   private static readonly RETRY_DELAY_MS = 500;
 
@@ -340,7 +347,11 @@ export class CallReportCollector {
     options: ICallReportOptions,
     logCollectorOptions?: ILogCollectorOptions
   ) {
-    this.options = options;
+    this.options = {
+      ...options,
+      initialInterval: options.initialInterval ?? 1000,
+      initialDuration: options.initialDuration ?? 10000,
+    };
     this.logCollectorOptions = logCollectorOptions || {
       enabled: false,
       level: 'debug',
@@ -366,15 +377,16 @@ export class CallReportCollector {
 
     this.peerConnection = peerConnection;
     this.intervalStartTime = new Date();
+    this._stopped = false;
 
     logger.info('CallReportCollector: Starting stats collection', {
       interval: this.options.interval,
+      initialInterval: this.options.initialInterval,
+      initialDuration: this.options.initialDuration,
       logCollectorActive: this.logCollector?.isActive() ?? false,
     });
 
-    this.intervalId = setInterval(() => {
-      this._collectStats();
-    }, this.options.interval);
+    this._scheduleNextCollection();
   }
 
   /**
@@ -384,8 +396,10 @@ export class CallReportCollector {
    * no periodic interval has completed yet.
    */
   public async stop(): Promise<void> {
+    this._stopped = true;
+
     if (this.intervalId) {
-      clearInterval(this.intervalId);
+      clearTimeout(this.intervalId);
       this.intervalId = null;
     }
 
@@ -657,6 +671,58 @@ export class CallReportCollector {
     }
   }
 
+  private _scheduleNextCollection(): void {
+    if (
+      this._stopped ||
+      !this.peerConnection ||
+      !this.intervalStartTime ||
+      this.intervalId
+    ) {
+      return;
+    }
+
+    const interval = this._collectionIntervalFor(this.intervalStartTime);
+    this.intervalId = setTimeout(() => {
+      this.intervalId = null;
+      this._collectStats().finally(() => {
+        if (!this._stopped && this.peerConnection) {
+          this._scheduleNextCollection();
+        }
+      });
+    }, interval);
+  }
+
+  private _collectionIntervalFor(intervalStartTime: Date): number {
+    const defaultInterval = this._positiveInterval(this.options.interval, 5000);
+    const initialDuration = this._positiveInterval(
+      this.options.initialDuration,
+      0
+    );
+    const initialInterval = this._positiveInterval(
+      this.options.initialInterval,
+      defaultInterval
+    );
+
+    if (
+      initialDuration > 0 &&
+      intervalStartTime.getTime() - this.callStartTime.getTime() <
+        initialDuration
+    ) {
+      return Math.min(initialInterval, defaultInterval);
+    }
+
+    return defaultInterval;
+  }
+
+  private _positiveInterval(
+    value: number | undefined,
+    fallback: number
+  ): number {
+    return typeof value === 'number' && Number.isFinite(value) && value > 0
+      ? value
+      : fallback;
+  }
+
   /**
    * Collect stats from the peer connection and aggregate them.
    * @param isFinal - When true (called from stop()), always push a partial
@@ -818,7 +884,10 @@ export class CallReportCollector {
       // short calls (shorter than the collection interval) still produce
       // at least one stats entry in the buffer.
       const intervalDuration = now.getTime() - this.intervalStartTime.getTime();
-      if (isFinal || intervalDuration >= this.options.interval) {
+      const currentInterval = this._collectionIntervalFor(
+        this.intervalStartTime
+      );
+      if (isFinal || intervalDuration >= currentInterval) {
         // Create stats entry for this interval
         const statsEntry = this._createStatsEntry(
           this.intervalStartTime,

--- a/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
+++ b/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
@@ -180,10 +180,6 @@ export interface ITransportStats {
 export interface ICallReportOptions {
   enabled: boolean;
   interval: number;
-  /** @default 1000 (1 second) */
-  initialInterval?: number;
-  /** @default 10000 (10 seconds) */
-  initialDuration?: number;
 }
 
 export interface ILogCollectorOptions {
@@ -294,6 +290,9 @@ export class CallReportCollector {
   // Track selected candidate pair ID to detect mid-call path changes
   private previousCandidatePairId: string | null = null;
 
+  private static readonly INITIAL_COLLECTION_INTERVAL_MS = 1000;
+  private static readonly INITIAL_COLLECTION_DURATION_MS = 10000;
+
   // Maximum buffer size to prevent memory issues on long calls
   private readonly MAX_BUFFER_SIZE = 360; // 30 minutes at 5-second intervals, plus denser startup samples
 
@@ -347,11 +346,7 @@ export class CallReportCollector {
     options: ICallReportOptions,
     logCollectorOptions?: ILogCollectorOptions
   ) {
-    this.options = {
-      ...options,
-      initialInterval: options.initialInterval ?? 1000,
-      initialDuration: options.initialDuration ?? 10000,
-    };
+    this.options = options;
     this.logCollectorOptions = logCollectorOptions || {
       enabled: false,
       level: 'debug',
@@ -381,8 +376,8 @@ export class CallReportCollector {
 
     logger.info('CallReportCollector: Starting stats collection', {
       interval: this.options.interval,
-      initialInterval: this.options.initialInterval,
-      initialDuration: this.options.initialDuration,
+      initialInterval: CallReportCollector.INITIAL_COLLECTION_INTERVAL_MS,
+      initialDuration: CallReportCollector.INITIAL_COLLECTION_DURATION_MS,
       logCollectorActive: this.logCollector?.isActive() ?? false,
     });
 
@@ -694,21 +689,15 @@ export class CallReportCollector {
 
   private _collectionIntervalFor(intervalStartTime: Date): number {
     const defaultInterval = this._positiveInterval(this.options.interval, 5000);
-    const initialDuration = this._positiveInterval(
-      this.options.initialDuration,
-      0
-    );
-    const initialInterval = this._positiveInterval(
-      this.options.initialInterval,
-      defaultInterval
-    );
 
     if (
-      initialDuration > 0 &&
       intervalStartTime.getTime() - this.callStartTime.getTime() <
-        initialDuration
+      CallReportCollector.INITIAL_COLLECTION_DURATION_MS
     ) {
-      return Math.min(initialInterval, defaultInterval);
+      return Math.min(
+        CallReportCollector.INITIAL_COLLECTION_INTERVAL_MS,
+        defaultInterval
+      );
     }
 
     return defaultInterval;

--- a/packages/js/src/utils/interfaces.ts
+++ b/packages/js/src/utils/interfaces.ts
@@ -191,22 +191,6 @@ export interface IClientOptions {
   callReportInterval?: number;
 
   /**
-   * Interval in milliseconds for collecting call statistics during the first
-   * `callReportInitialDuration` milliseconds of a call.
-   *
-   * @default 1000 (1 second)
-   */
-  callReportInitialInterval?: number;
-
-  /**
-   * Duration in milliseconds for using `callReportInitialInterval` before
-   * falling back to `callReportInterval`.
-   *
-   * @default 10000 (10 seconds)
-   */
-  callReportInitialDuration?: number;
-
-  /**
    * Configuration for media permissions recovery on inbound calls.
    * When enabled and the initial `getUserMedia` call fails while answering,
    * the SDK emits a recoverable `telnyx.error` event with `resume()` and

--- a/packages/js/src/utils/interfaces.ts
+++ b/packages/js/src/utils/interfaces.ts
@@ -182,12 +182,29 @@ export interface IClientOptions {
   enableCallReports?: boolean;
 
   /**
-   * Interval in milliseconds for collecting call statistics.
-   * Stats are aggregated over each interval and stored locally until call end.
+   * Interval in milliseconds for collecting call statistics after the initial
+   * high-resolution startup window. Stats are aggregated over each interval
+   * and stored locally until call end.
    *
    * @default 5000 (5 seconds)
    */
   callReportInterval?: number;
+
+  /**
+   * Interval in milliseconds for collecting call statistics during the first
+   * `callReportInitialDuration` milliseconds of a call.
+   *
+   * @default 1000 (1 second)
+   */
+  callReportInitialInterval?: number;
+
+  /**
+   * Duration in milliseconds for using `callReportInitialInterval` before
+   * falling back to `callReportInterval`.
+   *
+   * @default 10000 (10 seconds)
+   */
+  callReportInitialDuration?: number;
 
   /**
    * Configuration for media permissions recovery on inbound calls.


### PR DESCRIPTION
## Summary
- collect call report stats every 1 second for the first 10 seconds of each call
- fall back to the existing configured longer interval after the startup window
- keep short calls covered by final partial stats collection and add cadence/short-call tests
- expose optional client settings for the startup cadence while preserving existing report payload/API contracts

## Verification
- `yarn workspace @telnyx/webrtc test packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts --runInBand`
- `yarn workspace @telnyx/webrtc build`
- `git diff --check`
