### PR TITLE
feat: warn on low local audio

### DIFF
--- a/packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts
@@ -1,8 +1,11 @@
 import logger from '../../util/logger';
+import { LOW_LOCAL_AUDIO } from '../../util/constants/errorCodes';
+import type { ITelnyxWarning } from '../../util/constants/warnings';
 import {
   CallReportCollector,
-  ILocalAudioSourceStats,
-  ILocalAudioTrackSnapshot,
+  type ILocalAudioSourceStats,
+  type ILocalAudioTrackSnapshot,
+  type IStatsInterval,
 } from '../../webrtc/CallReportCollector';
 
 type TestableCallReportCollector = {
@@ -16,12 +19,21 @@ type TestableCallReportCollector = {
     }>;
   } | null;
   cleanup: () => void;
+  onWarning: ((warning: ITelnyxWarning) => void) | null;
   _withoutUndefined: <T extends Record<string, unknown>>(obj: T) => T;
+  _checkQualityWarnings: (
+    statsEntry: IStatsInterval,
+    inboundAudio: RTCInboundRtpStreamStats | null
+  ) => void;
   _getLocalAudioTrackSnapshot: () => ILocalAudioTrackSnapshot | undefined;
   _getOutboundAudioSourceStats: (
     stats: RTCStatsReport,
     outboundAudio: RTCOutboundRtpStreamStats & { mediaSourceId?: string }
   ) => ILocalAudioSourceStats | undefined;
+  _getOutboundAudioLevel: (
+    stats: RTCStatsReport,
+    outboundAudio: RTCOutboundRtpStreamStats & { mediaSourceId?: string }
+  ) => number | null;
   _logLocalAudioTrackSnapshot: (
     localAudioTrack?: ILocalAudioTrackSnapshot,
     localAudioSource?: ILocalAudioSourceStats
@@ -33,6 +45,22 @@ const createCollector = (): TestableCallReportCollector =>
     enabled: true,
     interval: 5000,
   }) as unknown as TestableCallReportCollector;
+
+const createStatsEntry = (audioLevelAvg: number): IStatsInterval => ({
+  intervalStartUtc: '2026-05-15T00:00:00.000Z',
+  intervalEndUtc: '2026-05-15T00:00:05.000Z',
+  audio: {
+    outbound: {
+      audioLevelAvg,
+      bytesSent: 1000,
+      localTrack: {
+        id: 'track-id',
+        enabled: true,
+        muted: false,
+      },
+    },
+  },
+});
 
 describe('CallReportCollector local audio diagnostics', () => {
   afterEach(() => {
@@ -114,5 +142,79 @@ describe('CallReportCollector local audio diagnostics', () => {
         mediaSourceId: 'source-id',
       } as RTCOutboundRtpStreamStats & { mediaSourceId?: string })
     ).toBeUndefined();
+  });
+
+  it('derives outbound audio level from local audio energy deltas', () => {
+    const collector = createCollector();
+    const outboundAudio = {
+      type: 'outbound-rtp',
+      id: 'outbound-audio',
+      mediaSourceId: 'source-id',
+    } as RTCOutboundRtpStreamStats & { mediaSourceId?: string };
+    const firstStats = new Map<string, unknown>([
+      [
+        'source-id',
+        {
+          type: 'media-source',
+          kind: 'audio',
+          totalAudioEnergy: 1,
+          totalSamplesDuration: 10,
+        },
+      ],
+    ]) as unknown as RTCStatsReport;
+    const secondStats = new Map<string, unknown>([
+      [
+        'source-id',
+        {
+          type: 'media-source',
+          kind: 'audio',
+          totalAudioEnergy: 1.000001,
+          totalSamplesDuration: 11,
+        },
+      ],
+    ]) as unknown as RTCStatsReport;
+
+    expect(
+      collector._getOutboundAudioLevel(firstStats, outboundAudio)
+    ).toBeNull();
+    expect(
+      collector._getOutboundAudioLevel(secondStats, outboundAudio)
+    ).toBeCloseTo(0.001);
+  });
+
+  it('emits low local audio warning after consecutive outbound audio breaches', () => {
+    const collector = createCollector();
+    const onWarning = jest.fn();
+    collector.onWarning = onWarning;
+
+    collector._checkQualityWarnings(createStatsEntry(0), null);
+    collector._checkQualityWarnings(createStatsEntry(0), null);
+    expect(onWarning).not.toHaveBeenCalled();
+
+    collector._checkQualityWarnings(createStatsEntry(0), null);
+
+    expect(onWarning).toHaveBeenCalledTimes(1);
+    expect(onWarning).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: LOW_LOCAL_AUDIO,
+        name: 'LOW_LOCAL_AUDIO',
+      })
+    );
+  });
+
+  it('does not emit low local audio warning for disabled local tracks', () => {
+    const collector = createCollector();
+    const onWarning = jest.fn();
+    const statsEntry = createStatsEntry(0);
+    if (statsEntry.audio?.outbound?.localTrack) {
+      statsEntry.audio.outbound.localTrack.enabled = false;
+    }
+    collector.onWarning = onWarning;
+
+    collector._checkQualityWarnings(statsEntry, null);
+    collector._checkQualityWarnings(statsEntry, null);
+    collector._checkQualityWarnings(statsEntry, null);
+
+    expect(onWarning).not.toHaveBeenCalled();
   });
 });

