### PR TITLE
fix: flush call reports on socket close

### DIFF
--- a/packages/js/src/Modules/Verto/BaseSession.ts
+++ b/packages/js/src/Modules/Verto/BaseSession.ts
@@ -16,6 +16,7 @@ import {
   INVALID_CREDENTIALS,
   TOKEN_EXPIRING_SOON,
   RECONNECTION_EXHAUSTED,
+  WS_CLOSE_CODES,
 } from './util/constants';
 import { createTelnyxError, createTelnyxWarning } from './util/errors';
 import type { ITelnyxErrorEvent } from './util/errors';
@@ -37,6 +38,7 @@ import { Ping } from './messages/verto/Ping';
 import { Login } from './messages/Verto';
 import { AnonymousLogin } from './messages/verto/AnonymousLogin';
 import { ERROR_TYPE } from './webrtc/constants';
+import type { ICallReportFlushReason } from './webrtc/CallReportCollector';
 import type { ITelnyxWarningEvent } from './util/constants/warnings';
 
 /**
@@ -607,12 +609,86 @@ export default abstract class BaseSession {
    */
   protected async _onSocketOpen() {}
 
+  private _flushIntermediateCallReports(
+    flushReason: ICallReportFlushReason
+  ): void {
+    const calls = (this as unknown as {
+      calls?: Record<
+        string,
+        {
+          id?: string;
+          flushIntermediateCallReport?: (
+            flushReason?: ICallReportFlushReason
+          ) => void;
+        }
+      >;
+    }).calls;
+
+    if (!calls) return;
+
+    Object.values(calls).forEach((call) => {
+      if (!call?.flushIntermediateCallReport) return;
+
+      try {
+        call.flushIntermediateCallReport(flushReason);
+      } catch (error) {
+        logger.error('Failed to flush intermediate call report', {
+          callId: call.id,
+          flushReason,
+          error,
+        });
+      }
+    });
+  }
+
   /**
    * Callback when the ws connection is going to close or get an error
    * @return void
    * @private
    */
