### PR TITLE
VSUP-65: Fix stale call establishment timing marks

### DIFF
--- a/packages/js/src/Modules/Verto/index.ts
+++ b/packages/js/src/Modules/Verto/index.ts
@@ -5,6 +5,7 @@ import {
   IVertoOptions,
 } from './util/interfaces';
 import { IVertoCallOptions } from './webrtc/interfaces';
+import { callMarkName } from './webrtc/CallEstablishmentTimings';
 import Call from './webrtc/Call';
 import VertoHandler from './webrtc/VertoHandler';
 import {
@@ -61,7 +62,7 @@ export default class Verto extends BrowserSession {
       throw telnyxError;
     }
     const call = new Call(this, options);
-    performance.mark('new-call-start');
+    performance.mark(callMarkName(call.id, 'new-call-start'));
     call.invite();
     return call;
   }

--- a/packages/js/src/Modules/Verto/tests/webrtc/CallEstablishmentTimings.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/CallEstablishmentTimings.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Tests for CallEstablishmentTimings.
+ *
+ * Other test files in this suite mock `global.performance` with stubs via
+ * Object.defineProperty. Since Jest runs tests in the same worker process,
+ * those stubs leak into this file. We restore a working performance API
+ * before our tests run.
+ */
+import {
+  callMarkName,
+  collectCallEstablishmentTimings,
+  clearCallMarks,
+} from '../../webrtc/CallEstablishmentTimings';
+
+// Restore a real-acting performance API — the one from Node's perf_hooks
+// does not support mark/clearMarks in older Node versions, so we build
+// a lightweight in-memory implementation.
+const _marks = new Map<string, number>();
+let _time = 0;
+
+Object.defineProperty(global, 'performance', {
+  writable: true,
+  value: {
+    mark(name: string) {
+      _marks.set(name, _time);
+      _time += 1;
+    },
+    clearMarks(name?: string) {
+      if (name === undefined) {
+        _marks.clear();
+        _time = 0;
+      } else {
+        _marks.delete(name);
+      }
+    },
+    getEntriesByName(name: string) {
+      const t = _marks.get(name);
+      if (t !== undefined) {
+        return [{ startTime: t }];
+      }
+      return [];
+    },
+    getEntriesByType() {
+      return [];
+    },
+    measure: jest.fn(),
+    clearMeasures: jest.fn(),
+    now: jest.fn().mockReturnValue(Date.now()),
+  },
+});
+
+describe('CallEstablishmentTimings', () => {
+  beforeEach(() => {
+    _marks.clear();
+    _time = 0;
+  });
+
+  describe('callMarkName', () => {
+    it('should produce a call-scoped mark name', () => {
+      expect(callMarkName('call-abc', 'ringing')).toBe(
+        'telnyx:call:call-abc:ringing'
+      );
+    });
+
+    it('should produce different names for different call IDs', () => {
+      expect(callMarkName('call-1', 'ringing')).not.toBe(
+        callMarkName('call-2', 'ringing')
+      );
+    });
+  });
+
+  describe('collectCallEstablishmentTimings', () => {
+    it('should return empty steps when no start mark exists', () => {
+      const timings = collectCallEstablishmentTimings(
+        'call-1',
+        'trickle',
+        'outbound'
+      );
+      expect(timings.steps).toEqual([]);
+    });
+
+    it('should collect timings scoped to a specific call ID', () => {
+      const callId = 'call-123';
+
+      performance.mark(callMarkName(callId, 'new-call-start'));
+      performance.mark(callMarkName(callId, 'ringing'));
+      performance.mark(callMarkName(callId, 'call-active'));
+
+      const timings = collectCallEstablishmentTimings(
+        callId,
+        'trickle',
+        'outbound'
+      );
+
+      expect(timings.steps).toHaveLength(2);
+      expect(timings.steps[0].label).toBe('Remote side ringing');
+      expect(timings.steps[1].label).toBe('Call is active');
+    });
+
+    it('should NOT include marks from a different call ID', () => {
+      const callId1 = 'call-1';
+      const callId2 = 'call-2';
+
+      performance.mark(callMarkName(callId1, 'new-call-start'));
+      performance.mark(callMarkName(callId1, 'ringing'));
+
+      performance.mark(callMarkName(callId2, 'new-call-start'));
+      performance.mark(callMarkName(callId2, 'ringing'));
+      performance.mark(callMarkName(callId2, 'call-active'));
+
+      const timings1 = collectCallEstablishmentTimings(
+        callId1,
+        'trickle',
+        'outbound'
+      );
+      const timings2 = collectCallEstablishmentTimings(
+        callId2,
+        'trickle',
+        'outbound'
+      );
+
+      expect(timings1.steps).toHaveLength(1);
+      expect(timings1.steps[0].label).toBe('Remote side ringing');
+
+      expect(timings2.steps).toHaveLength(2);
+      expect(timings2.steps[0].label).toBe('Remote side ringing');
+      expect(timings2.steps[1].label).toBe('Call is active');
+    });
+
+    it('should compute non-negative fromStart deltas', () => {
+      const callId = 'call-delta';
+
+      performance.mark(callMarkName(callId, 'new-call-start'));
+      performance.mark(callMarkName(callId, 'ringing'));
+
+      const timings = collectCallEstablishmentTimings(
+        callId,
+        'non-trickle',
+        'inbound'
+      );
+
+      expect(timings.steps).toHaveLength(1);
+      // From our mock: new-call-start at t=0, ringing at t=1
+      expect(timings.steps[0].fromStart).toBe(1);
+      expect(timings.steps[0].delta).toBe(1);
+    });
+  });
+
+  describe('clearCallMarks', () => {
+    it('should clear only marks for the specified call ID', () => {
+      const callId1 = 'call-clear-1';
+      const callId2 = 'call-clear-2';
+
+      performance.mark(callMarkName(callId1, 'new-call-start'));
+      performance.mark(callMarkName(callId1, 'ringing'));
+      performance.mark(callMarkName(callId2, 'new-call-start'));
+      performance.mark(callMarkName(callId2, 'ringing'));
+
+      clearCallMarks(callId1);
+
+      expect(
+        performance.getEntriesByName(
+          callMarkName(callId1, 'new-call-start'),
+          'mark'
+        ).length
+      ).toBe(0);
+      expect(
+        performance.getEntriesByName(callMarkName(callId1, 'ringing'), 'mark')
+          .length
+      ).toBe(0);
+
+      expect(
+        performance.getEntriesByName(
+          callMarkName(callId2, 'new-call-start'),
+          'mark'
+        ).length
+      ).toBe(1);
+      expect(
+        performance.getEntriesByName(callMarkName(callId2, 'ringing'), 'mark')
+          .length
+      ).toBe(1);
+    });
+
+    it('should not throw when clearing marks for a call that has none', () => {
+      expect(() => clearCallMarks('nonexistent-call')).not.toThrow();
+    });
+  });
+
+  describe('stale marks isolation (bug fix)', () => {
+    it('should not reuse stale marks from a previous call', () => {
+      const call1Id = 'stale-call-1';
+
+      performance.mark(callMarkName(call1Id, 'new-call-start'));
+      performance.mark(callMarkName(call1Id, 'ringing'));
+      // Call 1 never reaches call-active or connected.
+      // Peer close clears the stale marks.
+      clearCallMarks(call1Id);
+
+      // Call 2 starts
+      const call2Id = 'fresh-call-2';
+      performance.mark(callMarkName(call2Id, 'new-call-start'));
+      performance.mark(callMarkName(call2Id, 'ringing'));
+      performance.mark(callMarkName(call2Id, 'call-active'));
+
+      const timings2 = collectCallEstablishmentTimings(
+        call2Id,
+        'trickle',
+        'outbound'
+      );
+
+      expect(timings2.steps).toHaveLength(2);
+      // From our mock: new-call-start at t=0, ringing at t=1, call-active at t=2
+      expect(timings2.steps[0].fromStart).toBe(1);
+      expect(timings2.steps[1].fromStart).toBe(2);
+    });
+
+    it('should isolate concurrent calls with overlapping marks', () => {
+      const callA = 'concurrent-a';
+      const callB = 'concurrent-b';
+
+      performance.mark(callMarkName(callA, 'new-call-start'));
+      performance.mark(callMarkName(callA, 'ringing'));
+
+      performance.mark(callMarkName(callB, 'new-call-start'));
+      performance.mark(callMarkName(callB, 'ringing'));
+      performance.mark(callMarkName(callB, 'call-active'));
+
+      performance.mark(callMarkName(callA, 'call-active'));
+
+      const timingsA = collectCallEstablishmentTimings(
+        callA,
+        'trickle',
+        'outbound'
+      );
+      const timingsB = collectCallEstablishmentTimings(
+        callB,
+        'trickle',
+        'outbound'
+      );
+
+      expect(timingsA.steps).toHaveLength(2);
+      expect(timingsB.steps).toHaveLength(2);
+
+      // Each call's fromStart values should be relative to its own start mark
+      // Call A: new-call-start=0, ringing=1, call-active=5
+      expect(timingsA.steps[0].fromStart).toBe(1);
+      expect(timingsA.steps[1].fromStart).toBe(5);
+
+      // Call B: new-call-start=2, ringing=3, call-active=4
+      expect(timingsB.steps[0].fromStart).toBe(1);
+      expect(timingsB.steps[1].fromStart).toBe(2);
+    });
+
+    it('should handle a previous call whose marks were NOT cleared (defense in depth)', () => {
+      // Even if clearCallMarks was never called for the previous call,
+      // the call-scoped mark names prevent cross-contamination.
+      const call1Id = 'unclean-call-1';
+
+      performance.mark(callMarkName(call1Id, 'new-call-start'));
+      performance.mark(callMarkName(call1Id, 'ringing'));
+      // Marks NOT cleared — simulating a path where clearCallMarks wasn't called
+
+      const call2Id = 'second-call-2';
+      performance.mark(callMarkName(call2Id, 'new-call-start'));
+      performance.mark(callMarkName(call2Id, 'ringing'));
+      performance.mark(callMarkName(call2Id, 'call-active'));
+
+      const timings2 = collectCallEstablishmentTimings(
+        call2Id,
+        'trickle',
+        'outbound'
+      );
+
+      // Still correct — no cross-contamination because marks are scoped
+      expect(timings2.steps).toHaveLength(2);
+      expect(timings2.steps[0].label).toBe('Remote side ringing');
+      expect(timings2.steps[1].label).toBe('Call is active');
+    });
+  });
+});

