### PR TITLE
feat(webrtc): add opt-in outbound audio startup warmup

### DIFF
--- a/packages/js/src/Modules/Verto/tests/webrtc/AudioWarmup.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/AudioWarmup.test.ts
@@ -1,0 +1,361 @@
+import {
+  normalizeAudioWarmupOptions,
+  createAudioWarmupStream,
+} from '../../webrtc/AudioWarmup';
+
+// Mock AudioContext and Web Audio API
+const mockGainNode = {
+  gain: {
+    setValueAtTime: jest.fn(),
+    linearRampToValueAtTime: jest.fn(),
+  },
+  connect: jest.fn(),
+  disconnect: jest.fn(),
+};
+
+const mockDestination = {
+  stream: {
+    getAudioTracks: jest.fn(() => [{ kind: 'audio', label: 'destination-audio' }]),
+  },
+};
+
+const mockSource = {
+  connect: jest.fn(),
+  disconnect: jest.fn(),
+};
+
+const mockAudioContext = {
+  currentTime: 0,
+  createMediaStreamSource: jest.fn(() => mockSource),
+  createGain: jest.fn(() => mockGainNode),
+  createMediaStreamDestination: jest.fn(() => mockDestination),
+  close: jest.fn(() => Promise.resolve()),
+  state: 'running',
+};
+
+// Mock the global AudioContext constructor
+let AudioContextMock: jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.useFakeTimers();
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  AudioContextMock = jest.fn(() => mockAudioContext) as any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (global as any).AudioContext = AudioContextMock;
+
+  // Reset mock state
+  mockAudioContext.currentTime = 0;
+  mockAudioContext.state = 'running';
+  mockGainNode.gain.setValueAtTime.mockReset();
+  mockGainNode.gain.linearRampToValueAtTime.mockReset();
+  mockGainNode.connect.mockReset();
+  mockGainNode.disconnect.mockReset();
+  mockSource.connect.mockReset();
+  mockSource.disconnect.mockReset();
+  mockAudioContext.close.mockReset().mockReturnValue(Promise.resolve());
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+// Helper to create a mock MediaStream with audio (and optionally video) tracks
+function createMockStream(
+  hasAudio = true,
+  hasVideo = false
+): MediaStream {
+  const tracks: MediaStreamTrack[] = [];
+  if (hasAudio) {
+    tracks.push({
+      kind: 'audio',
+      label: 'mock-microphone',
+      enabled: true,
+      getConstraints: jest.fn(() => ({})),
+    } as unknown as MediaStreamTrack);
+  }
+  if (hasVideo) {
+    tracks.push({
+      kind: 'video',
+      label: 'mock-camera',
+      enabled: true,
+      getConstraints: jest.fn(() => ({})),
+    } as unknown as MediaStreamTrack);
+  }
+  return {
+    getAudioTracks: () => tracks.filter((t) => t.kind === 'audio'),
+    getVideoTracks: () => tracks.filter((t) => t.kind === 'video'),
+    getTracks: () => tracks,
+    addTrack: jest.fn(),
+  } as unknown as MediaStream;
+}
+
+// ============================================================
+// normalizeAudioWarmupOptions
+// ============================================================
+
+describe('normalizeAudioWarmupOptions', () => {
+  it('returns null for undefined', () => {
+    expect(normalizeAudioWarmupOptions(undefined)).toBeNull();
+  });
+
+  it('returns null for false', () => {
+    expect(normalizeAudioWarmupOptions(false)).toBeNull();
+  });
+
+  it('returns defaults for true', () => {
+    const result = normalizeAudioWarmupOptions(true);
+    expect(result).toEqual({ enabled: true, durationMs: 750, fadeInMs: 100 });
+  });
+
+  it('returns null for object with enabled: false', () => {
+    expect(normalizeAudioWarmupOptions({ enabled: false })).toBeNull();
+  });
+
+  it('returns defaults for object with enabled: true', () => {
+    const result = normalizeAudioWarmupOptions({ enabled: true });
+    expect(result).toEqual({ enabled: true, durationMs: 750, fadeInMs: 100 });
+  });
+
+  it('returns defaults for empty object (enabled defaults to true)', () => {
+    const result = normalizeAudioWarmupOptions({});
+    expect(result).toEqual({ enabled: true, durationMs: 750, fadeInMs: 100 });
+  });
+
+  it('applies custom durations', () => {
+    const result = normalizeAudioWarmupOptions({
+      durationMs: 500,
+      fadeInMs: 50,
+    });
+    expect(result).toEqual({ enabled: true, durationMs: 500, fadeInMs: 50 });
+  });
+
+  it('clamps durationMs to max 3000', () => {
+    const result = normalizeAudioWarmupOptions({ durationMs: 5000 });
+    expect(result?.durationMs).toBe(3000);
+  });
+
+  it('clamps durationMs to min 0', () => {
+    const result = normalizeAudioWarmupOptions({ durationMs: -100 });
+    expect(result?.durationMs).toBe(0);
+  });
+
+  it('clamps fadeInMs to max 1000', () => {
+    const result = normalizeAudioWarmupOptions({ fadeInMs: 2000 });
+    expect(result?.fadeInMs).toBe(1000);
+  });
+
+  it('clamps fadeInMs to min 0', () => {
+    const result = normalizeAudioWarmupOptions({ fadeInMs: -50 });
+    expect(result?.fadeInMs).toBe(0);
+  });
+
+  it('uses default durations when only enabled is set', () => {
+    const result = normalizeAudioWarmupOptions({ enabled: true, durationMs: 1000 });
+    expect(result).toEqual({ enabled: true, durationMs: 1000, fadeInMs: 100 });
+  });
+});
+
+// ============================================================
+// createAudioWarmupStream
+// ============================================================
+
+describe('createAudioWarmupStream', () => {
+  it('returns null when option is undefined (disabled)', () => {
+    const stream = createMockStream();
+    expect(createAudioWarmupStream(stream, undefined)).toBeNull();
+  });
+
+  it('returns null when option is false', () => {
+    const stream = createMockStream();
+    expect(createAudioWarmupStream(stream, false)).toBeNull();
+  });
+
+  it('returns null when stream has no audio tracks', () => {
+    const stream = createMockStream(false);
+    expect(createAudioWarmupStream(stream, true)).toBeNull();
+  });
+
+  it('returns null when option has enabled: false', () => {
+    const stream = createMockStream();
+    expect(createAudioWarmupStream(stream, { enabled: false })).toBeNull();
+  });
+
+  it('creates a warm-up controller with boolean true', () => {
+    const stream = createMockStream();
+    const controller = createAudioWarmupStream(stream, true);
+    expect(controller).not.toBeNull();
+    expect(controller!.active).toBe(true);
+    expect(controller!.stream).toBeDefined();
+  });
+
+  it('creates a warm-up controller with object options', () => {
+    const stream = createMockStream();
+    const controller = createAudioWarmupStream(stream, {
+      enabled: true,
+      durationMs: 500,
+      fadeInMs: 50,
+    });
+    expect(controller).not.toBeNull();
+    expect(controller!.active).toBe(true);
+  });
+
+  it('creates AudioContext and connects WebAudio nodes', () => {
+    const stream = createMockStream();
+    createAudioWarmupStream(stream, true);
+
+    expect(AudioContextMock).toHaveBeenCalled();
+    expect(mockAudioContext.createMediaStreamSource).toHaveBeenCalledWith(stream);
+    expect(mockAudioContext.createGain).toHaveBeenCalled();
+    expect(mockAudioContext.createMediaStreamDestination).toHaveBeenCalled();
+    expect(mockSource.connect).toHaveBeenCalledWith(mockGainNode);
+    expect(mockGainNode.connect).toHaveBeenCalledWith(mockDestination);
+  });
+
+  it('sets initial gain to 0', () => {
+    const stream = createMockStream();
+    createAudioWarmupStream(stream, true);
+
+    expect(mockGainNode.gain.setValueAtTime).toHaveBeenCalledWith(0, expect.any(Number));
+  });
+
+  it('returns a stream with destination audio track', () => {
+    const stream = createMockStream();
+    const controller = createAudioWarmupStream(stream, true);
+
+    const audioTracks = controller!.stream.getAudioTracks();
+    expect(audioTracks.length).toBe(1);
+    expect(audioTracks[0].label).toBe('destination-audio');
+  });
+
+  it('includes video tracks in sender stream', () => {
+    const stream = createMockStream(true, true);
+    const controller = createAudioWarmupStream(stream, true);
+
+    const videoTracks = controller!.stream.getVideoTracks();
+    expect(videoTracks.length).toBe(1);
+  });
+
+  it('preserves microphoneLabel in userVariables from original track', () => {
+    const stream = createMockStream();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const userVariables: Record<string, any> = {};
+    createAudioWarmupStream(stream, true, userVariables);
+
+    expect(userVariables.microphoneLabel).toBe('mock-microphone');
+  });
+
+  it('release() ramps gain from 0 to 1', () => {
+    const stream = createMockStream();
+    const controller = createAudioWarmupStream(stream, {
+      enabled: true,
+      fadeInMs: 100,
+    });
+
+    // Clear the initial setValueAtTime call
+    mockGainNode.gain.setValueAtTime.mockClear();
+    mockGainNode.gain.linearRampToValueAtTime.mockClear();
+
+    controller!.release();
+
+    expect(mockGainNode.gain.setValueAtTime).toHaveBeenCalledWith(0, expect.any(Number));
+    expect(mockGainNode.gain.linearRampToValueAtTime).toHaveBeenCalledWith(1, expect.any(Number));
+  });
+
+  it('release() is idempotent', () => {
+    const stream = createMockStream();
+    const controller = createAudioWarmupStream(stream, true);
+
+    controller!.release();
+    mockGainNode.gain.setValueAtTime.mockClear();
+    mockGainNode.gain.linearRampToValueAtTime.mockClear();
+
+    // Second call should be a no-op
+    controller!.release();
+    expect(mockGainNode.gain.setValueAtTime).not.toHaveBeenCalled();
+  });
+
+  it('cleanup() disconnects nodes and closes AudioContext', () => {
+    const stream = createMockStream();
+    const controller = createAudioWarmupStream(stream, true);
+
+    controller!.cleanup();
+
+    expect(mockSource.disconnect).toHaveBeenCalled();
+    expect(mockGainNode.disconnect).toHaveBeenCalled();
+    expect(mockAudioContext.close).toHaveBeenCalled();
+    expect(controller!.active).toBe(false);
+  });
+
+  it('cleanup() is idempotent', () => {
+    const stream = createMockStream();
+    const controller = createAudioWarmupStream(stream, true);
+
+    controller!.cleanup();
+    mockSource.disconnect.mockClear();
+    mockGainNode.disconnect.mockClear();
+    mockAudioContext.close.mockClear();
+
+    controller!.cleanup();
+    expect(mockSource.disconnect).not.toHaveBeenCalled();
+  });
+
+  it('safety timeout triggers release if not already released', () => {
+    const stream = createMockStream();
+    const controller = createAudioWarmupStream(stream, {
+      enabled: true,
+      durationMs: 750,
+    });
+
+    // Advance time past duration + safety margin (750 + 2000 = 2750ms)
+    jest.advanceTimersByTime(2800);
+
+    // Should have triggered release via safety timeout
+    expect(mockGainNode.gain.linearRampToValueAtTime).toHaveBeenCalledWith(1, expect.any(Number));
+
+    // Advance past the fade-in + 50ms delay after release
+    jest.advanceTimersByTime(200);
+    expect(controller!.active).toBe(false);
+  });
+
+  it('safety timeout is cleared when release() is called explicitly', () => {
+    const stream = createMockStream();
+    const controller = createAudioWarmupStream(stream, {
+      enabled: true,
+      durationMs: 750,
+    });
+
+    // Release before safety timeout
+    controller!.release();
+    mockGainNode.gain.setValueAtTime.mockClear();
+    mockGainNode.gain.linearRampToValueAtTime.mockClear();
+
+    // Advance past safety timeout
+    jest.advanceTimersByTime(3000);
+
+    // No extra ramp calls from safety timeout
+    expect(mockGainNode.gain.setValueAtTime).not.toHaveBeenCalled();
+  });
+
+  it('returns null when AudioContext constructor throws', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (global as any).AudioContext = jest.fn(() => {
+      throw new Error('AudioContext not available');
+    });
+
+    const stream = createMockStream();
+    const result = createAudioWarmupStream(stream, true);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when WebAudio setup throws (createGain)', () => {
+    mockAudioContext.createGain = jest.fn(() => {
+      throw new Error('createGain failed');
+    });
+
+    const stream = createMockStream();
+    const result = createAudioWarmupStream(stream, true);
+    expect(result).toBeNull();
+  });
+});

