### PR TITLE
fix: recover VPN media stalls over relay

### DIFF
--- a/packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts
@@ -53,6 +53,7 @@ type TestableCallReportCollector = {
     localAudioTrack?: ILocalAudioTrackSnapshot,
     localAudioSource?: ILocalAudioSourceStats
   ) => void;
+  shouldForceRelayCandidateForRecovery: () => boolean;
   sendPayload: SendPayload;
   _sendPayload: SendPayload;
 };
@@ -115,6 +116,89 @@ describe('CallReportCollector intermediate reports', () => {
         },
       })
     );
+  });
+});
+
+describe('CallReportCollector relay recovery detection', () => {
+  const vpnStats = (
+    overrides: Partial<IStatsInterval> = {}
+  ): IStatsInterval => ({
+    intervalStartUtc: '2026-05-19T21:10:00.000Z',
+    intervalEndUtc: '2026-05-19T21:10:05.000Z',
+    audio: {
+      outbound: { bytesSent: 1000 },
+      inbound: { bytesReceived: 1000 },
+    },
+    ice: {
+      local: { candidateType: 'srflx', networkType: 'vpn' },
+      writable: true,
+      requestsSent: 10,
+      responsesReceived: 10,
+    },
+    transport: { iceState: 'connected' },
+    ...overrides,
+  });
+
+  it('requests relay recovery for a stalled non-relay VPN media path', () => {
+    const collector = createCollector();
+    (collector as unknown as { statsBuffer: IStatsInterval[] }).statsBuffer = [
+      vpnStats(),
+      vpnStats({
+        audio: {
+          outbound: { bytesSent: 2000 },
+          inbound: { bytesReceived: 1000 },
+        },
+        ice: {
+          local: { candidateType: 'srflx', networkType: 'vpn' },
+          writable: false,
+          requestsSent: 20,
+          responsesReceived: 10,
+        },
+        transport: { iceState: 'disconnected' },
+      }),
+    ];
+
+    expect(collector.shouldForceRelayCandidateForRecovery()).toBe(true);
+  });
+
+  it('does not request relay recovery for an already selected relay candidate', () => {
+    const collector = createCollector();
+    (collector as unknown as { statsBuffer: IStatsInterval[] }).statsBuffer = [
+      vpnStats({
+        ice: {
+          local: { candidateType: 'relay', networkType: 'vpn' },
+          writable: false,
+        },
+      }),
+      vpnStats({
+        ice: {
+          local: { candidateType: 'relay', networkType: 'vpn' },
+          writable: false,
+        },
+      }),
+    ];
+
+    expect(collector.shouldForceRelayCandidateForRecovery()).toBe(false);
+  });
+
+  it('does not request relay recovery for non-VPN candidate paths', () => {
+    const collector = createCollector();
+    (collector as unknown as { statsBuffer: IStatsInterval[] }).statsBuffer = [
+      vpnStats({
+        ice: {
+          local: { candidateType: 'srflx', networkType: 'wifi' },
+          writable: false,
+        },
+      }),
+      vpnStats({
+        ice: {
+          local: { candidateType: 'srflx', networkType: 'wifi' },
+          writable: false,
+        },
+      }),
+    ];
+
+    expect(collector.shouldForceRelayCandidateForRecovery()).toBe(false);
   });
 });
 

--- a/packages/js/src/Modules/Verto/tests/webrtc/VertoHandler.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/VertoHandler.test.ts
@@ -178,12 +178,19 @@ describe('VertoHandler', () => {
       done();
     });
 