--- a/packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts
@@ -202,6 +202,43 @@ describe('CallReportCollector local audio diagnostics', () => {
     );
   });
 
+  it('does not emit low local audio warning during short silence after local audio is confirmed', () => {
+    const collector = createCollector();
+    const onWarning = jest.fn();
+    collector.onWarning = onWarning;
+
+    collector._checkQualityWarnings(createStatsEntry(0.01), null);
+    collector._checkQualityWarnings(createStatsEntry(0), null);
+    collector._checkQualityWarnings(createStatsEntry(0), null);
+    collector._checkQualityWarnings(createStatsEntry(0), null);
+
+    expect(onWarning).not.toHaveBeenCalled();
+  });
+
+  it('emits low local audio warning again only after long silence once local audio is confirmed', () => {
+    const collector = createCollector();
+    const onWarning = jest.fn();
+    collector.onWarning = onWarning;
+
+    collector._checkQualityWarnings(createStatsEntry(0), null);
+    collector._checkQualityWarnings(createStatsEntry(0), null);
+    collector._checkQualityWarnings(createStatsEntry(0), null);
+    expect(onWarning).toHaveBeenCalledTimes(1);
+
+    collector._checkQualityWarnings(createStatsEntry(0.01), null);
+
+    for (let i = 0; i < 5; i += 1) {
+      collector._checkQualityWarnings(createStatsEntry(0), null);
+    }
+    expect(onWarning).toHaveBeenCalledTimes(1);
+
+    collector._checkQualityWarnings(createStatsEntry(0), null);
+    expect(onWarning).toHaveBeenCalledTimes(2);
+
+    collector._checkQualityWarnings(createStatsEntry(0), null);
+    expect(onWarning).toHaveBeenCalledTimes(2);
+  });
+
   it('does not emit low local audio warning for disabled local tracks', () => {
     const collector = createCollector();
     const onWarning = jest.fn();

--- a/packages/js/src/Modules/Verto/util/constants/errorCodes.ts
+++ b/packages/js/src/Modules/Verto/util/constants/errorCodes.ts
@@ -52,6 +52,7 @@ export const TELNYX_WARNING_CODES = {
   HIGH_JITTER: 31002,
   HIGH_PACKET_LOSS: 31003,
   LOW_MOS: 31004,
+  LOW_LOCAL_AUDIO: 31005,
 
   // ── Connection / data-flow warnings (320xx) ─────────────────────────
   LOW_BYTES_RECEIVED: 32001,
@@ -104,6 +105,7 @@ export const {
   HIGH_JITTER,
   HIGH_PACKET_LOSS,
   LOW_MOS,
+  LOW_LOCAL_AUDIO,
   LOW_BYTES_RECEIVED,
   LOW_BYTES_SENT,
   ICE_CONNECTIVITY_LOST,

--- a/packages/js/src/Modules/Verto/util/constants/warnings.ts
+++ b/packages/js/src/Modules/Verto/util/constants/warnings.ts
@@ -103,6 +103,24 @@ export const SDK_WARNINGS = {
       'Close bandwidth-heavy applications',
     ],
   },
+  31005: {
+    name: 'LOW_LOCAL_AUDIO',
+    message: 'Low local microphone audio detected',
+    description:
+      'Local outbound audio level stayed below the acceptable threshold for multiple consecutive samples. This may indicate that the microphone is not capturing enough audio even while RTP is being sent.',
+    causes: [
+      'Microphone input level is too low',
+      'Wrong microphone selected',
+      'Microphone is obstructed or too far from the speaker',
+      'Operating system input gain is muted or very low',
+    ],
+    solutions: [
+      'Check the selected microphone',
+      'Increase microphone input gain',
+      'Move closer to the microphone',
+      'Verify the microphone is not muted at the operating system or hardware level',
+    ],
+  },
 
   // ── Connection / data-flow warnings (320xx) ─────────────────────────
   32001: {

--- a/packages/js/src/Modules/Verto/util/constants/warnings.ts
+++ b/packages/js/src/Modules/Verto/util/constants/warnings.ts
@@ -107,7 +107,7 @@ export const SDK_WARNINGS = {
     name: 'LOW_LOCAL_AUDIO',
     message: 'Low local microphone audio detected',
     description:
-      'Local outbound audio level stayed below the acceptable threshold for multiple consecutive samples. This may indicate that the microphone is not capturing enough audio even while RTP is being sent.',
+      'Local outbound audio level stayed below the acceptable threshold before the microphone produced real audio, or stayed silent for a long continuous window after audio was confirmed. This may indicate that the microphone is not capturing enough audio even while RTP is being sent.',
     causes: [
       'Microphone input level is too low',
       'Wrong microphone selected',

--- a/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
+++ b/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
@@ -29,6 +29,7 @@ import {
   HIGH_JITTER,
   HIGH_PACKET_LOSS,
   LOW_MOS,
+  LOW_LOCAL_AUDIO,
   LOW_BYTES_RECEIVED,
   LOW_BYTES_SENT,
 } from '../../../Modules/Verto/util/constants/errorCodes';
@@ -311,6 +312,10 @@ export class CallReportCollector {
   private static readonly THRESHOLD_JITTER_MS = 30; // 30ms
   private static readonly THRESHOLD_PACKET_LOSS_PCT = 1; // 1%
   private static readonly THRESHOLD_MOS = 3.5;
+  // WebRTC audioLevel is linear RMS in [0, 1]. Treat near-silence as a
+  // local microphone issue only after consecutive intervals, mirroring the
+  // high-jitter warning pattern and avoiding one-off pauses in speech.
+  private static readonly THRESHOLD_LOCAL_AUDIO_LEVEL = 0.001;
 
   // Consecutive breach counters (per warning code)
   private _breachCounters: Record<number, number> = {};
@@ -931,6 +936,12 @@ export class CallReportCollector {
         packetLossPct > CallReportCollector.THRESHOLD_PACKET_LOSS_PCT
     );
 
+    // Local microphone audio warning — outbound audioLevelAvg is sourced from
+    // media-source audioLevel when present, or computed from totalAudioEnergy
+    // deltas as a fallback. Do not warn for an intentionally disabled/muted
+    // local track.
+    this._trackBreach(LOW_LOCAL_AUDIO, this._isLowLocalAudio(statsEntry));
+
     // MOS warning — simplified E-model
     if (
       rtt !== undefined &&
@@ -969,6 +980,19 @@ export class CallReportCollector {
       const currBytes = statsEntry.audio.outbound.bytesSent ?? 0;
       this._trackBreach(LOW_BYTES_SENT, currBytes - prevBytes === 0);
     }
+  }
+
+  private _isLowLocalAudio(statsEntry: IStatsInterval): boolean {
+    const outbound = statsEntry.audio?.outbound;
+    const audioLevel = outbound?.audioLevelAvg;
+    if (audioLevel === undefined) return false;
+
+    const localTrack = outbound?.localTrack;
+    if (localTrack?.enabled === false || localTrack?.muted === true) {
+      return false;
+    }
+
+    return audioLevel <= CallReportCollector.THRESHOLD_LOCAL_AUDIO_LEVEL;
   }
 
   /**

--- a/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
+++ b/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
@@ -313,9 +313,12 @@ export class CallReportCollector {
   private static readonly THRESHOLD_PACKET_LOSS_PCT = 1; // 1%
   private static readonly THRESHOLD_MOS = 3.5;
   // WebRTC audioLevel is linear RMS in [0, 1]. Treat near-silence as a
-  // local microphone issue only after consecutive intervals, mirroring the
-  // high-jitter warning pattern and avoiding one-off pauses in speech.
+  // local microphone issue only before the microphone has produced a real
+  // audio sample. Once local audio has been confirmed, only warn again after
+  // a long continuous silence window to avoid false positives during natural
+  // agent/customer pauses.
   private static readonly THRESHOLD_LOCAL_AUDIO_LEVEL = 0.001;
+  private static readonly CONFIRMED_LOCAL_AUDIO_SILENCE_MS = 30_000;
 
   // Consecutive breach counters (per warning code)
   private _breachCounters: Record<number, number> = {};
@@ -331,6 +334,13 @@ export class CallReportCollector {
 
   // Last logged local audio track snapshot, used to avoid repetitive logs.
   private _lastLocalAudioTrackSnapshotJson: string | null = null;
+
+  // Local audio warning state. Before confirmation, low audio warns quickly so
+  // broken microphone setup is surfaced early. After the SDK sees real local
+  // audio, short silence windows are expected in live calls and only long
+  // continuous silence should warn again.
+  private _hasConfirmedLocalAudio: boolean = false;
+  private _confirmedLocalAudioSilenceMs: number = 0;
 
   /** Running segment counter for multi-part reports. */
   private _segmentIndex: number = 0;
@@ -939,8 +949,9 @@ export class CallReportCollector {
     // Local microphone audio warning — outbound audioLevelAvg is sourced from
     // media-source audioLevel when present, or computed from totalAudioEnergy
     // deltas as a fallback. Do not warn for an intentionally disabled/muted
-    // local track.
-    this._trackBreach(LOW_LOCAL_AUDIO, this._isLowLocalAudio(statsEntry));
+    // local track. Once any real local audio has been observed, avoid warning
+    // on normal 5-10s pauses; require a long continuous silence window instead.
+    this._trackLowLocalAudio(statsEntry);
 
     // MOS warning — simplified E-model
     if (
@@ -982,17 +993,58 @@ export class CallReportCollector {
     }
   }
 
-  private _isLowLocalAudio(statsEntry: IStatsInterval): boolean {
+  private _trackLowLocalAudio(statsEntry: IStatsInterval): void {
     const outbound = statsEntry.audio?.outbound;
     const audioLevel = outbound?.audioLevelAvg;
-    if (audioLevel === undefined) return false;
-
     const localTrack = outbound?.localTrack;
-    if (localTrack?.enabled === false || localTrack?.muted === true) {
-      return false;
+
+    if (
+      audioLevel === undefined ||
+      localTrack?.enabled === false ||
+      localTrack?.muted === true
+    ) {
+      this._resetLowLocalAudioWarning();
+      return;
     }
 
-    return audioLevel <= CallReportCollector.THRESHOLD_LOCAL_AUDIO_LEVEL;
+    const isLow = audioLevel <= CallReportCollector.THRESHOLD_LOCAL_AUDIO_LEVEL;
+
+    if (!isLow) {
+      this._hasConfirmedLocalAudio = true;
+      this._confirmedLocalAudioSilenceMs = 0;
+      this._trackBreach(LOW_LOCAL_AUDIO, false);
+      return;
+    }
+
+    if (!this._hasConfirmedLocalAudio) {
+      this._trackBreach(LOW_LOCAL_AUDIO, true);
+      return;
+    }
+
+    this._confirmedLocalAudioSilenceMs +=
+      this._getStatsIntervalDurationMs(statsEntry);
+
+    if (
+      this._confirmedLocalAudioSilenceMs >=
+      CallReportCollector.CONFIRMED_LOCAL_AUDIO_SILENCE_MS
+    ) {
+      this._emitWarningOncePerEpisode(LOW_LOCAL_AUDIO);
+    }
+  }
+
+  private _resetLowLocalAudioWarning(): void {
+    this._confirmedLocalAudioSilenceMs = 0;
+    this._trackBreach(LOW_LOCAL_AUDIO, false);
+  }
+
+  private _getStatsIntervalDurationMs(statsEntry: IStatsInterval): number {
+    const start = new Date(statsEntry.intervalStartUtc).getTime();
+    const end = new Date(statsEntry.intervalEndUtc).getTime();
+    const duration = end - start;
+
+    return Number.isFinite(duration) && duration > 0
+      ? duration
+      : this.options.interval;
   }
 
   /**
@@ -1014,18 +1066,7 @@ export class CallReportCollector {
         const lastEmitted = this._lastWarningEmitted[code] ?? 0;
         if (now - lastEmitted >= CallReportCollector.WARNING_THROTTLE_MS) {
           this._lastWarningEmitted[code] = now;
-          try {
-            const warning = createTelnyxWarning(code);
-            logger.warn(
-              `CallReportCollector: warning ${warning.code}: ${warning.message}`
-            );
-            this.onWarning?.(warning);
-          } catch (err) {
-            logger.error(
-              `CallReportCollector: Failed to emit warning ${code}`,
-              { error: err }
-            );
-          }
+          this._emitWarning(code);
         }
       }
     } else {
@@ -1033,6 +1074,28 @@ export class CallReportCollector {
       this._breachCounters[code] = 0;
       this._activeWarnings.delete(code);
       delete this._lastWarningEmitted[code];
+    }
+  }
+
+  private _emitWarningOncePerEpisode(code: SdkWarningCode): void {
+    if (this._activeWarnings.has(code)) return;
+
+    this._activeWarnings.add(code);
+    this._lastWarningEmitted[code] = Date.now();
+    this._emitWarning(code);
+  }
+
+  private _emitWarning(code: SdkWarningCode): void {
+    try {
+      const warning = createTelnyxWarning(code);
+      logger.warn(
+        `CallReportCollector: warning ${warning.code}: ${warning.message}`
+      );
+      this.onWarning?.(warning);
+    } catch (err) {
+      logger.error(`CallReportCollector: Failed to emit warning ${code}`, {
+        error: err,
+      });
     }
   }
 


### PR DESCRIPTION
## Summary
- add a `LOW_LOCAL_AUDIO` warning code surfaced through the existing `telnyx.warning` quality-event path
- trigger the initial warning after consecutive low outbound local audio-level samples, including audio levels derived from local `totalAudioEnergy` deltas
- avoid warning when the local track is intentionally disabled or muted
- after the microphone has produced real audio, suppress normal short pauses and only emit `LOW_LOCAL_AUDIO` again after 30s of continuous local silence

## Verification
- `yarn workspace @telnyx/webrtc test src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts --runInBand`
- `yarn workspace @telnyx/webrtc exec eslint src/Modules/Verto/webrtc/CallReportCollector.ts src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts src/Modules/Verto/util/constants/errorCodes.ts src/Modules/Verto/util/constants/warnings.ts`