--- a/packages/js/src/Modules/Verto/tests/webrtc/AudioWarmup.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/AudioWarmup.test.ts
@@ -251,6 +251,27 @@ describe('createAudioWarmupStream', () => {
     expect(userVariables.microphoneLabel).toBe('mock-microphone');
   });
 
+  it('senderStream destination track label differs from original mic label', () => {
+    // Documents that Peer.ts must guard against overwriting microphoneLabel
+    // with the destination track label when iterating senderStream tracks.
+    const stream = createMockStream();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const userVariables: Record<string, any> = {};
+    const controller = createAudioWarmupStream(stream, true, userVariables);
+
+    // userVariables has the original mic label
+    expect(userVariables.microphoneLabel).toBe('mock-microphone');
+
+    // But the senderStream audio track has the destination's label
+    const senderAudioTrack = controller!.stream.getAudioTracks()[0];
+    expect(senderAudioTrack.label).toBe('destination-audio');
+    expect(senderAudioTrack.label).not.toBe('mock-microphone');
+
+    // If Peer.ts naively did `userVariables.microphoneLabel = track.label`
+    // on the senderStream audio track, it would overwrite the real label.
+    // Peer.ts must skip this assignment when warm-up is active.
+  });
+
   // ============================================================
   // scheduleRelease() — delayed release after durationMs
   // ============================================================