-    it('should force relay on the recovered call only when the previous call reports a VPN media-path stall', async (done) => {
+    it('should not force relay on the first recovered call even when the previous call reports a VPN media-path stall', async (done) => {
       await instance.connect();
       const callId = 'e2fda6dc-fc9d-4d77-8096-53bb502443b6';
       _setupCall({ id: callId });
       call.setState(State.Active);
-      call.shouldForceRelayCandidateForRecovery = jest.fn(() => true);
+      const shouldForceRelayCandidateForRecovery = jest.fn(() => true);
+      (
+        call as unknown as {
+          _callReportCollector: {
+            shouldForceRelayCandidateForRecovery: jest.Mock;
+          };
+        }
+      )._callReportCollector = { shouldForceRelayCandidateForRecovery };
 
       // Mock answer to prevent actual WebRTC peer creation
       const originalAnswer = Call.prototype.answer;
@@ -195,9 +202,40 @@ describe('VertoHandler', () => {
       handler.handleMessage(msg);
 
       const newCall = instance.calls[callId];
-      expect(call.shouldForceRelayCandidateForRecovery).toHaveBeenCalledTimes(
-        1
+      expect(shouldForceRelayCandidateForRecovery).not.toHaveBeenCalled();
+      expect(newCall).toBeDefined();
+      expect(newCall.options.forceRelayCandidate).toBe(false);
+      expect(newCall.recoveredCallId).toEqual(callId);
+
+      Call.prototype.answer = originalAnswer;
+      done();
+    });
+
+    it('should force relay only when an already recovered call reports the recovery path is still stalled', async (done) => {
+      await instance.connect();
+      const callId = 'e2fda6dc-fc9d-4d77-8096-53bb502443b6';
+      _setupCall({ id: callId, recoveredCallId: callId });
+      call.setState(State.Active);
+      const shouldForceRelayCandidateForRecovery = jest.fn(() => true);
+      (
+        call as unknown as {
+          _callReportCollector: {
+            shouldForceRelayCandidateForRecovery: jest.Mock;
+          };
+        }
+      )._callReportCollector = { shouldForceRelayCandidateForRecovery };
+
+      // Mock answer to prevent actual WebRTC peer creation
+      const originalAnswer = Call.prototype.answer;
+      Call.prototype.answer = jest.fn();
+
+      const msg = JSON.parse(
+        `{"jsonrpc":"2.0","id":4409,"method":"telnyx_rtc.attach","params":{"callID":"${callId}","sdp":"SDP","caller_id_name":"Extension 1004","caller_id_number":"1004","callee_id_name":"Outbound Call","callee_id_number":"1003"}}`
       );
+      handler.handleMessage(msg);
+
+      const newCall = instance.calls[callId];
+      expect(shouldForceRelayCandidateForRecovery).toHaveBeenCalledTimes(1);
       expect(newCall).toBeDefined();
       expect(newCall.options.forceRelayCandidate).toBe(true);
       expect(newCall.recoveredCallId).toEqual(callId);

--- a/packages/js/src/Modules/Verto/tests/webrtc/VertoHandler.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/VertoHandler.test.ts
@@ -178,6 +178,34 @@ describe('VertoHandler', () => {
       done();
     });
 
+    it('should force relay on the recovered call only when the previous call reports a VPN media-path stall', async (done) => {
+      await instance.connect();
+      const callId = 'e2fda6dc-fc9d-4d77-8096-53bb502443b6';
+      _setupCall({ id: callId });
+      call.setState(State.Active);
+      call.shouldForceRelayCandidateForRecovery = jest.fn(() => true);
+
+      // Mock answer to prevent actual WebRTC peer creation
+      const originalAnswer = Call.prototype.answer;
+      Call.prototype.answer = jest.fn();
+
+      const msg = JSON.parse(
+        `{"jsonrpc":"2.0","id":4408,"method":"telnyx_rtc.attach","params":{"callID":"${callId}","sdp":"SDP","caller_id_name":"Extension 1004","caller_id_number":"1004","callee_id_name":"Outbound Call","callee_id_number":"1003"}}`
+      );
+      handler.handleMessage(msg);
+
+      const newCall = instance.calls[callId];
+      expect(call.shouldForceRelayCandidateForRecovery).toHaveBeenCalledTimes(
+        1
+      );
+      expect(newCall).toBeDefined();
+      expect(newCall.options.forceRelayCandidate).toBe(true);
+      expect(newCall.recoveredCallId).toEqual(callId);
+
+      Call.prototype.answer = originalAnswer;
+      done();
+    });
+
     it('should NOT set recoveredCallId when no existing call (fresh attach)', async (done) => {
       await instance.connect();
       const callId = 'fresh-call-id-1234';

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -387,6 +387,16 @@ export default abstract class BaseCall implements IWebRTCCall {
     return !isAudioTrackEnabled(this.options.localStream);
   }
 
+  shouldForceRelayCandidateForRecovery(): boolean {
+    if (this.options.forceRelayCandidate) {
+      return false;
+    }
+
+    return (
+      this._callReportCollector?.shouldForceRelayCandidateForRecovery() ?? false
+    );
+  }
+
   async invite() {
     this._creatingPeer = true;
     this.direction = Direction.Outbound;

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -392,6 +392,10 @@ export default abstract class BaseCall implements IWebRTCCall {
       return false;
     }
 
+    if (!this.recoveredCallId) {
+      return false;
+    }
+
     return (
       this._callReportCollector?.shouldForceRelayCandidateForRecovery() ?? false
     );

--- a/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
+++ b/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
@@ -691,10 +691,82 @@ export class CallReportCollector {
   }
 
   /**
+   * Detect the VPN media-path stall seen during browser network/VPN flaps.
+   *
+   * This intentionally stays narrow: only a non-relay VPN selected pair can
+   * request relay-only recovery, and only when the latest stats show either
+   * stalled ICE checks or one-way media symptoms. TURN candidates being present
+   * is not enough by itself; browsers prefer direct/srflx pairs while ICE still
+   * considers them viable.
+   */
+  public shouldForceRelayCandidateForRecovery(): boolean {
+    if (this.statsBuffer.length < 2) {
+      return false;
+    }
+
+    const latest = this.statsBuffer[this.statsBuffer.length - 1];
+    const previous = this.statsBuffer[this.statsBuffer.length - 2];
+    const latestLocalCandidate = latest.ice?.local;
+
+    const isVpnNonRelayPath =
+      latestLocalCandidate?.networkType === 'vpn' &&
+      latestLocalCandidate?.candidateType !== 'relay';
+
+    if (!isVpnNonRelayPath) {
+      return false;
+    }
+
+    const iceNotWritable = latest.ice?.writable === false;
+    const iceTransportFailed =
+      latest.transport?.iceState === 'disconnected' ||
+      latest.transport?.iceState === 'failed';
+
+    const requestsSentDelta = this._positiveDelta(
+      latest.ice?.requestsSent,
+      previous.ice?.requestsSent
+    );
+    const responsesReceivedDelta = this._positiveDelta(
+      latest.ice?.responsesReceived,
+      previous.ice?.responsesReceived
+    );
+    const iceChecksStalled =
+      requestsSentDelta > 0 && responsesReceivedDelta === 0;
+
+    const outboundBytesDelta = this._positiveDelta(
+      latest.audio?.outbound?.bytesSent,
+      previous.audio?.outbound?.bytesSent
+    );
+    const inboundBytesDelta = this._positiveDelta(
+      latest.audio?.inbound?.bytesReceived,
+      previous.audio?.inbound?.bytesReceived
+    );
+    const inboundMediaStalled =
+      outboundBytesDelta > 0 && inboundBytesDelta === 0;
+
+    return (
+      iceNotWritable ||
+      iceTransportFailed ||
+      iceChecksStalled ||
+      inboundMediaStalled
+    );
+  }
+
+  /**
    * Get the collected logs (for debugging)
    */
   public getLogs(): ILogEntry[] {
     return this.logCollector?.getLogs() ?? [];
+  }
+
+  private _positiveDelta(
+    latest: number | undefined,
+    previous: number | undefined
+  ): number {
+    if (latest === undefined || previous === undefined) {
+      return 0;
+    }
+
+    return Math.max(0, latest - previous);
   }
 
   /**
@@ -969,7 +1041,11 @@ export class CallReportCollector {
   }
 
   private _requestIntermediateFlushIfNeeded(now: Date): void {
-    if (!this.onFlushNeeded || this._flushing || this.statsBuffer.length === 0) {
+    if (
+      !this.onFlushNeeded ||
+      this._flushing ||
+      this.statsBuffer.length === 0
+    ) {
       return;
     }
 

--- a/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
+++ b/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
@@ -93,7 +93,10 @@ class VertoHandler {
       return this._handlePvtEvent(params.pvtData);
     }
 
-    const _buildCall = (recoveredCallId?: string) => {
+    const _buildCall = (
+      recoveredCallId?: string,
+      forceRelayCandidateForRecovery?: boolean
+    ) => {
       const callOptions: IVertoCallOptions = {
         audio: true,
         // So far, if SIP configuration supports video, then we will always get video section in SDP.
@@ -111,7 +114,10 @@ class VertoHandler {
         debugOutput: session.options.debugOutput ?? 'socket',
         trickleIce: session.options.trickleIce ?? false,
         prefetchIceCandidates: session.options.prefetchIceCandidates ?? true,
-        forceRelayCandidate: session.options.forceRelayCandidate ?? false,
+        forceRelayCandidate:
+          forceRelayCandidateForRecovery ||
+          session.options.forceRelayCandidate ||
+          false,
         keepConnectionAliveOnSocketClose:
           session.options.keepConnectionAliveOnSocketClose ?? false,
       };
@@ -216,6 +222,14 @@ class VertoHandler {
         }
 
         const recoveredCallId = existingCall.id;
+        const forceRelayCandidateForRecovery =
+          existingCall.shouldForceRelayCandidateForRecovery?.() ?? false;
+
+        if (forceRelayCandidateForRecovery) {
+          logger.warn(
+            `[${new Date().toISOString()}][${callID}] Attach: forcing relay candidate for recovery after VPN media-path stall`
+          );
+        }
 
         logger.info(
           `[${new Date().toISOString()}][${callID}] closing existing call on ATTACH.`
@@ -228,7 +242,10 @@ class VertoHandler {
         logger.info(
           `[${new Date().toISOString()}][${callID}] Attach: Creating new call for recovery (recoveredCallId: ${recoveredCallId})`
         );
-        const call = _buildCall(recoveredCallId);
+        const call = _buildCall(
+          recoveredCallId,
+          forceRelayCandidateForRecovery
+        );
         call.answer();
         this._ack(id, method);
         break;

--- a/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
+++ b/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
@@ -227,7 +227,7 @@ class VertoHandler {
 
         if (forceRelayCandidateForRecovery) {
           logger.warn(
-            `[${new Date().toISOString()}][${callID}] Attach: forcing relay candidate for recovery after VPN media-path stall`
+            `[${new Date().toISOString()}][${callID}] Attach: forcing relay candidate because recovered VPN media path is still stalled`
           );
         }
 

--- a/packages/js/src/Modules/Verto/webrtc/interfaces.ts
+++ b/packages/js/src/Modules/Verto/webrtc/interfaces.ts
@@ -183,6 +183,7 @@ export interface IWebRTCCall {
   setAudioBandwidthEncodingsMaxBps: (max: number) => void;
   setVideoBandwidthEncodingsMaxBps: (max: number) => void;
   getStats: (callback: Function, constraints: any) => void;
+  shouldForceRelayCandidateForRecovery?: () => boolean;
   setState: (state: State) => void;
   // Privates
   handleMessage: (msg: any) => void;


### PR DESCRIPTION
## Summary

Short-term VPN media-path workaround with a conservative escalation gate.

The SDK now uses existing call report stats to detect stalled VPN/non-relay media paths, but it **does not force relay on the first attach recovery**. First recovery stays on normal ICE behavior so the browser/server can recover naturally.

Relay-only recovery is requested only when an already recovered call stalls again on the recovered path. In that case, the next `telnyx_rtc.attach` creates the replacement call with `forceRelayCandidate: true` (`iceTransportPolicy: 'relay'`).

The stall detector remains intentionally narrow. Relay escalation requires:

- the existing call is already a recovered call (`recoveredCallId` is set)
- previous selected local candidate is VPN and non-relay
- recent stats show a stall signal:
  - ICE not writable
  - ICE transport `disconnected` / `failed`
  - ICE requests rising while responses stay flat
  - outbound bytes moving while inbound bytes stay flat

If the call was already relay-only, the selected path is not VPN, or this is the first attach recovery, behavior is unchanged.

## Why not force relay immediately?

Latest samples (`823254e5`, `38b3d7a4`) show NAT traversal over VPN srflx paths (`10.177/10.178.x.x` → `199.127.x.x`) where inbound RTP freezes and outbound continues. ICE restart / normal recovery should remain the first attempt while the socket is alive. Relay is now reserved for the case where the recovered path still stalls.

## Why the browser does not automatically pick TURN

TURN being available only means relay candidates are available to ICE. Browsers still prefer higher-priority direct/server-reflexive pairs when connectivity checks consider them viable. In the VPN flap case, the selected srflx VPN path can become writable/connected again from ICE's point of view while inbound RTP remains stalled/degraded, so the browser has no reason to automatically abandon that path for the lower-priority TURN relay. Forcing `iceTransportPolicy: 'relay'` on the next recovery peer connection is the deterministic escalation path.

## Tests

- `yarn jest packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts packages/js/src/Modules/Verto/tests/webrtc/VertoHandler.test.ts packages/js/src/Modules/Verto/tests/webrtc/Call.test.ts --runInBand`
- `yarn jest packages/js/src/Modules/Verto/tests/webrtc/VertoHandler.test.ts --runInBand`
- `yarn --cwd packages/js build`

Note: staged lint hook currently fails on pre-existing lint violations in `VertoHandler.test.ts`; focused tests and package build pass.