-  public onNetworkClose(): void {
+  private _getSocketCloseCodeName(code?: number): string | undefined {
+    if (code === undefined) return undefined;
+
+    const match = Object.entries(WS_CLOSE_CODES).find(
+      ([, value]) => value === code
+    );
+    return match?.[0];
+  }
+
+  private _getSocketCloseError(error?: unknown): string | undefined {
+    if (!error) return undefined;
+    if (error instanceof Error) return error.message;
+    return String(error);
+  }
+
+  private _createSocketCloseFlushReason(event?: {
+    code?: number;
+    reason?: string;
+    wasClean?: boolean;
+    error?: unknown;
+  }): ICallReportFlushReason {
+    return {
+      type: event?.error ? 'socket-error' : 'socket-close',
+      socketClose: {
+        code: event?.code,
+        codeName: this._getSocketCloseCodeName(event?.code),
+        reason: event?.reason,
+        wasClean: event?.wasClean,
+        error: this._getSocketCloseError(event?.error),
+      },
+    };
+  }
+
+  public onNetworkClose(event?: {
+    code?: number;
+    reason?: string;
+    wasClean?: boolean;
+    error?: unknown;
+  }): void {
+    this._flushIntermediateCallReports(
+      this._createSocketCloseFlushReason(event)
+    );
+
     if (this.relayProtocol) {
       deRegisterAll(this.relayProtocol);
     }

--- a/packages/js/src/Modules/Verto/tests/behaveLike/BaseSession.spec.ts
+++ b/packages/js/src/Modules/Verto/tests/behaveLike/BaseSession.spec.ts
@@ -81,6 +81,75 @@ export default (instance: any) => {
       describe('unsubscribe', () => {});
       describe('broadcast', () => {});
 
+      describe('.onNetworkClose()', () => {
+        it('flushes active call reports as intermediate reports on socket close', () => {
+          const flushIntermediateCallReport = jest.fn();
+          instance._autoReconnect = false;
+          instance.calls = {
+            'call-id': { id: 'call-id', flushIntermediateCallReport },
+          };
+
+          instance.onNetworkClose({
+            code: 1000,
+            reason: 'normal',
+            wasClean: true,
+          });
+
+          expect(flushIntermediateCallReport).toHaveBeenCalledWith({
+            type: 'socket-close',
+            socketClose: {
+              code: 1000,
+              codeName: 'NORMAL_CLOSURE',
+              reason: 'normal',
+              wasClean: true,
+              error: undefined,
+            },
+          });
+        });
+
+        it('flushes active call reports as intermediate reports on socket errors', () => {
+          const flushIntermediateCallReport = jest.fn();
+          instance._autoReconnect = false;
+          instance.calls = {
+            'call-id': { id: 'call-id', flushIntermediateCallReport },
+          };
+
+          instance.onNetworkClose({ error: new Error('socket error') });
+
+          expect(flushIntermediateCallReport).toHaveBeenCalledWith({
+            type: 'socket-error',
+            socketClose: {
+              code: undefined,
+              codeName: undefined,
+              reason: undefined,
+              wasClean: undefined,
+              error: 'socket error',
+            },
+          });
+        });
+
+        it('marks abnormal socket closes when flushing intermediate call reports', () => {
+          const flushIntermediateCallReport = jest.fn();
+          instance._autoReconnect = false;
+          instance.calls = {
+            'call-id': { id: 'call-id', flushIntermediateCallReport },
+          };
+
+          instance.onNetworkClose({ code: 1006 });
+
+          expect(flushIntermediateCallReport).toHaveBeenCalledWith({
+            type: 'socket-close',
+            socketClose: {
+              code: 1006,
+              codeName: 'ABNORMAL_CLOSURE',
+              reason: undefined,
+              wasClean: undefined,
+              error: undefined,
+            },
+          });
+        });
+      });
+
       describe('.disconnect()', () => {
         it('should close the connection', async (done) => {
           await instance.disconnect();

--- a/packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts
@@ -3,6 +3,7 @@ import { LOW_LOCAL_AUDIO } from '../../util/constants/errorCodes';
 import type { ITelnyxWarning } from '../../util/constants/warnings';
 import {
   CallReportCollector,
+  type ICallReportPayload,
   type ILocalAudioSourceStats,
   type ILocalAudioTrackSnapshot,
   type IStatsInterval,
@@ -19,6 +20,10 @@ type TestableCallReportCollector = {
     }>;
   } | null;
   cleanup: () => void;
+  flush: (
+    summary: { callId: string },
+    flushReason?: ICallReportPayload['flushReason']
+  ) => ICallReportPayload | null;
   onWarning: ((warning: ITelnyxWarning) => void) | null;
   _withoutUndefined: <T extends Record<string, unknown>>(obj: T) => T;
   _checkQualityWarnings: (
@@ -60,6 +65,45 @@ const createStatsEntry = (audioLevelAvg: number): IStatsInterval => ({
       },
     },
   },
+});
+
+describe('CallReportCollector intermediate reports', () => {
+  it('includes flush reason metadata in intermediate report payloads', () => {
+    const collector = createCollector();
+    const statsEntry = createStatsEntry(0.5);
+    (collector as unknown as { statsBuffer: IStatsInterval[] }).statsBuffer = [
+      statsEntry,
+    ];
+
+    const payload = collector.flush(
+      { callId: 'call-id' },
+      {
+        type: 'socket-close',
+        socketClose: {
+          code: 1006,
+          codeName: 'ABNORMAL_CLOSURE',
+          reason: 'network changed',
+          wasClean: false,
+        },
+      }
+    );
+
+    expect(payload).toEqual(
+      expect.objectContaining({
+        segment: 0,
+        stats: [statsEntry],
+        flushReason: {
+          type: 'socket-close',
+          socketClose: {
+            code: 1006,
+            codeName: 'ABNORMAL_CLOSURE',
+            reason: 'network changed',
+            wasClean: false,
+          },
+        },
+      })
+    );
+  });
 });
 
 describe('CallReportCollector local audio diagnostics', () => {

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -4,7 +4,10 @@ import pkg from '../../../../package.json';
 import BrowserSession from '../BrowserSession';
 import BaseMessage from '../messages/BaseMessage';
 
-import { CallReportCollector } from './CallReportCollector';
+import {
+  CallReportCollector,
+  type ICallReportFlushReason,
+} from './CallReportCollector';
 import {
   Answer,
   Attach,
@@ -2283,10 +2286,18 @@ export default abstract class BaseCall implements IWebRTCCall {
 
   /**
    * Flush an intermediate call report segment mid-call.
-   * Called by the CallReportCollector when the estimated payload size
-   * approaches the server's 2 MB limit.
+   * Used for size-limit and socket-close safety flushes without falsely
+   * finalizing the call.
    */
-  private _flushIntermediateReport() {
+  public flushIntermediateCallReport(
+    flushReason: ICallReportFlushReason = { type: 'manual' }
+  ) {
+    this._flushIntermediateReport(flushReason);
+  }
+
+  private _flushIntermediateReport(
+    flushReason: ICallReportFlushReason = { type: 'buffer-limit' }
+  ) {
     if (!this._callReportCollector) return;
 
     const callReportId = this.session.callReportId;
@@ -2318,8 +2329,14 @@ export default abstract class BaseCall implements IWebRTCCall {
       sdkVersion: SDK_VERSION,
     };
 
-    const payload = this._callReportCollector.flush(summary);
+    const payload = this._callReportCollector.flush(summary, flushReason);
     if (!payload) return;
+
+    logger.info('Flushing intermediate call report', {
+      callId: this.id,
+      flushReason,
+      segment: payload.segment,
+    });
 
     const voiceSdkId = getReconnectToken() || undefined;
 

--- a/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
+++ b/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
@@ -242,12 +242,25 @@ export interface ICallSummary {
   endTimestamp?: string;
 }
 
+export interface ICallReportFlushReason {
+  type: 'buffer-limit' | 'manual' | 'socket-close' | 'socket-error';
+  socketClose?: {
+    code?: number;
+    codeName?: string;
+    reason?: string;
+    wasClean?: boolean;
+    error?: string;
+  };
+}
+
 export interface ICallReportPayload {
   summary: ICallSummary;
   stats: IStatsInterval[];
   logs?: ILogEntry[];
   /** Segment index for multi-part reports (0-based). Present when a report was flushed early. */
   segment?: number;
+  /** Why this intermediate segment was flushed. */
+  flushReason?: ICallReportFlushReason;
 }
 
 export class CallReportCollector {
@@ -441,7 +454,10 @@ export class CallReportCollector {
    *
    * The caller is responsible for posting the returned payload.
    */
-  public flush(summary: ICallSummary): ICallReportPayload | null {
+  public flush(
+    summary: ICallSummary,
+    flushReason?: ICallReportFlushReason
+  ): ICallReportPayload | null {
     if (this._flushing || this.statsBuffer.length === 0) {
       return null;
     }
@@ -467,6 +483,7 @@ export class CallReportCollector {
         stats,
         ...(logs.length > 0 ? { logs } : {}),
         segment,
+        ...(flushReason ? { flushReason } : {}),
       };
 
       logger.info('CallReportCollector: Flushed intermediate segment', {
@@ -474,6 +491,7 @@ export class CallReportCollector {
         intervals: stats.length,
         logEntries: logs.length,
         callId: summary.callId,
+        flushReason,
       });
 
       return payload;

--- a/packages/js/src/Modules/Verto/webrtc/interfaces.ts
+++ b/packages/js/src/Modules/Verto/webrtc/interfaces.ts
@@ -1,3 +1,4 @@
+import type { ICallReportFlushReason } from './CallReportCollector';
 import { State } from './constants';
 
 export interface IMediaSettings {
@@ -161,6 +162,7 @@ export interface IWebRTCCall {
   invite: () => void;
   answer: (params: AnswerParams) => void;
   hangup: (params?: IHangupParams, execute?: boolean) => Promise<void>;
+  flushIntermediateCallReport?: (reason?: ICallReportFlushReason) => void;
 
   hold: () => void;
   unhold: () => void;


### PR DESCRIPTION
## Summary
- Flush active calls as intermediate call-report segments when the socket closes.
- Use `WS_CLOSE_CODES` instead of magic numbers and include identifiable socket close metadata in the report payload.
- Persist `flushReason` with `type`, `socketClose.code`, `socketClose.codeName`, `reason`, `wasClean`, and `error` when available.
- Expose a call-level intermediate flush hook without finalizing the call.

## Verification
- `yarn test packages/js/src/Modules/Verto/tests/behaveLike/BaseSession.spec.ts packages/js/src/Modules/Verto/tests/webrtc/Call.test.ts packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts --runInBand`
- `yarn workspace @telnyx/webrtc build`