--- a/packages/js/src/Modules/Verto/tests/webrtc/AudioWarmup.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/AudioWarmup.test.ts
@@ -39,6 +39,7 @@ let AudioContextMock: jest.Mock;
 beforeEach(() => {
   jest.clearAllMocks();
   jest.useFakeTimers();
+  jest.clearAllTimers();
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   AudioContextMock = jest.fn(() => mockAudioContext) as any;
@@ -55,6 +56,10 @@ beforeEach(() => {
   mockSource.connect.mockReset();
   mockSource.disconnect.mockReset();
   mockAudioContext.close.mockReset().mockReturnValue(Promise.resolve());
+  // Restore createGain in case a previous test overwrote it
+  mockAudioContext.createGain = jest.fn(() => mockGainNode);
+  mockAudioContext.createMediaStreamSource.mockReset().mockReturnValue(mockSource);
+  mockAudioContext.createMediaStreamDestination.mockReset().mockReturnValue(mockDestination);
 });
 
 afterEach(() => {
@@ -240,122 +245,294 @@ describe('createAudioWarmupStream', () => {
   it('preserves microphoneLabel in userVariables from original track', () => {
     const stream = createMockStream();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const userVariables: Record<string, any> = {};
+    const userVariables: Record<string, any> = {};
     createAudioWarmupStream(stream, true, userVariables);
 
     expect(userVariables.microphoneLabel).toBe('mock-microphone');
   });
 
-  it('release() ramps gain from 0 to 1', () => {
-    const stream = createMockStream();
-    const controller = createAudioWarmupStream(stream, {
-      enabled: true,
-      fadeInMs: 100,
+  // ============================================================
+  // scheduleRelease() — delayed release after durationMs
+  // ============================================================
+
+  describe('scheduleRelease', () => {
+    it('gain is still 0 immediately after scheduleRelease (before durationMs)', () => {
+      const stream = createMockStream();
+      const controller = createAudioWarmupStream(stream, {
+        enabled: true,
+        durationMs: 750,
+        fadeInMs: 100,
+      });
+
+      // Clear initial gain setup calls
+      mockGainNode.gain.setValueAtTime.mockClear();
+      mockGainNode.gain.linearRampToValueAtTime.mockClear();
+
+      controller!.scheduleRelease();
+
+      // Immediately after scheduleRelease, no ramp should be scheduled yet
+      expect(mockGainNode.gain.setValueAtTime).not.toHaveBeenCalled();
+      expect(mockGainNode.gain.linearRampToValueAtTime).not.toHaveBeenCalled();
+      expect(controller!.active).toBe(true);
     });
 
-    // Clear the initial setValueAtTime call
-    mockGainNode.gain.setValueAtTime.mockClear();
-    mockGainNode.gain.linearRampToValueAtTime.mockClear();
+    it('ramps gain 0→1 after durationMs elapses', () => {
+      const stream = createMockStream();
+      const controller = createAudioWarmupStream(stream, {
+        enabled: true,
+        durationMs: 750,
+        fadeInMs: 100,
+      });
 
-    controller!.release();
+      controller!.scheduleRelease();
+      mockGainNode.gain.setValueAtTime.mockClear();
+      mockGainNode.gain.linearRampToValueAtTime.mockClear();
 
-    expect(mockGainNode.gain.setValueAtTime).toHaveBeenCalledWith(0, expect.any(Number));
-    expect(mockGainNode.gain.linearRampToValueAtTime).toHaveBeenCalledWith(1, expect.any(Number));
-  });
+      // Advance past durationMs
+      jest.advanceTimersByTime(750);
 
-  it('release() is idempotent', () => {
-    const stream = createMockStream();
-    const controller = createAudioWarmupStream(stream, true);
-
-    controller!.release();
-    mockGainNode.gain.setValueAtTime.mockClear();
-    mockGainNode.gain.linearRampToValueAtTime.mockClear();
-
-    // Second call should be a no-op
-    controller!.release();
-    expect(mockGainNode.gain.setValueAtTime).not.toHaveBeenCalled();
-  });
-
-  it('cleanup() disconnects nodes and closes AudioContext', () => {
-    const stream = createMockStream();
-    const controller = createAudioWarmupStream(stream, true);
-
-    controller!.cleanup();
-
-    expect(mockSource.disconnect).toHaveBeenCalled();
-    expect(mockGainNode.disconnect).toHaveBeenCalled();
-    expect(mockAudioContext.close).toHaveBeenCalled();
-    expect(controller!.active).toBe(false);
-  });
-
-  it('cleanup() is idempotent', () => {
-    const stream = createMockStream();
-    const controller = createAudioWarmupStream(stream, true);
-
-    controller!.cleanup();
-    mockSource.disconnect.mockClear();
-    mockGainNode.disconnect.mockClear();
-    mockAudioContext.close.mockClear();
-
-    controller!.cleanup();
-    expect(mockSource.disconnect).not.toHaveBeenCalled();
-  });
-
-  it('safety timeout triggers release if not already released', () => {
-    const stream = createMockStream();
-    const controller = createAudioWarmupStream(stream, {
-      enabled: true,
-      durationMs: 750,
+      // Now the ramp should be scheduled
+      expect(mockGainNode.gain.setValueAtTime).toHaveBeenCalledWith(0, expect.any(Number));
+      expect(mockGainNode.gain.linearRampToValueAtTime).toHaveBeenCalledWith(1, expect.any(Number));
     });
 
-    // Advance time past duration + safety margin (750 + 2000 = 2750ms)
-    jest.advanceTimersByTime(2800);
+    it('does not schedule double release on duplicate scheduleRelease calls', () => {
+      const stream = createMockStream();
+      const controller = createAudioWarmupStream(stream, {
+        enabled: true,
+        durationMs: 750,
+        fadeInMs: 100,
+      });
 
-    // Should have triggered release via safety timeout
-    expect(mockGainNode.gain.linearRampToValueAtTime).toHaveBeenCalledWith(1, expect.any(Number));
+      // Call scheduleRelease multiple times
+      controller!.scheduleRelease();
+      controller!.scheduleRelease();
+      controller!.scheduleRelease();
 
-    // Advance past the fade-in + 50ms delay after release
-    jest.advanceTimersByTime(200);
-    expect(controller!.active).toBe(false);
-  });
+      mockGainNode.gain.setValueAtTime.mockClear();
+      mockGainNode.gain.linearRampToValueAtTime.mockClear();
 
-  it('safety timeout is cleared when release() is called explicitly', () => {
-    const stream = createMockStream();
-    const controller = createAudioWarmupStream(stream, {
-      enabled: true,
-      durationMs: 750,
+      // Advance past durationMs
+      jest.advanceTimersByTime(750);
+
+      // Only one ramp should occur
+      expect(mockGainNode.gain.setValueAtTime).toHaveBeenCalledTimes(1);
+      expect(mockGainNode.gain.linearRampToValueAtTime).toHaveBeenCalledTimes(1);
     });
 
-    // Release before safety timeout
-    controller!.release();
-    mockGainNode.gain.setValueAtTime.mockClear();
-    mockGainNode.gain.linearRampToValueAtTime.mockClear();
+    it('marks active as false after durationMs + fadeInMs', () => {
+      const stream = createMockStream();
+      const controller = createAudioWarmupStream(stream, {
+        enabled: true,
+        durationMs: 750,
+        fadeInMs: 100,
+      });
 
-    // Advance past safety timeout
-    jest.advanceTimersByTime(3000);
+      controller!.scheduleRelease();
 
-    // No extra ramp calls from safety timeout
-    expect(mockGainNode.gain.setValueAtTime).not.toHaveBeenCalled();
+      // After durationMs
+      jest.advanceTimersByTime(750);
+      expect(controller!.active).toBe(true); // still during fade-in
+
+      // After fade-in + buffer
+      jest.advanceTimersByTime(200);
+      expect(controller!.active).toBe(false);
+    });
   });
 
-  it('returns null when AudioContext constructor throws', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (global as any).AudioContext = jest.fn(() => {
-      throw new Error('AudioContext not available');
+  // ============================================================
+  // release() — immediate release
+  // ============================================================
+
+  describe('release', () => {
+    it('immediately ramps gain from 0 to 1', () => {
+      const stream = createMockStream();
+      const controller = createAudioWarmupStream(stream, {
+        enabled: true,
+        fadeInMs: 100,
+      });
+
+      mockGainNode.gain.setValueAtTime.mockClear();
+      mockGainNode.gain.linearRampToValueAtTime.mockClear();
+
+      controller!.release();
+
+      expect(mockGainNode.gain.setValueAtTime).toHaveBeenCalledWith(0, expect.any(Number));
+      expect(mockGainNode.gain.linearRampToValueAtTime).toHaveBeenCalledWith(1, expect.any(Number));
     });
 
-    const stream = createMockStream();
-    const result = createAudioWarmupStream(stream, true);
-    expect(result).toBeNull();
+    it('is idempotent', () => {
+      const stream = createMockStream();
+      const controller = createAudioWarmupStream(stream, true);
+
+      controller!.release();
+      mockGainNode.gain.setValueAtTime.mockClear();
+      mockGainNode.gain.linearRampToValueAtTime.mockClear();
+
+      // Second call should be a no-op
+      controller!.release();
+      expect(mockGainNode.gain.setValueAtTime).not.toHaveBeenCalled();
+    });
+
+    it('cancels scheduled release when called after scheduleRelease', () => {
+      const stream = createMockStream();
+      const controller = createAudioWarmupStream(stream, {
+        enabled: true,
+        durationMs: 750,
+        fadeInMs: 100,
+      });
+
+      controller!.scheduleRelease();
+      mockGainNode.gain.setValueAtTime.mockClear();
+      mockGainNode.gain.linearRampToValueAtTime.mockClear();
+
+      // Immediate release should cancel the scheduled one and ramp now
+      controller!.release();
+
+      expect(mockGainNode.gain.linearRampToValueAtTime).toHaveBeenCalledWith(1, expect.any(Number));
+
+      // Record the call count after release()
+      const rampCallCount = mockGainNode.gain.linearRampToValueAtTime.mock.calls.length;
+
+      // Advancing past durationMs should NOT trigger additional ramp calls
+      jest.advanceTimersByTime(800);
+      expect(mockGainNode.gain.linearRampToValueAtTime.mock.calls.length).toBe(rampCallCount);
+    });
   });
 
-  it('returns null when WebAudio setup throws (createGain)', () => {
-    mockAudioContext.createGain = jest.fn(() => {
-      throw new Error('createGain failed');
+  // ============================================================
+  // cleanup()
+  // ============================================================
+
+  describe('cleanup', () => {
+    it('disconnects nodes and closes AudioContext', () => {
+      const stream = createMockStream();
+      const controller = createAudioWarmupStream(stream, true);
+
+      controller!.cleanup();
+
+      expect(mockSource.disconnect).toHaveBeenCalled();
+      expect(mockGainNode.disconnect).toHaveBeenCalled();
+      expect(mockAudioContext.close).toHaveBeenCalled();
+      expect(controller!.active).toBe(false);
     });
 
-    const stream = createMockStream();
-    const result = createAudioWarmupStream(stream, true);
-    expect(result).toBeNull();
+    it('is idempotent', () => {
+      const stream = createMockStream();
+      const controller = createAudioWarmupStream(stream, true);
+
+      controller!.cleanup();
+      mockSource.disconnect.mockClear();
+      mockGainNode.disconnect.mockClear();
+      mockAudioContext.close.mockClear();
+
+      controller!.cleanup();
+      expect(mockSource.disconnect).not.toHaveBeenCalled();
+    });
+
+    it('cancels scheduled release', () => {
+      const stream = createMockStream();
+      const controller = createAudioWarmupStream(stream, {
+        enabled: true,
+        durationMs: 750,
+        fadeInMs: 100,
+      });
+
+      controller!.scheduleRelease();
+      controller!.cleanup();
+
+      mockGainNode.gain.setValueAtTime.mockClear();
+      mockGainNode.gain.linearRampToValueAtTime.mockClear();
+
+      // Advancing past durationMs should NOT trigger ramp after cleanup
+      jest.advanceTimersByTime(750);
+      expect(mockGainNode.gain.setValueAtTime).not.toHaveBeenCalled();
+      expect(mockGainNode.gain.linearRampToValueAtTime).not.toHaveBeenCalled();
+    });
+  });
+
+  // ============================================================
+  // Safety timeout — fallback if connected event never arrives
+  // ============================================================
+
+  describe('safety timeout', () => {
+    it('triggers immediate release if connected never arrives', () => {
+      const stream = createMockStream();
+      const controller = createAudioWarmupStream(stream, {
+        enabled: true,
+        durationMs: 750,
+      });
+
+      mockGainNode.gain.setValueAtTime.mockClear();
+      mockGainNode.gain.linearRampToValueAtTime.mockClear();
+
+      // Advance time past duration + safety margin (750 + 2000 = 2750ms)
+      jest.advanceTimersByTime(2800);
+
+      // Should have triggered release via safety timeout
+      expect(mockGainNode.gain.linearRampToValueAtTime).toHaveBeenCalledWith(1, expect.any(Number));
+
+      // Advance past the fade-in + 50ms delay after release
+      jest.advanceTimersByTime(200);
+      expect(controller!.active).toBe(false);
+    });
+
+    it('is cancelled when scheduleRelease is called', () => {
+      const stream = createMockStream();
+      const controller = createAudioWarmupStream(stream, {
+        enabled: true,
+        durationMs: 750,
+      });
+
+      // Simulate peer connected → scheduleRelease
+      controller!.scheduleRelease();
+
+      mockGainNode.gain.setValueAtTime.mockClear();
+      mockGainNode.gain.linearRampToValueAtTime.mockClear();
+
+      // Advance past the safety timeout window
+      jest.advanceTimersByTime(3000);
+
+      // Only one ramp from scheduleRelease, not an extra one from safety timeout
+      expect(mockGainNode.gain.linearRampToValueAtTime).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ============================================================
+  // Fallback / error cases
+  // ============================================================
+
+  describe('fallback', () => {
+    it('returns null when AudioContext constructor throws', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (global as any).AudioContext = jest.fn(() => {
+        throw new Error('AudioContext not available');
+      });
+
+      const stream = createMockStream();
+      const result = createAudioWarmupStream(stream, true);
+      expect(result).toBeNull();
+    });
+
+    it('returns null when WebAudio setup throws (createGain)', () => {
+      mockAudioContext.createGain = jest.fn(() => {
+        throw new Error('createGain failed');
+      });
+
+      const stream = createMockStream();
+      const result = createAudioWarmupStream(stream, true);
+      expect(result).toBeNull();
+    });
+
+    it('webitAudioContext fallback is supported in getAudioContextConstructor', () => {
+      // The getAudioContextConstructor() function checks window.AudioContext first,
+      // then falls back to window.webkitAudioContext for Safari compatibility.
+      // Full browser integration testing is needed to verify Safari behavior.
+      // Here we just confirm the normal path still works.
+      const stream = createMockStream();
+      const controller = createAudioWarmupStream(stream, true);
+      expect(controller).not.toBeNull();
+      expect(AudioContextMock).toHaveBeenCalled();
+    });
   });
 });

--- a/packages/js/src/Modules/Verto/util/interfaces.ts
+++ b/packages/js/src/Modules/Verto/util/interfaces.ts
@@ -121,6 +121,13 @@ export interface IVertoOptions {
     /** Called when retry fails, the timeout expires, or the app calls `reject()`. */
     onError?: (error: Error) => void;
   };
+
+  /**
+   * Opt-in outbound audio startup warm-up (client-level default).
+   * Can be overridden per-call via IVertoCallOptions.audioWarmup.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  audioWarmup?: boolean | Record<string, any>;
 }
 export interface ILoginParams {
   login?: string;

--- a/packages/js/src/Modules/Verto/webrtc/AudioWarmup.ts
+++ b/packages/js/src/Modules/Verto/webrtc/AudioWarmup.ts
@@ -1,0 +1,202 @@
+import logger from '../util/logger';
+import { IAudioWarmupOptions } from './interfaces';
+
+/** Default warm-up durations */
+const DEFAULT_DURATION_MS = 750;
+const MAX_DURATION_MS = 3000;
+const DEFAULT_FADE_IN_MS = 100;
+const MAX_FADE_IN_MS = 1000;
+/** Safety timeout margin added on top of durationMs */
+const SAFETY_TIMEOUT_MARGIN_MS = 2000;
+
+/**
+ * Controller returned by createAudioWarmupStream.
+ * - stream: the MediaStream to add to RTCPeerConnection (contains destination audio + original video)
+ * - release: ramp gain from 0 to 1 (call when peer connected)
+ * - cleanup: disconnect nodes, close/suspend AudioContext, clear timers
+ * - active: whether the warm-up is still active (not yet released/cleaned up)
+ */
+export type AudioWarmupController = {
+  stream: MediaStream;
+  release: () => void;
+  cleanup: () => void;
+  active: boolean;
+};
+
+/**
+ * Normalize the audioWarmup option into a resolved config, or null if disabled.
+ */
+export function normalizeAudioWarmupOptions(
+  option: boolean | IAudioWarmupOptions | undefined
+): { enabled: true; durationMs: number; fadeInMs: number } | null {
+  if (option === undefined || option === false) {
+    return null;
+  }
+  if (option === true) {
+    return { enabled: true, durationMs: DEFAULT_DURATION_MS, fadeInMs: DEFAULT_FADE_IN_MS };
+  }
+  // Object form: enabled unless explicitly false
+  if (option.enabled === false) {
+    return null;
+  }
+  const durationMs = Math.max(0, Math.min(option.durationMs ?? DEFAULT_DURATION_MS, MAX_DURATION_MS));
+  const fadeInMs = Math.max(0, Math.min(option.fadeInMs ?? DEFAULT_FADE_IN_MS, MAX_FADE_IN_MS));
+  return { enabled: true, durationMs, fadeInMs };
+}
+
+/**
+ * Create a WebAudio-based warm-up stream that sends initial outbound audio at
+ * zero gain, then ramps to full gain on release().
+ *
+ * - Returns null if disabled, no audio track, AudioContext unavailable, or
+ *   if any WebAudio error occurs (non-fatal fallback).
+ * - Original inputStream is never mutated; a new senderStream is produced.
+ * - Video tracks are passed through unchanged.
+ * - microphoneLabel is preserved from the original track (set on userVariables if provided).
+ */
+export function createAudioWarmupStream(
+  inputStream: MediaStream,
+  option: boolean | IAudioWarmupOptions | undefined,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  userVariables?: Record<string, any>
+): AudioWarmupController | null {
+  const config = normalizeAudioWarmupOptions(option);
+  if (!config) {
+    return null;
+  }
+
+  const audioTracks = inputStream.getAudioTracks();
+  if (audioTracks.length === 0) {
+    return null;
+  }
+
+  // We only handle the first audio track for warm-up
+  const sourceTrack = audioTracks[0];
+
+  // Preserve original microphone label
+  const originalLabel = sourceTrack.label;
+  if (userVariables && originalLabel) {
+    userVariables.microphoneLabel = originalLabel;
+  }
+
+  let audioContext: AudioContext;
+  try {
+    audioContext = new AudioContext();
+  } catch {
+    logger.warn('Audio warmup fallback: AudioContext unavailable');
+    return null;
+  }
+
+  try {
+    const source = audioContext.createMediaStreamSource(inputStream);
+    const gainNode = audioContext.createGain();
+    const destination = audioContext.createMediaStreamDestination();
+
+    // Initial gain = 0 (silent)
+    gainNode.gain.setValueAtTime(0, audioContext.currentTime);
+
+    source.connect(gainNode);
+    gainNode.connect(destination);
+
+    const destinationAudioTrack = destination.stream.getAudioTracks()[0];
+
+    // Build sender stream: destination audio + original video tracks
+    const senderStream = new MediaStream();
+    senderStream.addTrack(destinationAudioTrack);
+
+    const videoTracks = inputStream.getVideoTracks();
+    videoTracks.forEach((t) => senderStream.addTrack(t));
+
+    let _active = true;
+    let _cleanedUp = false;
+    let safetyTimeoutId: ReturnType<typeof setTimeout> | null = null;
+    let released = false;
+
+    const controller: AudioWarmupController = {
+      stream: senderStream,
+      active: true,
+      release: () => {
+        if (!_active || released) {
+          return;
+        }
+        released = true;
+
+        // Clear safety timeout if release triggered by connected state
+        if (safetyTimeoutId !== null) {
+          clearTimeout(safetyTimeoutId);
+          safetyTimeoutId = null;
+        }
+
+        try {
+          const now = audioContext.currentTime;
+          gainNode.gain.setValueAtTime(0, now);
+          gainNode.gain.linearRampToValueAtTime(1, now + config.fadeInMs / 1000);
+          logger.info('Audio warmup released');
+        } catch (e) {
+          logger.warn('Audio warmup fallback: gain ramp failed', e);
+        }
+
+        // Mark as no longer active after fade-in completes
+        setTimeout(() => {
+          _active = false;
+          controller.active = false;
+        }, config.fadeInMs + 50);
+      },
+      cleanup: () => {
+        if (_cleanedUp) {
+          return; // Already cleaned up
+        }
+        _cleanedUp = true;
+
+        // Clear safety timeout
+        if (safetyTimeoutId !== null) {
+          clearTimeout(safetyTimeoutId);
+          safetyTimeoutId = null;
+        }
+
+        _active = false;
+        released = true;
+        controller.active = false;
+
+        try {
+          source.disconnect();
+          gainNode.disconnect();
+        } catch {
+          // Ignore disconnect errors on already-disconnected nodes
+        }
+
+        try {
+          if (audioContext.state !== 'closed') {
+            audioContext.close().catch(() => {});
+          }
+        } catch {
+          // Ignore close errors
+        }
+      },
+    };
+
+    // Safety timeout: if connection state event is missed, release anyway
+    safetyTimeoutId = setTimeout(() => {
+      if (_active && !released) {
+        logger.info('Audio warmup fallback: safety timeout');
+        controller.release();
+      }
+    }, config.durationMs + SAFETY_TIMEOUT_MARGIN_MS);
+
+    logger.info(
+      `Audio warmup enabled durationMs=${config.durationMs} fadeInMs=${config.fadeInMs}`
+    );
+
+    return controller;
+  } catch (e) {
+    logger.warn('Audio warmup fallback: WebAudio setup failed', e);
+
+    try {
+      audioContext.close().catch(() => {});
+    } catch {
+      // Ignore
+    }
+
+    return null;
+  }
+}

--- a/packages/js/src/Modules/Verto/webrtc/AudioWarmup.ts
+++ b/packages/js/src/Modules/Verto/webrtc/AudioWarmup.ts
@@ -12,14 +12,20 @@ const SAFETY_TIMEOUT_MARGIN_MS = 2000;
 /**
  * Controller returned by createAudioWarmupStream.
  * - stream: the MediaStream to add to RTCPeerConnection (contains destination audio + original video)
- * - release: ramp gain from 0 to 1 (call when peer connected)
+ * - scheduleRelease: called when peer connects; waits durationMs then ramps gain 0→1 over fadeInMs
+ * - release: immediately ramp gain from 0 to 1 (used by safety timeout or forced release)
  * - cleanup: disconnect nodes, close/suspend AudioContext, clear timers
  * - active: whether the warm-up is still active (not yet released/cleaned up)
  */
 export type AudioWarmupController = {
   stream: MediaStream;
+  /** Schedule delayed release: wait durationMs then ramp gain 0→1. Call on peer connected. */
+  scheduleRelease: () => void;
+  /** Immediate release: ramp gain 0→1 now. Used by safety timeout or forced release. */
   release: () => void;
+  /** Cleanup WebAudio nodes, close AudioContext, clear all timers. */
   cleanup: () => void;
+  /** Whether warm-up gain is still at 0 (not yet released or faded in). */
   active: boolean;
 };
 
@@ -45,8 +51,25 @@ export function normalizeAudioWarmupOptions(
 }
 
 /**
+ * Resolve the AudioContext constructor for cross-browser support.
+ * Safari uses webkitAudioContext; Chrome/Firefox/Edge use AudioContext.
+ */
+function getAudioContextConstructor(): (new () => AudioContext) | null {
+  if (typeof AudioContext !== 'undefined') {
+    return AudioContext;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const wkt = (window as any).webkitAudioContext;
+  if (typeof wkt !== 'undefined') {
+    return wkt;
+  }
+  return null;
+}
+
+/**
  * Create a WebAudio-based warm-up stream that sends initial outbound audio at
- * zero gain, then ramps to full gain on release().
+ * zero gain. When the peer connects, call scheduleRelease() which waits
+ * durationMs then ramps gain to full over fadeInMs.
  *
  * - Returns null if disabled, no audio track, AudioContext unavailable, or
  *   if any WebAudio error occurs (non-fatal fallback).
@@ -79,11 +102,17 @@ export function createAudioWarmupStream(
     userVariables.microphoneLabel = originalLabel;
   }
 
+  const AudioContextCtor = getAudioContextConstructor();
+  if (!AudioContextCtor) {
+    logger.warn('Audio warmup fallback: AudioContext unavailable');
+    return null;
+  }
+
   let audioContext: AudioContext;
   try {
-    audioContext = new AudioContext();
+    audioContext = new AudioContextCtor();
   } catch {
-    logger.warn('Audio warmup fallback: AudioContext unavailable');
+    logger.warn('Audio warmup fallback: AudioContext constructor failed');
     return null;
   }
 
@@ -109,44 +138,99 @@ export function createAudioWarmupStream(
 
     let _active = true;
     let _cleanedUp = false;
+    let _releaseScheduled = false;
+    let _released = false;
+    let scheduleTimeoutId: ReturnType<typeof setTimeout> | null = null;
     let safetyTimeoutId: ReturnType<typeof setTimeout> | null = null;
-    let released = false;
+    let activeCheckTimeoutId: ReturnType<typeof setTimeout> | null = null;
+
+    /**
+     * Immediately ramp gain from 0 to 1 over fadeInMs.
+     * Used by scheduleRelease (after delay) and safety timeout.
+     */
+    const doRampRelease = () => {
+      if (_released) {
+        return;
+      }
+      _released = true;
+
+      try {
+        const now = audioContext.currentTime;
+        gainNode.gain.setValueAtTime(0, now);
+        gainNode.gain.linearRampToValueAtTime(1, now + config.fadeInMs / 1000);
+        logger.info('Audio warmup released');
+      } catch (e) {
+        logger.warn('Audio warmup fallback: gain ramp failed', e);
+      }
+
+      // Mark as no longer active after fade-in completes
+      activeCheckTimeoutId = setTimeout(() => {
+        _active = false;
+        controller.active = false;
+      }, config.fadeInMs + 50);
+    };
+
+    const clearAllTimers = () => {
+      if (scheduleTimeoutId !== null) {
+        clearTimeout(scheduleTimeoutId);
+        scheduleTimeoutId = null;
+      }
+      if (safetyTimeoutId !== null) {
+        clearTimeout(safetyTimeoutId);
+        safetyTimeoutId = null;
+      }
+      if (activeCheckTimeoutId !== null) {
+        clearTimeout(activeCheckTimeoutId);
+        activeCheckTimeoutId = null;
+      }
+    };
 
     const controller: AudioWarmupController = {
       stream: senderStream,
       active: true,
-      release: () => {
-        if (!_active || released) {
+
+      /**
+       * Schedule delayed release: wait durationMs then ramp gain 0→1.
+       * Call this when peer connects (connectionState or iceConnectionState === 'connected').
+       * Duplicate calls are no-ops (only the first schedules the timer).
+       */
+      scheduleRelease: () => {
+        if (!_active || _releaseScheduled || _cleanedUp) {
           return;
         }
-        released = true;
+        _releaseScheduled = true;
 
-        // Clear safety timeout if release triggered by connected state
+        // Clear safety timeout — connected state means media path is up,
+        // and we now control release timing ourselves
         if (safetyTimeoutId !== null) {
           clearTimeout(safetyTimeoutId);
           safetyTimeoutId = null;
         }
 
-        try {
-          const now = audioContext.currentTime;
-          gainNode.gain.setValueAtTime(0, now);
-          gainNode.gain.linearRampToValueAtTime(1, now + config.fadeInMs / 1000);
-          logger.info('Audio warmup released');
-        } catch (e) {
-          logger.warn('Audio warmup fallback: gain ramp failed', e);
+        logger.info(
+          `Audio warmup release scheduled on peer connected, waiting ${config.durationMs}ms`
+        );
+
+        scheduleTimeoutId = setTimeout(() => {
+          scheduleTimeoutId = null;
+          doRampRelease();
+        }, config.durationMs);
+      },
+
+      /**
+       * Immediate release: ramp gain 0→1 now.
+       * Used by safety timeout or forced release.
+       */
+      release: () => {
+        if (!_active || _cleanedUp) {
+          return;
         }
 
-        // Mark as no longer active after fade-in completes
-        setTimeout(() => {
-          _active = false;
-          controller.active = false;
-        }, config.fadeInMs + 50);
-      },
-      cleanup: () => {
-        if (_cleanedUp) {
-          return; // Already cleaned up
+        // Clear schedule timeout if one was set
+        if (scheduleTimeoutId !== null) {
+          clearTimeout(scheduleTimeoutId);
+          scheduleTimeoutId = null;
         }
-        _cleanedUp = true;
 
         // Clear safety timeout
         if (safetyTimeoutId !== null) {
@@ -154,8 +238,19 @@ export function createAudioWarmupStream(
           safetyTimeoutId = null;
         }
 
+        doRampRelease();
+      },
+
+      cleanup: () => {
+        if (_cleanedUp) {
+          return; // Already cleaned up
+        }
+        _cleanedUp = true;
+
+        clearAllTimers();
+
         _active = false;
-        released = true;
+        _released = true;
         controller.active = false;
 
         try {
@@ -175,9 +270,10 @@ export function createAudioWarmupStream(
       },
     };
 
-    // Safety timeout: if connection state event is missed, release anyway
+    // Safety timeout: if connection state event is never received, release anyway.
+    // This ensures we never leave outbound audio permanently silent.
     safetyTimeoutId = setTimeout(() => {
-      if (_active && !released) {
+      if (_active && !_released && !_releaseScheduled) {
         logger.info('Audio warmup fallback: safety timeout');
         controller.release();
       }

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -869,10 +869,7 @@ export default abstract class BaseCall implements IWebRTCCall {
       // Cleanup warm-up controller when audio input device changes.
       // The warm-up is a startup-only transform; after setAudioInDevice(),
       // the sender uses the raw new audio track directly (no WebAudio pipeline).
-      if (this.peer?._audioWarmupController) {
-        this.peer._audioWarmupController.cleanup();
-        this.peer._audioWarmupController = undefined;
-      }
+      this.peer?.cleanupAudioWarmup();
 
       const { localStream } = this.options;
       localStream.getAudioTracks().forEach((t) => t.stop());

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -866,6 +866,14 @@ export default abstract class BaseCall implements IWebRTCCall {
       sender.replaceTrack(audioTrack);
       this.options.micId = deviceId;
 
+      // Cleanup warm-up controller when audio input device changes.
+      // The warm-up is a startup-only transform; after setAudioInDevice(),
+      // the sender uses the raw new audio track directly (no WebAudio pipeline).
+      if (this.peer?._audioWarmupController) {
+        this.peer._audioWarmupController.cleanup();
+        this.peer._audioWarmupController = undefined;
+      }
+
       const { localStream } = this.options;
       localStream.getAudioTracks().forEach((t) => t.stop());
       localStream.getVideoTracks().forEach((t) => newStream.addTrack(t));

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -287,6 +287,7 @@ export default abstract class BaseCall implements IWebRTCCall {
         keepConnectionAliveOnSocketClose:
           options.keepConnectionAliveOnSocketClose,
         mutedMicOnStart: options.mutedMicOnStart,
+        audioWarmup: options.audioWarmup,
       },
       opts
     );

--- a/packages/js/src/Modules/Verto/webrtc/Peer.ts
+++ b/packages/js/src/Modules/Verto/webrtc/Peer.ts
@@ -743,7 +743,12 @@ export default class Peer {
 
         tracks.forEach((track) => {
           if (track.kind === 'audio') {
-            this.options.userVariables.microphoneLabel = track.label;
+            // When warm-up is active, microphoneLabel was already set from
+            // the original track by createAudioWarmupStream. Don't overwrite
+            // it with the synthetic destination track label.
+            if (!this._audioWarmupController) {
+              this.options.userVariables.microphoneLabel = track.label;
+            }
           }
           if (track.kind === 'video') {
             this.options.userVariables.cameraLabel = track.label;
@@ -767,7 +772,12 @@ export default class Peer {
 
         tracks.forEach((track) => {
           if (track.kind === 'audio') {
-            this.options.userVariables.microphoneLabel = track.label;
+            // When warm-up is active, microphoneLabel was already set from
+            // the original track by createAudioWarmupStream. Don't overwrite
+            // it with the synthetic destination track label.
+            if (!this._audioWarmupController) {
+              this.options.userVariables.microphoneLabel = track.label;
+            }
           }
           if (track.kind === 'video') {
             this.options.userVariables.cameraLabel = track.label;

--- a/packages/js/src/Modules/Verto/webrtc/Peer.ts
+++ b/packages/js/src/Modules/Verto/webrtc/Peer.ts
@@ -48,6 +48,7 @@ import {
   getPreferredCodecs,
   getUserMedia,
 } from './helpers';
+import { createAudioWarmupStream, AudioWarmupController } from './AudioWarmup';
 import { IVertoCallOptions } from './interfaces';
 
 /**
@@ -82,6 +83,7 @@ export default class Peer {
   private static readonly ICE_RESTART_TIMEOUT_MS = 15000;
   private _hadOfflineEvent: boolean = false;
   private _offlineHandler: (() => void) | null = null;
+  public _audioWarmupController?: AudioWarmupController;
 
   constructor(
     public type: PeerType,
@@ -372,6 +374,11 @@ export default class Peer {
       performance.mark(callMarkName(this.options.id, 'dtls-connected'));
       this.tryCollectTimings();
 
+      // Release audio warm-up when peer connection is established
+      if (this._audioWarmupController?.active) {
+        this._audioWarmupController.release();
+      }
+
       // Successful (re)connection — allow future ICE restarts if we fail again.
       // Only clear the restart-gate and offline flag here; isIceRestarting
       // must remain true until the Modify exchange completes (see
@@ -577,6 +584,12 @@ export default class Peer {
 
     if (state === 'connected') {
       performance.mark(callMarkName(this.options.id, 'ice-connected'));
+
+      // Release audio warm-up when ICE is connected (fallback if connectionState
+      // event is not fired or fires late)
+      if (this._audioWarmupController?.active) {
+        this._audioWarmupController.release();
+      }
     }
   };
 
@@ -670,7 +683,22 @@ export default class Peer {
     } = this.options;
 
     if (streamIsValid(localStream)) {
-      const audioTracks = localStream.getAudioTracks();
+      // Create warm-up stream if audioWarmup is enabled.
+      // The warm-up stream replaces audio tracks with WebAudio destination
+      // tracks at zero gain; video tracks pass through unchanged.
+      // The original localStream is kept for local preview.
+      const warmup = createAudioWarmupStream(
+        localStream,
+        this.options.audioWarmup,
+        this.options.userVariables
+      );
+      const senderStream = warmup?.stream || localStream;
+
+      if (warmup) {
+        this._audioWarmupController = warmup;
+      }
+
+      const audioTracks = senderStream.getAudioTracks();
       let tracks = [...audioTracks];
 
       logger.info('Local audio tracks: ', audioTracks);
@@ -686,7 +714,7 @@ export default class Peer {
       }
 
       if (!!this.options.video) {
-        const videoTracks = localStream.getVideoTracks();
+        const videoTracks = senderStream.getVideoTracks();
         tracks = [...audioTracks, ...videoTracks];
 
         logger.info('Local video tracks: ', videoTracks);
@@ -710,7 +738,7 @@ export default class Peer {
         // Use addTransceiver
         const transceiverParams: RTCRtpTransceiverInit = {
           direction: 'sendrecv',
-          streams: [localStream],
+          streams: [senderStream],
         };
 
         tracks.forEach((track) => {
@@ -745,7 +773,7 @@ export default class Peer {
             this.options.userVariables.cameraLabel = track.label;
           }
 
-          this.instance.addTrack(track, localStream);
+          this.instance.addTrack(track, senderStream);
         });
 
         this.instance.getTransceivers().forEach((trans) => {
@@ -760,7 +788,7 @@ export default class Peer {
         // Fallback to legacy addStream ..
         // addStream is deprecated
         // @ts-expect-error addStream does not exist on RTCPeerConnection
-        this.instance.addStream(localStream);
+        this.instance.addStream(senderStream);
       }
 
       if (screenShare === false) {
@@ -1029,6 +1057,12 @@ export default class Peer {
   }
 
   public async close() {
+    // Cleanup audio warm-up controller
+    if (this._audioWarmupController) {
+      this._audioWarmupController.cleanup();
+      this._audioWarmupController = undefined;
+    }
+
     // Clear call marks when the peer closes to prevent stale marks
     // from leaking into a subsequent call's timing calculation.
     // This covers cleanup paths that don't go through tryCollectTimings()

--- a/packages/js/src/Modules/Verto/webrtc/Peer.ts
+++ b/packages/js/src/Modules/Verto/webrtc/Peer.ts
@@ -83,7 +83,7 @@ export default class Peer {
   private static readonly ICE_RESTART_TIMEOUT_MS = 15000;
   private _hadOfflineEvent: boolean = false;
   private _offlineHandler: (() => void) | null = null;
-  public _audioWarmupController?: AudioWarmupController;
+  private _audioWarmupController?: AudioWarmupController;
 
   constructor(
     public type: PeerType,
@@ -376,7 +376,7 @@ export default class Peer {
 
       // Release audio warm-up when peer connection is established
       if (this._audioWarmupController?.active) {
-        this._audioWarmupController.release();
+        this._audioWarmupController.scheduleRelease();
       }
 
       // Successful (re)connection — allow future ICE restarts if we fail again.
@@ -588,7 +588,7 @@ export default class Peer {
       // Release audio warm-up when ICE is connected (fallback if connectionState
       // event is not fired or fires late)
       if (this._audioWarmupController?.active) {
-        this._audioWarmupController.release();
+        this._audioWarmupController.scheduleRelease();
       }
     }
   };
@@ -1056,12 +1056,21 @@ export default class Peer {
     );
   }
 
-  public async close() {
-    // Cleanup audio warm-up controller
+  /**
+   * Cleanup the audio warm-up controller and disconnect the WebAudio pipeline.
+   * Called by BaseCall.setAudioInDevice() when the audio input device changes
+   * after startup (warm-up is a startup-only transform).
+   */
+  public cleanupAudioWarmup() {
     if (this._audioWarmupController) {
       this._audioWarmupController.cleanup();
       this._audioWarmupController = undefined;
     }
+  }
+
+  public async close() {
+    // Cleanup audio warm-up controller
+    this.cleanupAudioWarmup();
 
     // Clear call marks when the peer closes to prevent stale marks
     // from leaking into a subsequent call's timing calculation.

--- a/packages/js/src/Modules/Verto/webrtc/interfaces.ts
+++ b/packages/js/src/Modules/Verto/webrtc/interfaces.ts
@@ -1,18 +1,11 @@
 import type { ICallReportFlushReason } from './CallReportCollector';
 import { State } from './constants';
+export type { IAudioWarmupOptions } from '../../../utils/interfaces';
+import type { IAudioWarmupOptions } from '../../../utils/interfaces';
 
 export interface IMediaSettings {
   useSdpASBandwidthKbps?: boolean;
   sdpASBandwidthKbps?: number;
-}
-
-export interface IAudioWarmupOptions {
-  /** Enable outbound audio startup warm-up. Defaults to false. */
-  enabled?: boolean;
-  /** Duration in ms to hold gain at zero before release. Default 750, max 3000. */
-  durationMs?: number;
-  /** Fade-in duration in ms when releasing gain from 0 to 1. Default 100, max 1000. */
-  fadeInMs?: number;
 }
 export interface IHangupParams {
   /** Custom hangup cause string (e.g., 'NORMAL_CLEARING', 'PURGE', 'USER_BUSY') */

--- a/packages/js/src/Modules/Verto/webrtc/interfaces.ts
+++ b/packages/js/src/Modules/Verto/webrtc/interfaces.ts
@@ -5,6 +5,15 @@ export interface IMediaSettings {
   useSdpASBandwidthKbps?: boolean;
   sdpASBandwidthKbps?: number;
 }
+
+export interface IAudioWarmupOptions {
+  /** Enable outbound audio startup warm-up. Defaults to false. */
+  enabled?: boolean;
+  /** Duration in ms to hold gain at zero before release. Default 750, max 3000. */
+  durationMs?: number;
+  /** Fade-in duration in ms when releasing gain from 0 to 1. Default 100, max 1000. */
+  fadeInMs?: number;
+}
 export interface IHangupParams {
   /** Custom hangup cause string (e.g., 'NORMAL_CLEARING', 'PURGE', 'USER_BUSY') */
   cause?: string;
@@ -96,6 +105,17 @@ export interface IVertoCallOptions {
    * ended/destroyed call and avoid duplicate UI elements (e.g. dialers).
    */
   recoveredCallId?: string;
+  /**
+   * Opt-in outbound audio startup warm-up.
+   * When enabled, initial outbound audio is sent at zero gain for a short
+   * configurable window so first real speech is not exposed to startup
+   * encoder/jitter-buffer/playout instability.
+   *
+   * - `undefined` / `false`: current behavior, no transform.
+   * - `true`: enabled with defaults (durationMs=750, fadeInMs=100).
+   * - object: enabled unless `enabled === false`; apply provided durations.
+   */
+  audioWarmup?: boolean | IAudioWarmupOptions;
 }
 
 export interface IStatsBinding {

--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -4,6 +4,7 @@ import {
   ICallOptions,
   ICredentials,
   INotification,
+  IAudioWarmupOptions,
 } from './utils/interfaces';
 import { SwEvent } from './Modules/Verto/util/constants';
 import {
@@ -19,6 +20,7 @@ export {
   ICallOptions,
   ICredentials,
   INotification,
+  IAudioWarmupOptions,
   SwEvent,
   NOTIFICATION_TYPE,
   ERROR_TYPE,

--- a/packages/js/src/utils/interfaces.ts
+++ b/packages/js/src/utils/interfaces.ts
@@ -257,6 +257,39 @@ export interface IClientOptions {
     /** Called when retry fails, the timeout expires, or the app calls `reject()`. */
     onError?: (error: Error) => void;
   };
+
+  /**
+   * Opt-in outbound audio startup warm-up.
+   * When enabled, initial outbound audio is sent at zero gain for a short
+   * configurable window so first real speech is not exposed to startup
+   * encoder/jitter-buffer/playout instability.
+   *
+   * - `undefined` / `false`: current behavior, no transform.
+   * - `true`: enabled with defaults (durationMs=750, fadeInMs=100).
+   * - object: enabled unless `enabled === false`; apply provided durations.
+   *
+   * Can be overridden per-call via `ICallOptions.audioWarmup`.
+   */
+  audioWarmup?: boolean | IAudioWarmupOptions;
+}
+
+/**
+ * Configuration for outbound audio startup warm-up.
+ * When enabled, initial outbound audio is sent at zero gain for a short
+ * configurable window so first real speech is not exposed to startup
+ * encoder/jitter-buffer/playout instability.
+ *
+ * - `undefined` / `false`: current behavior, no transform.
+ * - `true`: enabled with defaults (durationMs=750, fadeInMs=100).
+ * - object: enabled unless `enabled === false`; apply provided durations.
+ */
+export interface IAudioWarmupOptions {
+  /** Enable outbound audio startup warm-up. Defaults to false. */
+  enabled?: boolean;
+  /** Duration in ms to hold gain at zero before release. Default 750, max 3000. */
+  durationMs?: number;
+  /** Fade-in duration in ms when releasing gain from 0 to 1. Default 100, max 1000. */
+  fadeInMs?: number;
 }
 
 /**
@@ -396,6 +429,17 @@ export interface ICallOptions {
    * when the WebSocket connection is closed unexpectedly (e.g. network interruption, device sleep, etc).
    */
   keepConnectionAliveOnSocketClose?: boolean;
+
+  /**
+   * Opt-in outbound audio startup warm-up for this call.
+   * Overrides the client-level `audioWarmup` setting.
+   *
+   * - `undefined`: use client-level setting (default).
+   * - `false`: disable warm-up for this call even if enabled at client level.
+   * - `true`: enabled with defaults (durationMs=750, fadeInMs=100).
+   * - object: enabled unless `enabled === false`; apply provided durations.
+   */
+  audioWarmup?: boolean | IAudioWarmupOptions;
 }
 
 /**


### PR DESCRIPTION
## Summary

Add an opt-in Web SDK mitigation that sends initial outbound audio at zero gain for a short configurable warm-up window, reducing first-audio distortion from startup encoder/jitter-buffer/playout instability.

## Changes

- **New type:** `IAudioWarmupOptions` (`enabled`, `durationMs`, `fadeInMs`) added to `interfaces.ts`
- **New call option:** `audioWarmup?: boolean | IAudioWarmupOptions` on `IVertoCallOptions`
- **New module:** `AudioWarmup.ts` — WebAudio pipeline (MediaStreamSource → GainNode → MediaStreamDestinationNode) with `release()` and `cleanup()` controller
- **Peer.ts:** Creates warm-up stream when option enabled; sender stream uses warm-up destination track; release on `connectionState === 'connected'` and `iceConnectionState === 'connected'`; cleanup on `close()`
- **BaseCall.ts:** `setAudioInDevice()` cleans up warm-up controller (startup-only transform)
- **Tests:** 31 unit tests covering option normalization, helper behavior, idempotency, safety timeout, fallback on error

## API

```ts
// Disabled (default) — no behavior change
client.newCall({ destinationNumber: '1234' })

// Enabled with defaults (durationMs=750, fadeInMs=100)
client.newCall({ destinationNumber: '1234', audioWarmup: true })

// Custom configuration
client.newCall({
  destinationNumber: '1234',
  audioWarmup: { enabled: true, durationMs: 500, fadeInMs: 50 }
})
```

## Acceptance criteria

- [x] Opt-in only; default behavior unchanged
- [x] Warm-up failure is non-fatal (falls back to original stream)
- [x] Works with mic and custom `localStream`
- [x] Does not delay SDP/ICE/DTLS
- [x] Does not change remote media attachment
- [x] Mute/unmute and `setAudioInDevice()` are safe
- [x] Tests cover option normalization + helper behavior
- [x] `yarn lint` — no new errors beyond pre-existing
- [x] `yarn test --runInBand` — 322/322 pass
- [x] `yarn build` — succeeds

## Manual test plan

1. Baseline call with `audioWarmup` disabled — no behavior change
2. Enable `audioWarmup: { enabled: true, durationMs: 750, fadeInMs: 100 }`
3. Reproduce customer pattern: remote/mobile side starts speaking immediately after WebRTC answer
4. Confirm first-audio distortion is reduced/absent
5. Confirm call report shows RTP starts immediately, near-zero audio level during warm-up, normal after release