### PR TITLE
feat: add low local audio warning subtypes

### DIFF
--- a/packages/js/CHANGELOG.md
+++ b/packages/js/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+- feat: add `LOW_LOCAL_AUDIO` warning subtypes (`initial_silence`, `sustained_silence`) and diagnostic `details` so clients can distinguish low local microphone audio causes.
+- feat: include outbound call-report `audioLevelSource` / `audioLevelSources` diagnostics for WebRTC stats sources (`media-source.audioLevel`, `media-source.energy`, `track.audioLevel`).
+- docs: document structured warning `subtype` / `details` fields and low local audio diagnostics.
+
 ## [2.26.4](https://github.com/team-telnyx/webrtc/compare/webrtc/v2.26.0...webrtc/v2.26.4) (2026-04-29)
 
 - docs: update ts docs

--- a/packages/js/docs/error-handling.md
+++ b/packages/js/docs/error-handling.md
@@ -23,14 +23,14 @@ Use `telnyx.ready` to know when the client is authenticated and the gateway is r
 
 ## Event Overview
 
-| Event | Purpose | Recommended use |
-| --- | --- | --- |
-| `telnyx.ready` | Client is authenticated and gateway reached `REGISTER` or `REGED` | Enable calling UI and flush any reconnect state |
-| `telnyx.error` | Fatal or blocking SDK errors | Show actionable errors, retry, re-authenticate, or fail the current action |
-| `telnyx.warning` | Non-fatal quality, connectivity, and token warnings | Show degraded-state UI and collect telemetry |
-| `telnyx.notification` | Call lifecycle updates and compatibility notifications | Drive call UI and hangup handling |
-| `telnyx.socket.close` | Raw WebSocket close event | Log close codes and monitor reconnect behavior |
-| `telnyx.socket.error` | Raw WebSocket error wrapper | Log opaque socket failures alongside `sessionId` |
+| Event                 | Purpose                                                           | Recommended use                                                            |
+| --------------------- | ----------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| `telnyx.ready`        | Client is authenticated and gateway reached `REGISTER` or `REGED` | Enable calling UI and flush any reconnect state                            |
+| `telnyx.error`        | Fatal or blocking SDK errors                                      | Show actionable errors, retry, re-authenticate, or fail the current action |
+| `telnyx.warning`      | Non-fatal quality, connectivity, and token warnings               | Show degraded-state UI and collect telemetry                               |
+| `telnyx.notification` | Call lifecycle updates and compatibility notifications            | Drive call UI and hangup handling                                          |
+| `telnyx.socket.close` | Raw WebSocket close event                                         | Log close codes and monitor reconnect behavior                             |
+| `telnyx.socket.error` | Raw WebSocket error wrapper                                       | Log opaque socket failures alongside `sessionId`                           |
 
 ## Structured Errors (`telnyx.error`)
 
