### PR TITLE
fix: ignore late SDP responses after hangup

### DIFF
--- a/packages/js/src/Modules/Verto/tests/webrtc/Call.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/Call.test.ts
@@ -12,7 +12,7 @@ Object.defineProperty(global, 'performance', {
 });
 
 import { isQueued, register, deRegister } from '../../services/Handler';
-import { State } from '../../webrtc/constants';
+import { PeerType, State } from '../../webrtc/constants';
 import {
   ANSWER_WHILE_PEER_ACTIVE,
   DUPLICATE_INBOUND_ANSWER,
@@ -327,6 +327,35 @@ describe('Call', () => {
       await call.hangup({ cause: 'CUSTOM_CAUSE', causeCode: 99 }, false);
       expect(call.cause).toEqual('CUSTOM_CAUSE');
       expect(call.causeCode).toEqual(99);
+    });
+  });
+
+  describe('outbound invite response races', () => {
+    it('should not move a hung up outbound call back to trying when invite ACK arrives late', async () => {
+      let resolveInvite: (response: { node_id: string }) => void;
+      const inviteResponse = new Promise<{ node_id: string }>((resolve) => {
+        resolveInvite = resolve;
+      });
+      jest.spyOn(session, 'execute').mockReturnValue(inviteResponse);
+      const onTrickleIceSdp = (
+        Reflect.get(call, '_onTrickleIceSdp') as (
+          this: Call,
+          data: RTCSessionDescriptionInit
+        ) => void
+      ).bind(call);
+
+      onTrickleIceSdp({
+        type: PeerType.Offer,
+        sdp: 'v=0\no=- 1 2 IN IP4 127.0.0.1\ns=-',
+      });
+      expect(call.state).toEqual('requesting');
+
+      call.setState(State.Hangup);
+      resolveInvite({ node_id: 'late-node' });
+      await inviteResponse;
+      await Promise.resolve();
+
+      expect(call.state).toEqual('hangup');
     });
   });
 

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -1075,6 +1075,10 @@ export default abstract class BaseCall implements IWebRTCCall {
     this.setBandwidthEncodingsMaxBps(max, 'video');
   }
 
+  private _isTerminatingOrTerminated(): boolean {
+    return [State.Hangup, State.Destroy, State.Purge].includes(this._state);
+  }
+
   /**
    * Registers callback for stats.
    *
@@ -1667,6 +1671,12 @@ export default abstract class BaseCall implements IWebRTCCall {
     performance.mark(callMarkName(this.id, 'send-sdp'));
     this._execute(msg)
       .then((response) => {
+        if (this._isTerminatingOrTerminated()) {
+          logger.debug(
+            `[${this.id}] Ignoring ${type} response because call is ${this.state}`
+          );
+          return;
+        }
         const { node_id = null } = response;
         this._targetNodeId = node_id;
         if (type === PeerType.Offer) {
@@ -1755,6 +1765,12 @@ export default abstract class BaseCall implements IWebRTCCall {
     performance.mark(callMarkName(this.id, 'send-sdp'));
     this._execute(msg)
       .then((response) => {
+        if (this._isTerminatingOrTerminated()) {
+          logger.debug(
+            `[${this.id}] Ignoring ${type} response because call is ${this.state}`
+          );
+          return;
+        }
         const { node_id = null } = response;
         this._targetNodeId = node_id;
         if (type === PeerType.Offer) {


### PR DESCRIPTION
## Summary

- ignore late invite/answer SDP execute responses after the call has already moved to `hangup`, `destroy`, or `purge`
- prevent a delayed invite ACK from moving an already-hung-up outbound call back to `trying`
- adds regression coverage for the `requesting -> hangup -> trying` race

## Context

This is the state-race half split out of PR #623. The original observed sequence was:

```text
SEND telnyx_rtc.invite
state requesting -> hangup
SEND telnyx_rtc.bye
RECV invite result: CALL CREATED
state hangup -> trying
```

Once the SDK has locally terminated the call, the late SDP response should be ignored instead of reviving call state.

## Validation

- `yarn jest packages/js/src/Modules/Verto/tests/webrtc/Call.test.ts --runInBand`