--- a/packages/js/src/Modules/Verto/tests/webrtc/CallEstablishmentTimings.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/CallEstablishmentTimings.test.ts
@@ -276,5 +276,43 @@ describe('CallEstablishmentTimings', () => {
       expect(timings2.steps[0].label).toBe('Remote side ringing');
       expect(timings2.steps[1].label).toBe('Call is active');
     });
+
+    it('should clear marks even when no peer was created (peerless teardown)', () => {
+      // Simulate: inbound invite marks new-call-start, but the call is
+      // rejected/terminated before answer() creates a peer.
+      // _finalize() should still clear the marks.
+      const callId = 'peerless-call';
+
+      performance.mark(callMarkName(callId, 'new-call-start'));
+      performance.mark(callMarkName(callId, 'ringing'));
+
+      // Simulate _finalize() clearing marks (no peer close involved)
+      clearCallMarks(callId);
+
+      // Marks for this call should be gone
+      expect(
+        performance.getEntriesByName(
+          callMarkName(callId, 'new-call-start'),
+          'mark'
+        ).length
+      ).toBe(0);
+      expect(
+        performance.getEntriesByName(callMarkName(callId, 'ringing'), 'mark')
+          .length
+      ).toBe(0);
+
+      // A subsequent call with a different ID should not be affected
+      const nextCallId = 'after-peerless';
+      performance.mark(callMarkName(nextCallId, 'new-call-start'));
+      performance.mark(callMarkName(nextCallId, 'ringing'));
+      performance.mark(callMarkName(nextCallId, 'call-active'));
+
+      const timings = collectCallEstablishmentTimings(
+        nextCallId,
+        'trickle',
+        'outbound'
+      );
+      expect(timings.steps).toHaveLength(2);
+    });
   });
 });

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -49,6 +49,7 @@ import {
 } from '../util/webrtc';
 import Call from './Call';
 import { MCULayoutEventHandler } from './LayoutHandler';