@@ -115,52 +115,51 @@ client.on(SwEvent.Error, (event) => {
 
 #### SDP errors
 
-| Code | Name | Message | Typical trigger |
-| --- | --- | --- | --- |
-| `40001` | `SDP_CREATE_OFFER_FAILED` | Failed to create call offer | `RTCPeerConnection.createOffer()` failed |
-| `40002` | `SDP_CREATE_ANSWER_FAILED` | Failed to answer the call | `RTCPeerConnection.createAnswer()` failed |
-| `40003` | `SDP_SET_LOCAL_DESCRIPTION_FAILED` | Failed to apply local call settings | `setLocalDescription()` failed |
-| `40004` | `SDP_SET_REMOTE_DESCRIPTION_FAILED` | Failed to apply remote call settings | `setRemoteDescription()` failed |
-| `40005` | `SDP_SEND_FAILED` | Failed to send call data to server | Invite/answer signaling could not be sent |
+| Code    | Name                                | Message                              | Typical trigger                           |
+| ------- | ----------------------------------- | ------------------------------------ | ----------------------------------------- |
+| `40001` | `SDP_CREATE_OFFER_FAILED`           | Failed to create call offer          | `RTCPeerConnection.createOffer()` failed  |
+| `40002` | `SDP_CREATE_ANSWER_FAILED`          | Failed to answer the call            | `RTCPeerConnection.createAnswer()` failed |
+| `40003` | `SDP_SET_LOCAL_DESCRIPTION_FAILED`  | Failed to apply local call settings  | `setLocalDescription()` failed            |
+| `40004` | `SDP_SET_REMOTE_DESCRIPTION_FAILED` | Failed to apply remote call settings | `setRemoteDescription()` failed           |
+| `40005` | `SDP_SEND_FAILED`                   | Failed to send call data to server   | Invite/answer signaling could not be sent |
 
 #### Media errors
 
-| Code | Name | Message | Typical trigger |
-| --- | --- | --- | --- |
-| `42001` | `MEDIA_MICROPHONE_PERMISSION_DENIED` | Microphone access denied | Browser or OS denied microphone permission |
-| `42002` | `MEDIA_DEVICE_NOT_FOUND` | No microphone found | Missing/disconnected device or invalid `deviceId` |
-| `42003` | `MEDIA_GET_USER_MEDIA_FAILED` | Failed to access microphone | `getUserMedia()` failed for another reason |
+| Code    | Name                                 | Message                     | Typical trigger                                   |
+| ------- | ------------------------------------ | --------------------------- | ------------------------------------------------- |
+| `42001` | `MEDIA_MICROPHONE_PERMISSION_DENIED` | Microphone access denied    | Browser or OS denied microphone permission        |
+| `42002` | `MEDIA_DEVICE_NOT_FOUND`             | No microphone found         | Missing/disconnected device or invalid `deviceId` |
+| `42003` | `MEDIA_GET_USER_MEDIA_FAILED`        | Failed to access microphone | `getUserMedia()` failed for another reason        |
 
 #### Call-control errors
 
-| Code | Name | Message | Typical trigger |
-| --- | --- | --- | --- |
-| `44001` | `HOLD_FAILED` | Failed to hold the call | Hold request failed |
-| `44002` | `INVALID_CALL_PARAMETERS` | Invalid call parameters | Required call params were missing or invalid |
-| `44003` | `BYE_SEND_FAILED` | Failed to hang up cleanly | Local hangup succeeded but BYE could not be sent |
-| `44004` | `SUBSCRIBE_FAILED` | Failed to subscribe to call events | Verto subscribe failed |
+| Code    | Name                      | Message                            | Typical trigger                                  |
+| ------- | ------------------------- | ---------------------------------- | ------------------------------------------------ |
+| `44001` | `HOLD_FAILED`             | Failed to hold the call            | Hold request failed                              |
+| `44002` | `INVALID_CALL_PARAMETERS` | Invalid call parameters            | Required call params were missing or invalid     |
+| `44003` | `BYE_SEND_FAILED`         | Failed to hang up cleanly          | Local hangup succeeded but BYE could not be sent |
+| `44004` | `SUBSCRIBE_FAILED`        | Failed to subscribe to call events | Verto subscribe failed                           |
 
 #### WebSocket and transport errors
 
-| Code | Name | Message | Typical trigger |
-| --- | --- | --- | --- |
-| `45001` | `WEBSOCKET_CONNECTION_FAILED` | Unable to connect to server | WebSocket construction/connection failed |
-| `45002` | `WEBSOCKET_ERROR` | Connection to server lost | Browser `ws.onerror` fired |
-| `45003` | `RECONNECTION_EXHAUSTED` | Unable to reconnect to server | Gateway reconnect attempts were exhausted |
-| `45004` | `GATEWAY_FAILED` | Gateway connection failed | Gateway reported `FAILED` or `FAIL_WAIT` |
+| Code    | Name                          | Message                       | Typical trigger                           |
+| ------- | ----------------------------- | ----------------------------- | ----------------------------------------- |
+| `45001` | `WEBSOCKET_CONNECTION_FAILED` | Unable to connect to server   | WebSocket construction/connection failed  |
+| `45002` | `WEBSOCKET_ERROR`             | Connection to server lost     | Browser `ws.onerror` fired                |
+| `45003` | `RECONNECTION_EXHAUSTED`      | Unable to reconnect to server | Gateway reconnect attempts were exhausted |
+| `45004` | `GATEWAY_FAILED`              | Gateway connection failed     | Gateway reported `FAILED` or `FAIL_WAIT`  |
 
 #### Authentication and session errors
 
-| Code | Name | Message | Typical trigger |
-| --- | --- | --- | --- |
-| `46001` | `LOGIN_FAILED` | Authentication failed | Login rejected or registration never reached ready state |
-| `46002` | `INVALID_CREDENTIALS` | Invalid credential parameters | Client-side login validation failed before request send |
-| `46003` | `AUTHENTICATION_REQUIRED` | Authentication required | Request sent before auth completed or after auth was lost |
-| `48001` | `NETWORK_OFFLINE` | Device is offline | Browser `offline` event fired |
-| `49001` | `UNEXPECTED_ERROR` | An unexpected error occurred | Unclassified failure during peer/call setup |
+| Code    | Name                      | Message                       | Typical trigger                                           |
+| ------- | ------------------------- | ----------------------------- | --------------------------------------------------------- |
+| `46001` | `LOGIN_FAILED`            | Authentication failed         | Login rejected or registration never reached ready state  |
+| `46002` | `INVALID_CREDENTIALS`     | Invalid credential parameters | Client-side login validation failed before request send   |
+| `46003` | `AUTHENTICATION_REQUIRED` | Authentication required       | Request sent before auth completed or after auth was lost |
+| `48001` | `NETWORK_OFFLINE`         | Device is offline             | Browser `offline` event fired                             |
+| `49001` | `UNEXPECTED_ERROR`        | An unexpected error occurred  | Unclassified failure during peer/call setup               |
 
-> [!NOTE]
-> Invalid login options currently also include `type: ERROR_TYPE.invalidCredentialsOptions` on the runtime event payload for backward compatibility. The stable signal to key on is still `event.error.code === TELNYX_ERROR_CODES.INVALID_CREDENTIALS`.
+> Note: Invalid login options currently also include `type: ERROR_TYPE.invalidCredentialsOptions` on the runtime event payload for backward compatibility. The stable signal to key on is still `event.error.code === TELNYX_ERROR_CODES.INVALID_CREDENTIALS`.
 
 ## Structured Warnings (`telnyx.warning`)
 
@@ -174,7 +173,20 @@ interface ITelnyxWarningEvent {
   sessionId: string;
   callId?: string;
 }
+
+interface ITelnyxWarning {
+  code: number;
+  name: string;
+  subtype?: string;
+  message: string;
+  description: string;
+  causes: string[];
+  solutions: string[];
+  details?: Record<string, unknown>;
+}
 ```
+
+`warning.subtype` and `warning.details` are optional. They are present only when a warning code has multiple diagnostic causes or source-specific context.
 
 ### Basic example
 
@@ -192,45 +204,72 @@ client.on(SwEvent.Warning, ({ warning, callId }) => {
     return;
   }
 
+  if (warning.code === TELNYX_WARNING_CODES.LOW_LOCAL_AUDIO) {
+    console.debug('Low local audio subtype:', warning.subtype);
+    console.debug('Low local audio details:', warning.details);
+  }
+
   console.debug(SDK_WARNINGS[warning.code]?.description);
   console.warn(`[${warning.code}] ${warning.name}: ${warning.message}`);
 });
 ```
 
+### Low local audio diagnostics
+
+`LOW_LOCAL_AUDIO` (`31005`) can be emitted with a subtype so applications can distinguish setup-time silence from sustained silence after audio was already confirmed:
+
+| Subtype             | Meaning                                                                                              | Typical action                                                                                            |
+| ------------------- | ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `initial_silence`   | Local outbound audio stayed below threshold before the SDK observed real microphone audio            | Prompt the user to check microphone selection, hardware mute, OS input level, or distance from microphone |
+| `sustained_silence` | Local outbound audio was confirmed earlier, then stayed below threshold for a long continuous window | Treat as a softer warning; avoid interrupting normal short pauses                                         |
+
+`warning.details` for this warning may include:
+
+| Field               | Description                                                                |
+| ------------------- | -------------------------------------------------------------------------- |
+| `audioLevel`        | Averaged outbound audio level that breached the threshold                  |
+| `threshold`         | SDK threshold used for low local audio detection                           |
+| `audioLevelSource`  | Primary WebRTC stats source used for `audioLevel`                          |
+| `audioLevelSources` | All WebRTC stats sources observed for outbound audio level in the interval |
+| `silenceDurationMs` | Continuous silence duration, present for `sustained_silence`               |
+
+`audioLevelSource` / `audioLevelSources` describe WebRTC stats APIs, not microphone device identity. Possible values are `media-source.audioLevel`, `media-source.energy`, and `track.audioLevel`.
+
 ### Warning code reference
 
 #### Network quality warnings
 
-| Code | Name | Message | Typical trigger |
-| --- | --- | --- | --- |
-| `31001` | `HIGH_RTT` | High network latency detected | RTT stayed above threshold |
-| `31002` | `HIGH_JITTER` | High jitter detected | Jitter stayed above threshold |
-| `31003` | `HIGH_PACKET_LOSS` | High packet loss detected | Packet loss stayed above threshold |
-| `31004` | `LOW_MOS` | Low call quality score | MOS stayed below threshold |
+| Code    | Name               | Message                             | Typical trigger                               |
+| ------- | ------------------ | ----------------------------------- | --------------------------------------------- |
+| `31001` | `HIGH_RTT`         | High network latency detected       | RTT stayed above threshold                    |
+| `31002` | `HIGH_JITTER`      | High jitter detected                | Jitter stayed above threshold                 |
+| `31003` | `HIGH_PACKET_LOSS` | High packet loss detected           | Packet loss stayed above threshold            |
+| `31004` | `LOW_MOS`          | Low call quality score              | MOS stayed below threshold                    |
+| `31005` | `LOW_LOCAL_AUDIO`  | Low local microphone audio detected | Outbound microphone audio stayed near silence |
 
 #### Data-flow warnings
 
-| Code | Name | Message | Typical trigger |
-| --- | --- | --- | --- |
-| `32001` | `LOW_BYTES_RECEIVED` | No audio data received | Remote audio bytes stopped increasing |
-| `32002` | `LOW_BYTES_SENT` | No audio data being sent | Local audio bytes stopped increasing |
+| Code    | Name                 | Message                  | Typical trigger                       |
+| ------- | -------------------- | ------------------------ | ------------------------------------- |
+| `32001` | `LOW_BYTES_RECEIVED` | No audio data received   | Remote audio bytes stopped increasing |
+| `32002` | `LOW_BYTES_SENT`     | No audio data being sent | Local audio bytes stopped increasing  |
 
 #### Connectivity warnings
 
-| Code | Name | Message | Typical trigger |
-| --- | --- | --- | --- |
-| `33001` | `ICE_CONNECTIVITY_LOST` | Connection interrupted | ICE connection state became `disconnected` |
-| `33002` | `ICE_GATHERING_TIMEOUT` | ICE gathering timed out | ICE gathering safety timeout fired |
-| `33003` | `ICE_GATHERING_EMPTY` | No ICE candidates gathered | No candidates were collected |
-| `33004` | `PEER_CONNECTION_FAILED` | Connection failed | Peer connection state became `failed` |
-| `33005` | `ONLY_HOST_ICE_CANDIDATES` | Only local network candidates available | SDP contained only host ICE candidates |
+| Code    | Name                       | Message                                 | Typical trigger                            |
+| ------- | -------------------------- | --------------------------------------- | ------------------------------------------ |
+| `33001` | `ICE_CONNECTIVITY_LOST`    | Connection interrupted                  | ICE connection state became `disconnected` |
+| `33002` | `ICE_GATHERING_TIMEOUT`    | ICE gathering timed out                 | ICE gathering safety timeout fired         |
+| `33003` | `ICE_GATHERING_EMPTY`      | No ICE candidates gathered              | No candidates were collected               |
+| `33004` | `PEER_CONNECTION_FAILED`   | Connection failed                       | Peer connection state became `failed`      |
+| `33005` | `ONLY_HOST_ICE_CANDIDATES` | Only local network candidates available | SDP contained only host ICE candidates     |
 
 #### Authentication and session warnings
 
-| Code | Name | Message | Typical trigger |
-| --- | --- | --- | --- |
-| `34001` | `TOKEN_EXPIRING_SOON` | Authentication token expiring soon | JWT expires within 120 seconds |
-| `35001` | `SESSION_NOT_REATTACHED` | Active call lost after reconnect | Server returned an empty `reattached_sessions` list while calls still existed locally |
+| Code    | Name                     | Message                            | Typical trigger                                                                       |
+| ------- | ------------------------ | ---------------------------------- | ------------------------------------------------------------------------------------- |
+| `34001` | `TOKEN_EXPIRING_SOON`    | Authentication token expiring soon | JWT expires within 120 seconds                                                        |
+| `35001` | `SESSION_NOT_REATTACHED` | Active call lost after reconnect   | Server returned an empty `reattached_sessions` list while calls still existed locally |
 
 ## Notifications (`telnyx.notification`)
 
@@ -243,12 +282,12 @@ client.on(SwEvent.Warning, ({ warning, callId }) => {
 
 ### Error-related notification types
 
-| `notification.type` | Current status | Payload notes |
-| --- | --- | --- |
-| `callUpdate` | Active | Includes `call`; use this for call state and hangup data |
-| `userMediaError` | Compatibility notification | Final media-failure notification. Includes raw browser/media `error`, `errorName`, `errorMessage`, and `call` when available |
-| `peerConnectionFailureError` | Compatibility notification | Includes raw `error`; structured replacement is warning `33004` |
-| `signalingStateClosed` | Active | Includes `sessionId`; indicates the current peer signaling state closed |
+| `notification.type`          | Current status             | Payload notes                                                                                                                |
+| ---------------------------- | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `callUpdate`                 | Active                     | Includes `call`; use this for call state and hangup data                                                                     |
+| `userMediaError`             | Compatibility notification | Final media-failure notification. Includes raw browser/media `error`, `errorName`, `errorMessage`, and `call` when available |
+| `peerConnectionFailureError` | Compatibility notification | Includes raw `error`; structured replacement is warning `33004`                                                              |
+| `signalingStateClosed`       | Active                     | Includes `sessionId`; indicates the current peer signaling state closed                                                      |
 
 ### Listener scoping
 
@@ -306,26 +345,26 @@ client.on(SwEvent.Notification, (notification) => {
 
 When a call reaches `hangup`, inspect these fields on the `Call` object:
 
-| Field | Type | Meaning |
-| --- | --- | --- |
-| `cause` | `string` | High-level cause such as `USER_BUSY` or `CALL_REJECTED` |
-| `causeCode` | `number` | Numeric cause code |
-| `sipCode` | `number` | SIP response code when available |
-| `sipReason` | `string` | SIP reason phrase when available |
+| Field       | Type     | Meaning                                                 |
+| ----------- | -------- | ------------------------------------------------------- |
+| `cause`     | `string` | High-level cause such as `USER_BUSY` or `CALL_REJECTED` |
+| `causeCode` | `number` | Numeric cause code                                      |
+| `sipCode`   | `number` | SIP response code when available                        |
+| `sipReason` | `string` | SIP reason phrase when available                        |
 
 Typical cases:
 
-| Field value | Meaning |
-| --- | --- |
-| `cause === 'NORMAL_CLEARING'` | Expected call completion |
-| `cause === 'USER_BUSY'` | Remote party was busy |
-| `cause === 'CALL_REJECTED'` | Remote party rejected the call |
-| `cause === 'NO_ANSWER'` | Call timed out unanswered |
+| Field value                      | Meaning                                    |
+| -------------------------------- | ------------------------------------------ |
+| `cause === 'NORMAL_CLEARING'`    | Expected call completion                   |
+| `cause === 'USER_BUSY'`          | Remote party was busy                      |
+| `cause === 'CALL_REJECTED'`      | Remote party rejected the call             |
+| `cause === 'NO_ANSWER'`          | Call timed out unanswered                  |
 | `cause === 'UNALLOCATED_NUMBER'` | Dialed number is invalid or does not exist |
-| `cause === 'PURGE'` | Call was purged from the system |
-| `sipCode === 403` | Forbidden |
-| `sipCode === 404` | Destination not found |
-| `sipCode === 486` | Busy Here |
+| `cause === 'PURGE'`              | Call was purged from the system            |
+| `sipCode === 403`                | Forbidden                                  |
+| `sipCode === 404`                | Destination not found                      |
+| `sipCode === 486`                | Busy Here                                  |
 
 ## Socket Events
 
@@ -341,15 +380,15 @@ The SDK exposes both raw socket events and structured transport errors.
 
 Useful close codes:
 
-| Code | Meaning |
-| --- | --- |
-| `1000` | Normal closure |
-| `1001` | Going away |
-| `1002` | Protocol error |
-| `1003` | Unsupported data |
+| Code   | Meaning                 |
+| ------ | ----------------------- |
+| `1000` | Normal closure          |
+| `1001` | Going away              |
+| `1002` | Protocol error          |
+| `1003` | Unsupported data        |
 | `1005` | No status code received |
-| `1006` | Abnormal closure |
-| `1011` | Internal error |
+| `1006` | Abnormal closure        |
+| `1011` | Internal error          |
 
 ### `telnyx.socket.error`
 
@@ -368,14 +407,14 @@ This event is intentionally low-detail because browsers expose very little infor
 
 The browser session exposes WebSocket state helpers on `client.connection`:
 
-| Getter | Meaning |
-| --- | --- |
+| Getter                         | Meaning                      |
+| ------------------------------ | ---------------------------- |
 | `client.connection.connecting` | WebSocket is in `CONNECTING` |
-| `client.connection.connected` | WebSocket is in `OPEN` |
-| `client.connection.closing` | WebSocket is in `CLOSING` |
-| `client.connection.closed` | WebSocket is in `CLOSED` |
-| `client.connection.isAlive` | `CONNECTING` or `OPEN` |
-| `client.connection.isDead` | `CLOSING` or `CLOSED` |
+| `client.connection.connected`  | WebSocket is in `OPEN`       |
+| `client.connection.closing`    | WebSocket is in `CLOSING`    |
+| `client.connection.closed`     | WebSocket is in `CLOSED`     |
+| `client.connection.isAlive`    | `CONNECTING` or `OPEN`       |
+| `client.connection.isDead`     | `CLOSING` or `CLOSED`        |
 
 Example:
 
@@ -429,10 +468,10 @@ The SDK still exposes low-level RTC events, but new integrations should prefer `
 
 ### Legacy or low-level RTC events
 
-| Event | Status | Preferred surface |
-| --- | --- | --- |
-| `telnyx.rtc.mediaError` | Legacy/compatibility | `telnyx.error` with `42001`, `42002`, or `42003` |
-| `telnyx.rtc.peerConnectionFailureError` | Legacy/compatibility | `telnyx.warning` with `33004` |
+| Event                                           | Status                 | Preferred surface                                                                        |
+| ----------------------------------------------- | ---------------------- | ---------------------------------------------------------------------------------------- |
+| `telnyx.rtc.mediaError`                         | Legacy/compatibility   | `telnyx.error` with `42001`, `42002`, or `42003`                                         |
+| `telnyx.rtc.peerConnectionFailureError`         | Legacy/compatibility   | `telnyx.warning` with `33004`                                                            |
 | `telnyx.rtc.peerConnectionSignalingStateClosed` | Low-level active event | `notification.type === 'signalingStateClosed'` if you want the higher-level notification |
 
 ### Migration checklist

--- a/packages/js/docs/sw-events.md
+++ b/packages/js/docs/sw-events.md
@@ -13,6 +13,7 @@ This document catalogs the remaining `SwEvent` constants exposed by the WebRTC J
       - [`telnyx.ready`](#telnyxready)
       - [`telnyx.notification`](#telnyxnotification)
     - [Diagnostics \& Telemetry](#diagnostics--telemetry)
+      - [`telnyx.warning`](#telnyxwarning)
       - [`telnyx.stats.frame`](#telnyxstatsframe)
       - [`telnyx.stats.report`](#telnyxstatsreport)
   - [Sample Subscription Patterns](#sample-subscription-patterns)
@@ -27,6 +28,7 @@ This document catalogs the remaining `SwEvent` constants exposed by the WebRTC J
 | --------------------- | ----------------- | ------------------------------------------------------------------- | ----------------------------------- | ----------------------------------------------------------------- |
 | `telnyx.ready`        | Session readiness | SDK is authenticated and the gateway reports `REGED`                | `{ type: 'vertoClientReady', ... }` | Enable dial-pad/UI, resolve "client ready" promises               |
 | `telnyx.notification` | Session readiness | Generic call/session updates (e.g., `callUpdate`, `userMediaError`) | `params` from Verto RPC             | Drive call state machines, show call errors, react to chat events |
+| `telnyx.warning`      | Diagnostics       | Structured non-fatal SDK warnings, including call-quality issues    | `{ warning, sessionId, callId? }`   | Show degraded-state UI and collect warning telemetry              |
 | `telnyx.stats.frame`  | Diagnostics       | One-second slices of WebRTC stats captured by the debug reporter    | `{ jitter, rtt, mos, ... }`         | Plot live charts or compute health scores                         |
 | `telnyx.stats.report` | Diagnostics       | Entire timeline returned when stats capture stops                   | `Array<WebRTCStatsTimelineEntry>`   | Persist logs, attach diagnostics to support cases                 |
 
@@ -71,6 +73,32 @@ A catch-all event that delivers call updates, hangup reasons, DTMF indications, 
 | `signalingStateClosed`       | Peer signaling state closed           | `{ previousConnectionState }` |
 
 ### Diagnostics & Telemetry
+
+#### `telnyx.warning`
+
+Emitted for degraded but recoverable SDK conditions. The payload contains a structured `warning` object, the SDK `sessionId`, and a `callId` when the warning is call-scoped.
+
+Quality warnings can include optional subtype and details fields for richer UI and telemetry. For example, `LOW_LOCAL_AUDIO` (`31005`) may include:
+
+```ts
+{
+  warning: {
+    code: 31005,
+    name: 'LOW_LOCAL_AUDIO',
+    subtype: 'initial_silence', // or 'sustained_silence'
+    details: {
+      audioLevel: 0,
+      threshold: 0.001,
+      audioLevelSource: 'media-source.audioLevel',
+      audioLevelSources: ['media-source.audioLevel', 'media-source.energy']
+    }
+  },
+  sessionId: '...',
+  callId: '...'
+}
+```
+
+`audioLevelSource` and `audioLevelSources` identify the WebRTC stats source used for diagnostics. They do not identify the physical microphone device and do not require additional browser permissions beyond the active call media permissions.
 
 #### `telnyx.stats.frame`
 

--- a/packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts
@@ -53,6 +53,8 @@ const createStatsEntry = (audioLevelAvg: number): IStatsInterval => ({
     outbound: {
       audioLevelAvg,
       bytesSent: 1000,
+      audioLevelSource: 'media-source.audioLevel',
+      audioLevelSources: ['media-source.audioLevel', 'media-source.energy'],
       localTrack: {
         id: 'track-id',
         enabled: true,
@@ -199,6 +201,13 @@ describe('CallReportCollector local audio diagnostics', () => {
       expect.objectContaining({
         code: LOW_LOCAL_AUDIO,
         name: 'LOW_LOCAL_AUDIO',
+        subtype: 'initial_silence',
+        details: expect.objectContaining({
+          subtype: 'initial_silence',
+          audioLevelSource: 'media-source.audioLevel',
+          audioLevelSources: ['media-source.audioLevel', 'media-source.energy'],
+          threshold: 0.001,
+        }),
       })
     );
   });
@@ -235,6 +244,16 @@ describe('CallReportCollector local audio diagnostics', () => {
 
     collector._checkQualityWarnings(createStatsEntry(0), null);
     expect(onWarning).toHaveBeenCalledTimes(2);
+    expect(onWarning).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        code: LOW_LOCAL_AUDIO,
+        subtype: 'sustained_silence',
+        details: expect.objectContaining({
+          subtype: 'sustained_silence',
+          silenceDurationMs: 30000,
+        }),
+      })
+    );
 
     collector._checkQualityWarnings(createStatsEntry(0), null);
     expect(onWarning).toHaveBeenCalledTimes(2);

--- a/packages/js/src/Modules/Verto/util/constants/warnings.ts
+++ b/packages/js/src/Modules/Verto/util/constants/warnings.ts
@@ -19,6 +19,8 @@ export interface ITelnyxWarning {
   code: SdkWarningCode;
   /** Machine-readable name in UPPER_SNAKE_CASE */
   name: string;
+  /** Optional machine-readable subtype for warnings that have multiple causes */
+  subtype?: string;
   /** Short human-readable message for UI alerts */
   message: string;
   /** Full explanation of the warning */
@@ -27,6 +29,8 @@ export interface ITelnyxWarning {
   causes: string[];
   /** Suggested remediation steps */
   solutions: string[];
+  /** Optional diagnostic context for consumers that want richer UI/logging */
+  details?: Record<string, unknown>;
 }
 
 export interface ITelnyxWarningEvent {
@@ -306,6 +310,15 @@ export type SdkWarningCode = keyof typeof SDK_WARNINGS;
 
 type WarningEntry = (typeof SDK_WARNINGS)[SdkWarningCode];
 
+export interface ITelnyxWarningOptions {
+  /** Optional override for the default message */
+  message?: string;
+  /** Optional machine-readable subtype for warnings that have multiple causes */
+  subtype?: string;
+  /** Optional diagnostic context for consumers that want richer UI/logging */
+  details?: Record<string, unknown>;
+}
+
 /**
  * Creates a warning object from a registered warning code.
  *
@@ -315,15 +328,21 @@ type WarningEntry = (typeof SDK_WARNINGS)[SdkWarningCode];
  */
 export function createTelnyxWarning(
   code: SdkWarningCode,
-  message?: string
+  messageOrOptions?: string | ITelnyxWarningOptions
 ): ITelnyxWarning {
   const entry: WarningEntry = SDK_WARNINGS[code];
+  const options =
+    typeof messageOrOptions === 'string'
+      ? { message: messageOrOptions }
+      : (messageOrOptions ?? {});
   return {
     code,
     name: entry.name,
-    message: message || entry.message,
+    ...(options.subtype ? { subtype: options.subtype } : {}),
+    message: options.message || entry.message,
     description: entry.description,
     causes: [...entry.causes],
     solutions: [...entry.solutions],
+    ...(options.details ? { details: { ...options.details } } : {}),
   };
 }

--- a/packages/js/src/Modules/Verto/util/errors.ts
+++ b/packages/js/src/Modules/Verto/util/errors.ts
@@ -13,6 +13,7 @@ import {
   SDK_WARNINGS,
   SdkWarningCode,
   ITelnyxWarning,
+  type ITelnyxWarningOptions,
   createTelnyxWarning,
 } from './constants/warnings';
 import {
@@ -22,7 +23,13 @@ import {
 } from './constants/errorCodes';
 
 export { SDK_ERRORS, SdkErrorCode };
-export { SDK_WARNINGS, SdkWarningCode, ITelnyxWarning, createTelnyxWarning };
+export {
+  SDK_WARNINGS,
+  SdkWarningCode,
+  ITelnyxWarning,
+  ITelnyxWarningOptions,
+  createTelnyxWarning,
+};
 
 export type TelnyxMediaErrorCode =
   | typeof MEDIA_MICROPHONE_PERMISSION_DENIED

--- a/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
+++ b/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
@@ -78,6 +78,24 @@ interface ExtendedMediaSourceStats {
   echoReturnLossEnhancement?: number;
 }
 
+export type AudioLevelSource =
+  | 'media-source.audioLevel'
+  | 'media-source.energy'
+  | 'track.audioLevel';
+
+type LowLocalAudioSubtype = 'initial_silence' | 'sustained_silence';
+
+interface AudioLevelSample {
+  level: number;
+  source: AudioLevelSource;
+  availableSources: AudioLevelSource[];
+}
+
+interface WarningEmitOptions {
+  subtype?: string;
+  details?: Record<string, unknown>;
+}
+
 /**
  * Local audio track metadata captured from the RTCRtpSender track.
  * Useful to distinguish RTP carrying silence from muted/ended/wrong inputs.
@@ -197,6 +215,8 @@ export interface IStatsInterval {
       packetsSent?: number;
       bytesSent?: number;
       audioLevelAvg?: number;
+      audioLevelSource?: AudioLevelSource;
+      audioLevelSources?: AudioLevelSource[];
       bitrateAvg?: number;
       localTrack?: ILocalAudioTrackSnapshot;
       mediaSource?: ILocalAudioSourceStats;
@@ -265,6 +285,9 @@ export class CallReportCollector {
   private intervalAudioLevels: { outbound: number[]; inbound: number[] } = {
     outbound: [],
     inbound: [],
+  };
+  private intervalAudioLevelSources: { outbound: AudioLevelSource[] } = {
+    outbound: [],
   };
   private intervalJitters: number[] = [];
   private intervalRTTs: number[] = [];
@@ -778,9 +801,15 @@ export class CallReportCollector {
       if (outboundAudio) {
         // Outbound audioLevel: available on the media-source stat (Chrome 96+)
         // or on the deprecated track stat as fallback
-        const audioLevel = this._getOutboundAudioLevel(stats, outboundAudio);
+        const audioLevel = this._getOutboundAudioLevelSample(
+          stats,
+          outboundAudio
+        );
         if (audioLevel !== null) {
-          this.intervalAudioLevels.outbound.push(audioLevel);
+          this.intervalAudioLevels.outbound.push(audioLevel.level);
+          this.intervalAudioLevelSources.outbound.push(
+            ...audioLevel.availableSources
+          );
         }
 
         // Calculate bitrate
@@ -1054,6 +1083,8 @@ export class CallReportCollector {
   private _trackLowLocalAudio(statsEntry: IStatsInterval): void {
     const outbound = statsEntry.audio?.outbound;
     const audioLevel = outbound?.audioLevelAvg;
+    const audioLevelSource = outbound?.audioLevelSource;
+    const audioLevelSources = outbound?.audioLevelSources;
     const localTrack = outbound?.localTrack;
 
     if (
@@ -1075,7 +1106,15 @@ export class CallReportCollector {
     }
 
     if (!this._hasConfirmedLocalAudio) {
-      this._trackBreach(LOW_LOCAL_AUDIO, true);
+      this._trackBreach(LOW_LOCAL_AUDIO, true, {
+        subtype: 'initial_silence',
+        details: this._lowLocalAudioDetails(
+          'initial_silence',
+          audioLevel,
+          audioLevelSource,
+          audioLevelSources
+        ),
+      });
       return;
     }
 
@@ -1086,8 +1125,34 @@ export class CallReportCollector {
       this._confirmedLocalAudioSilenceMs >=
       CallReportCollector.CONFIRMED_LOCAL_AUDIO_SILENCE_MS
     ) {
-      this._emitWarningOncePerEpisode(LOW_LOCAL_AUDIO);
+      this._emitWarningOncePerEpisode(LOW_LOCAL_AUDIO, {
+        subtype: 'sustained_silence',
+        details: this._lowLocalAudioDetails(
+          'sustained_silence',
+          audioLevel,
+          audioLevelSource,
+          audioLevelSources,
+          this._confirmedLocalAudioSilenceMs
+        ),
+      });
     }
+  }
+
+  private _lowLocalAudioDetails(
+    subtype: LowLocalAudioSubtype,
+    audioLevel: number,
+    audioLevelSource?: AudioLevelSource,
+    audioLevelSources?: AudioLevelSource[],
+    silenceDurationMs?: number
+  ): Record<string, unknown> {
+    return this._withoutUndefined({
+      subtype,
+      audioLevel,
+      audioLevelSource,
+      audioLevelSources,
+      threshold: CallReportCollector.THRESHOLD_LOCAL_AUDIO_LEVEL,
+      silenceDurationMs,
+    });
   }
 
   private _resetLowLocalAudioWarning(): void {
@@ -1112,7 +1177,11 @@ export class CallReportCollector {
    * condition persists — so consumers know the issue is ongoing.
    * Resets when the condition clears.
    */
-  private _trackBreach(code: SdkWarningCode, isBreach: boolean): void {
+  private _trackBreach(
+    code: SdkWarningCode,
+    isBreach: boolean,
+    options?: WarningEmitOptions
+  ): void {
     if (isBreach) {
       this._breachCounters[code] = (this._breachCounters[code] ?? 0) + 1;
       if (
@@ -1124,7 +1193,7 @@ export class CallReportCollector {
         const lastEmitted = this._lastWarningEmitted[code] ?? 0;
         if (now - lastEmitted >= CallReportCollector.WARNING_THROTTLE_MS) {
           this._lastWarningEmitted[code] = now;
-          this._emitWarning(code);
+          this._emitWarning(code, options);
         }
       }
     } else {
@@ -1135,19 +1204,25 @@ export class CallReportCollector {
     }
   }
 
-  private _emitWarningOncePerEpisode(code: SdkWarningCode): void {
+  private _emitWarningOncePerEpisode(
+    code: SdkWarningCode,
+    options?: WarningEmitOptions
+  ): void {
     if (this._activeWarnings.has(code)) return;
 
     this._activeWarnings.add(code);
     this._lastWarningEmitted[code] = Date.now();
-    this._emitWarning(code);
+    this._emitWarning(code, options);
   }
 
-  private _emitWarning(code: SdkWarningCode): void {
+  private _emitWarning(
+    code: SdkWarningCode,
+    options?: WarningEmitOptions
+  ): void {
     try {
-      const warning = createTelnyxWarning(code);
+      const warning = createTelnyxWarning(code, options);
       logger.warn(
-        `CallReportCollector: warning ${warning.code}: ${warning.message}`
+        `CallReportCollector: warning ${warning.code}${warning.subtype ? `/${warning.subtype}` : ''}: ${warning.message}`
       );
       this.onWarning?.(warning);
     } catch (err) {
@@ -1185,6 +1260,10 @@ export class CallReportCollector {
         packetsSent: outboundAudio.packetsSent,
         bytesSent: outboundAudio.bytesSent,
         audioLevelAvg: this._average(this.intervalAudioLevels.outbound),
+        audioLevelSource: this.intervalAudioLevelSources.outbound[0],
+        audioLevelSources: this._unique(
+          this.intervalAudioLevelSources.outbound
+        ),
         bitrateAvg: this._average(this.intervalBitrates.outbound),
         ...(localAudioTrack ? { localTrack: localAudioTrack } : {}),
         ...(localAudioSource ? { mediaSource: localAudioSource } : {}),
@@ -1484,27 +1563,69 @@ export class CallReportCollector {
     stats: RTCStatsReport,
     outboundAudio: ExtendedOutboundRtpStreamStats
   ): number | null {
+    return (
+      this._getOutboundAudioLevelSample(stats, outboundAudio)?.level ?? null
+    );
+  }
+
+  private _getOutboundAudioLevelSample(
+    stats: RTCStatsReport,
+    outboundAudio: ExtendedOutboundRtpStreamStats
+  ): AudioLevelSample | null {
     const mediaSource = this._getOutboundMediaSource(stats, outboundAudio);
+    const availableSources: AudioLevelSource[] = [];
+    let energyLevel: number | null = null;
 
-    // Try direct audioLevel on media-source
-    if (mediaSource?.audioLevel !== undefined) {
-      return mediaSource.audioLevel;
-    }
-
-    // 3. Compute RMS audio level from totalAudioEnergy deltas on media-source
+    // Compute energy deltas whenever available so we both expose the source
+    // and keep previous energy counters warm if direct audioLevel disappears.
     if (mediaSource) {
-      const level = this._computeAudioLevelFromEnergy(
+      energyLevel = this._computeAudioLevelFromEnergy(
         mediaSource.totalAudioEnergy,
         mediaSource.totalSamplesDuration,
         'outbound'
       );
-      if (level !== null) {
-        return level;
+      if (energyLevel !== null) {
+        availableSources.push('media-source.energy');
       }
     }
 
+    const trackAudioLevel = this._getTrackAudioLevel(
+      stats,
+      outboundAudio.trackId
+    );
+    if (trackAudioLevel !== null) {
+      availableSources.push('track.audioLevel');
+    }
+
+    // Try direct audioLevel on media-source
+    if (mediaSource?.audioLevel !== undefined) {
+      availableSources.unshift('media-source.audioLevel');
+      return {
+        level: mediaSource.audioLevel,
+        source: 'media-source.audioLevel',
+        availableSources,
+      };
+    }
+
+    // 3. Compute RMS audio level from totalAudioEnergy deltas on media-source
+    if (energyLevel !== null) {
+      return {
+        level: energyLevel,
+        source: 'media-source.energy',
+        availableSources,
+      };
+    }
+
     // 4. Deprecated track stat fallback (legacy browsers only)
-    return this._getTrackAudioLevel(stats, outboundAudio.trackId);
+    if (trackAudioLevel !== null) {
+      return {
+        level: trackAudioLevel,
+        source: 'track.audioLevel',
+        availableSources,
+      };
+    }
+
+    return null;
   }
 
   /**
@@ -1623,11 +1744,18 @@ export class CallReportCollector {
     return parseFloat((sum / values.length).toFixed(4));
   }
 
+  private _unique<T extends string>(values: T[]): T[] | undefined {
+    if (values.length === 0) return undefined;
+
+    return values.filter((value, index) => values.indexOf(value) === index);
+  }
+
   /**
    * Reset interval accumulators for next collection period
    */
   private _resetIntervalAccumulators(): void {
     this.intervalAudioLevels = { outbound: [], inbound: [] };
+    this.intervalAudioLevelSources = { outbound: [] };
     this.intervalJitters = [];
     this.intervalRTTs = [];
     this.intervalBitrates = { outbound: [], inbound: [] };


### PR DESCRIPTION
## Summary
- add optional `warning.subtype` and `warning.details` fields for richer SDK warning context
- split `LOW_LOCAL_AUDIO` into `initial_silence` vs `sustained_silence` warning subtypes
- include outbound audio level source diagnostics in call report stats and warning details
- document the warning payload changes, low-local-audio subtypes, and stats source semantics in markdown docs/changelog

## Validation
- ✅ `yarn --cwd packages/js test CallReportCollector.test.ts --runInBand`
- ✅ `yarn --cwd packages/js build`
- ✅ `yarn --cwd packages/js eslint src/Modules/Verto/webrtc/CallReportCollector.ts src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts src/Modules/Verto/util/constants/warnings.ts src/Modules/Verto/util/errors.ts`
- ✅ `yarn --cwd packages/js eslint docs/error-handling.md docs/sw-events.md CHANGELOG.md`
- ⚠️ `yarn --cwd packages/js lint` still fails on existing unrelated repo-wide lint debt in tests/util files