+import { callMarkName } from './CallEstablishmentTimings';
 import Peer from './Peer';
 import {
   ConferenceAction,
@@ -389,7 +390,7 @@ export default abstract class BaseCall implements IWebRTCCall {
     if (this.options.trickleIce) {
       this._resetTrickleIceCandidateState();
     }
-    performance.mark('new-peer');
+    performance.mark(callMarkName(this.id, 'new-peer'));
     this.peer = new Peer(
       PeerType.Offer,
       this.options,
@@ -454,7 +455,7 @@ export default abstract class BaseCall implements IWebRTCCall {
       return;
     }
 
-    performance.mark('answer-called');
+    performance.mark(callMarkName(this.id, 'answer-called'));
     this._creatingPeer = true;
     this.stopRingtone();
 
@@ -470,7 +471,7 @@ export default abstract class BaseCall implements IWebRTCCall {
     if (this.options.trickleIce) {
       this._resetTrickleIceCandidateState();
     }
-    performance.mark('new-peer');
+    performance.mark(callMarkName(this.id, 'new-peer'));
     this.peer = new Peer(
       PeerType.Answer,
       this.options,
@@ -1115,7 +1116,7 @@ export default abstract class BaseCall implements IWebRTCCall {
         break;
       }
       case State.Active: {
-        performance.mark('call-active');
+        performance.mark(callMarkName(this.id, 'call-active'));
         this.peer?.tryCollectTimings();
 
         // Clear recovery flag when call becomes active again
@@ -1154,7 +1155,7 @@ export default abstract class BaseCall implements IWebRTCCall {
 
     switch (method) {
       case VertoMethod.Answer: {
-        performance.mark('telnyx-rtc-answer');
+        performance.mark(callMarkName(this.id, 'telnyx-rtc-answer'));
         this.gotAnswer = true;
         if (params.telnyx_call_control_id) {
           this.options.telnyxCallControlId = params.telnyx_call_control_id;
@@ -1179,7 +1180,7 @@ export default abstract class BaseCall implements IWebRTCCall {
         break;
       }
       case VertoMethod.Media: {
-        performance.mark('telnyx-rtc-media');
+        performance.mark(callMarkName(this.id, 'telnyx-rtc-media'));
         // Media is an early-media event for the pre-Answer phase only.
         // After Early state (including mid-call ICE restart), the answer SDP
         // is delivered via Modify responses or the telnyx_rtc.modify path,
@@ -1233,7 +1234,7 @@ export default abstract class BaseCall implements IWebRTCCall {
         break;
       }
       case VertoMethod.Ringing: {
-        performance.mark('ringing');
+        performance.mark(callMarkName(this.id, 'ringing'));
         this.playRingback();
         if (params.telnyx_call_control_id) {
           this.options.telnyxCallControlId = params.telnyx_call_control_id;
@@ -1522,7 +1523,7 @@ export default abstract class BaseCall implements IWebRTCCall {
     await this.peer.instance
       .setRemoteDescription(sdp)
       .then(() => {
-        performance.mark('set-remote-description');
+        performance.mark(callMarkName(this.id, 'set-remote-description'));
         if (this.options.trickleIce) {
           this._isRemoteDescriptionSet = true;
           this._flushPendingTrickleIceCandidates();
@@ -1624,7 +1625,7 @@ export default abstract class BaseCall implements IWebRTCCall {
       );
     }
 
-    performance.mark('ice-gathering-end');
+    performance.mark(callMarkName(this.id, 'ice-gathering-end'));
     let msg = null;
 
     const tmpParams = {
@@ -1660,7 +1661,7 @@ export default abstract class BaseCall implements IWebRTCCall {
         void this.hangup({ initiator: 'sdk:unknown-local-sdp-type' }, false);
         return;
     }
-    performance.mark('send-sdp');
+    performance.mark(callMarkName(this.id, 'send-sdp'));
     this._execute(msg)
       .then((response) => {
         const { node_id = null } = response;
@@ -1748,7 +1749,7 @@ export default abstract class BaseCall implements IWebRTCCall {
         return;
     }
 
-    performance.mark('send-sdp');
+    performance.mark(callMarkName(this.id, 'send-sdp'));
     this._execute(msg)
       .then((response) => {
         const { node_id = null } = response;
@@ -1878,14 +1879,14 @@ export default abstract class BaseCall implements IWebRTCCall {
    */
   private _trackCandidateMarks(candidate: RTCIceCandidate) {
     if (!this._firstCandidateSent) {
-      performance.mark('first-candidate');
+      performance.mark(callMarkName(this.id, 'first-candidate'));
       this._firstCandidateSent = true;
     }
 
     if (!this._firstNonHostCandidateSent) {
       const candidateType = candidate.candidate.match(/typ (\w+)/)?.[1];
       if (candidateType && candidateType !== 'host') {
-        performance.mark('first-non-host-candidate');
+        performance.mark(callMarkName(this.id, 'first-non-host-candidate'));
         this._firstNonHostCandidateSent = true;
       }
     }
@@ -1943,7 +1944,7 @@ export default abstract class BaseCall implements IWebRTCCall {
       );
       if (instance.iceGatheringState === 'complete') {
         logger.debug('Finished gathering candidates');
-        performance.mark('ice-gathering-completed');
+        performance.mark(callMarkName(this.id, 'ice-gathering-completed'));
       }
     };
 

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -49,7 +49,7 @@ import {
 } from '../util/webrtc';
 import Call from './Call';
 import { MCULayoutEventHandler } from './LayoutHandler';
-import { callMarkName } from './CallEstablishmentTimings';
+import { callMarkName, clearCallMarks } from './CallEstablishmentTimings';
 import Peer from './Peer';
 import {
   ConferenceAction,
@@ -2254,6 +2254,11 @@ export default abstract class BaseCall implements IWebRTCCall {
 
   protected _finalize() {
     this._stopStats();
+
+    // Clear call marks at the call lifecycle level so cleanup runs even when
+    // no peer was created (e.g. inbound invite rejected before answer()).
+    // Peer.close() also clears marks as defense-in-depth.
+    clearCallMarks(this.id);
 
     logger.debug(`[${this.id}] Closing peer from _finalize`);
     this.peer?.close();

--- a/packages/js/src/Modules/Verto/webrtc/CallEstablishmentTimings.ts
+++ b/packages/js/src/Modules/Verto/webrtc/CallEstablishmentTimings.ts
@@ -68,6 +68,17 @@ const MARK_LABELS: Record<string, string> = {
 };
 
 /**
+ * Build a call-scoped performance mark name.
+ * Format: `telnyx:call:{callId}:{suffix}`
+ *
+ * Scoping marks by call_id prevents stale marks from a previous call
+ * from being picked up by a subsequent call's timing collection.
+ */
+export function callMarkName(callId: string, suffix: string): string {
+  return `telnyx:call:${callId}:${suffix}`;
+}
+
+/**
  * Safely get the timestamp of a performance mark.
  * Returns undefined if the mark doesn't exist.
  */
@@ -87,14 +98,17 @@ function getMarkTime(markName: string): number | undefined {
  * Collect all call establishment timings from performance marks.
  * All times are measured from the 'new-call-start' mark.
  *
+ * @param callId - The call ID to scope mark lookups to
  * @param mode - 'trickle' or 'non-trickle' ICE mode
  * @param direction - 'outbound' or 'inbound'
  */
 export function collectCallEstablishmentTimings(
+  callId: string,
   mode: 'trickle' | 'non-trickle',
   direction: 'outbound' | 'inbound'
 ): ICallEstablishmentTimings {
-  const startTime = getMarkTime('new-call-start');
+  const startMark = callMarkName(callId, 'new-call-start');
+  const startTime = getMarkTime(startMark);
 
   if (startTime === undefined) {
     return { mode, direction, steps: [] };
@@ -105,7 +119,7 @@ export function collectCallEstablishmentTimings(
 
   for (const suffix of MARK_SUFFIXES) {
     if (suffix === 'new-call-start') continue; // skip the start point itself
-    const time = getMarkTime(suffix);
+    const time = getMarkTime(callMarkName(callId, suffix));
     if (time !== undefined) {
       raw.push({
         label: MARK_LABELS[suffix] || suffix,
@@ -190,12 +204,13 @@ export function logCallEstablishmentTimings(
 }
 
 /**
- * Clear all call establishment performance marks.
+ * Clear all call establishment performance marks for a given call.
+ * Marks are scoped by call_id, so only marks belonging to this call are removed.
  */
-export function clearCallMarks(): void {
+export function clearCallMarks(callId: string): void {
   for (const suffix of MARK_SUFFIXES) {
     try {
-      performance.clearMarks(suffix);
+      performance.clearMarks(callMarkName(callId, suffix));
     } catch {
       logger.warn('Clearing performance marks is failed');
     }

--- a/packages/js/src/Modules/Verto/webrtc/Peer.ts
+++ b/packages/js/src/Modules/Verto/webrtc/Peer.ts
@@ -21,6 +21,7 @@ import {
   PEER_CLOSED_DURING_INIT,
 } from '../util/constants/errorCodes';
 import {
+  callMarkName,
   collectCallEstablishmentTimings,
   logCallEstablishmentTimings,
   clearCallMarks,
@@ -161,7 +162,7 @@ export default class Peer {
   }
 
   startNegotiation() {
-    performance.mark('start-negotiation');
+    performance.mark(callMarkName(this.options.id, 'start-negotiation'));
 
     this._negotiating = true;
 
@@ -172,7 +173,7 @@ export default class Peer {
     }
   }
   async startTrickleIceNegotiation() {
-    performance.mark('start-negotiation');
+    performance.mark(callMarkName(this.options.id, 'start-negotiation'));
 
     this._negotiating = true;
 
@@ -258,7 +259,9 @@ export default class Peer {
 
   private handleTrackEvent(event: RTCTrackEvent) {
     if (!this._firstMediaTrackMarked) {
-      performance.mark('first-remote-media-track');
+      performance.mark(
+        callMarkName(this.options.id, 'first-remote-media-track')
+      );
       this._firstMediaTrackMarked = true;
     }
 
@@ -366,7 +369,7 @@ export default class Peer {
     this._prevConnectionState = connectionState;
 
     if (connectionState === 'connected') {
-      performance.mark('dtls-connected');
+      performance.mark(callMarkName(this.options.id, 'dtls-connected'));
       this.tryCollectTimings();
 
       // Successful (re)connection — allow future ICE restarts if we fail again.
@@ -381,7 +384,9 @@ export default class Peer {
 
     if (this._isTrickleIce()) {
       if (connectionState === 'connecting') {
-        performance.mark('peer-connection-connecting');
+        performance.mark(
+          callMarkName(this.options.id, 'peer-connection-connecting')
+        );
       }
 
       if (connectionState === 'connected') {
@@ -389,7 +394,9 @@ export default class Peer {
         // so also clear the safety timeout when the connection succeeds.
         this._clearIceGatheringSafetyTimeout();
 
-        performance.mark('peer-connection-connected');
+        performance.mark(
+          callMarkName(this.options.id, 'peer-connection-connected')
+        );
       }
     }
   };
@@ -404,16 +411,23 @@ export default class Peer {
       return;
     }
     const callActiveExists =
-      performance.getEntriesByName('call-active', 'mark').length > 0;
+      performance.getEntriesByName(
+        callMarkName(this.options.id, 'call-active'),
+        'mark'
+      ).length > 0;
     if (!callActiveExists || this.instance.connectionState !== 'connected') {
       return;
     }
     this._timingsCollected = true;
     const mode = this._isTrickleIce() ? 'trickle' : 'non-trickle';
     const direction = this.isOffer ? 'outbound' : 'inbound';
-    const timings = collectCallEstablishmentTimings(mode, direction);
+    const timings = collectCallEstablishmentTimings(
+      this.options.id,
+      mode,
+      direction
+    );
     logCallEstablishmentTimings(timings);
-    clearCallMarks();
+    clearCallMarks(this.options.id);
   }
 
   private async createPeerConnection() {
@@ -448,7 +462,7 @@ export default class Peer {
         sdp: this.options.remoteSdp,
         type: PeerType.Offer,
       });
-      performance.mark('set-remote-description');
+      performance.mark(callMarkName(this.options.id, 'set-remote-description'));
 
       // Race condition guard: close() may have run during the await above,
       // setting this.instance to null. Throw a structured error so the caller
@@ -544,7 +558,7 @@ export default class Peer {
       throw telnyxError;
     }
 
-    performance.mark('get-user-media');
+    performance.mark(callMarkName(this.options.id, 'get-user-media'));
 
     if (
       this.options.mutedMicOnStart &&
@@ -554,7 +568,7 @@ export default class Peer {
       disableAudioTracks(this.options.localStream);
     }
 
-    performance.mark('peer-creation-end');
+    performance.mark(callMarkName(this.options.id, 'peer-creation-end'));
   }
 
   private _handleIceConnectionStateChange = () => {
@@ -562,7 +576,7 @@ export default class Peer {
     logger.debug(`[${new Date().toISOString()}] ICE Connection State`, state);
 
     if (state === 'connected') {
-      performance.mark('ice-connected');
+      performance.mark(callMarkName(this.options.id, 'ice-connected'));
     }
   };
 
@@ -821,10 +835,10 @@ export default class Peer {
 
     try {
       const offer = await this.instance.createOffer(this._constraints);
-      performance.mark('create-offer');
+      performance.mark(callMarkName(this.options.id, 'create-offer'));
       await this._setLocalDescription(offer);
-      performance.mark('set-local-description');
-      performance.mark('ice-gathering-started');
+      performance.mark(callMarkName(this.options.id, 'set-local-description'));
+      performance.mark(callMarkName(this.options.id, 'ice-gathering-started'));
 
       if (!this._isTrickleIce()) {
         this._sdpReady();
@@ -895,10 +909,10 @@ export default class Peer {
 
     try {
       const answer = await this.instance.createAnswer();
-      performance.mark('create-answer');
+      performance.mark(callMarkName(this.options.id, 'create-answer'));
       await this._setLocalDescription(answer);
-      performance.mark('set-local-description');
-      performance.mark('ice-gathering-started');
+      performance.mark(callMarkName(this.options.id, 'set-local-description'));
+      performance.mark(callMarkName(this.options.id, 'ice-gathering-started'));
 
       return answer;
     } catch (error) {
@@ -1015,6 +1029,11 @@ export default class Peer {
   }
 
   public async close() {
+    // Clear call marks when the peer closes to prevent stale marks
+    // from leaking into a subsequent call's timing calculation.
+    // This covers cleanup paths that don't go through tryCollectTimings()
+    // (e.g. early hangup, call failure, signaling state closed).
+    clearCallMarks(this.options.id);
     this.finishIceRestart();
     this._clearIceGatheringSafetyTimeout();
     if (this._offlineHandler && typeof window !== 'undefined') {

--- a/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
+++ b/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
@@ -2,6 +2,7 @@ import logger from '../util/logger';
 import { createTelnyxError, createTelnyxWarning } from '../util/errors';
 import BrowserSession from '../BrowserSession';
 import Call from './Call';
+import { callMarkName } from './CallEstablishmentTimings';
 import { checkSubscribeResponse } from './helpers';
 import { Result } from '../messages/Verto';
 import {
@@ -147,7 +148,7 @@ class VertoHandler {
         callOptions.recoveredCallId = recoveredCallId;
       }
 
-      performance.mark('new-call-start');
+      performance.mark(callMarkName(callOptions.id, 'new-call-start'));
       const call = new Call(session, callOptions);
       call.nodeId = this.nodeId;
       return call;


### PR DESCRIPTION
## Problem

Call establishment timing calculation could show wildly inflated durations (e.g. 237s ringing as reported in VSUP-65). 

**Root cause:** Performance marks used bare suffixes like `ringing`, `new-call-start` — they were global and not scoped to any particular call. If `clearCallMarks()` was never called (because the call failed/hung up before reaching `call-active` + `connected`), stale marks persisted and polluted the next call's timing collection.

## Fix

- **Scope marks by `call_id`**: All performance marks now use format `telnyx:call:{callId}:{suffix}` — marks from different calls can never collide
- **`clearCallMarks(callId)`**: Takes a `callId` parameter and only clears that call's marks
- **`collectCallEstablishmentTimings(callId, mode, direction)`**: Takes a `callId` and only looks up marks for that call
- **`Peer.close()`** now calls `clearCallMarks(callId)` to ensure marks are cleaned up on all teardown paths (hangup, failure, signaling closed)

This provides **defense in depth**: even if `clearCallMarks` is never called for a call, the scoped mark names prevent cross-contamination.

## Files Changed

| File | Change |
|------|--------|
| `CallEstablishmentTimings.ts` | Added `callMarkName()`, updated `clearCallMarks` and `collectCallEstablishmentTimings` to take `callId` |
| `Peer.ts` | Use `callMarkName()` for all marks, add `clearCallMarks` in `close()` |
| `BaseCall.ts` | Use `callMarkName()` for all marks |
| `Verto/index.ts` | Use `callMarkName()` for `new-call-start` |
| `VertoHandler.ts` | Use `callMarkName()` for `new-call-start` |
| `CallEstablishmentTimings.test.ts` | **New** — 11 tests covering scoping, isolation, stale marks, concurrent calls |

## Test Results

```
Test Suites: 14 passed, 14 total
Tests:       248 passed, 248 total
```

## Acceptance Criteria

- [x] The reported case no longer shows an inflated ringing time like 237 seconds
- [x] Timing calculation is scoped by `call_id` and does not mix marks across calls
- [x] `clearCallMarks` is called/covered for the relevant cleanup paths
- [x] Add/update a small SDK test around stale call marks / repeated calls

Closes VSUP-65