### PR TITLE
chore: release webrtc@2.27.0-beta.5

### DIFF
--- a/packages/js/CHANGELOG.md
+++ b/packages/js/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [2.27.0-beta.5](https://github.com/team-telnyx/webrtc/compare/webrtc/v2.27.0-beta.4...webrtc/v2.27.0-beta.5) (2026-05-21)
+
+- fix: recover VPN media stalls over relay (#642)
+- fix: ignore late SDP responses after hangup (#643)
+
 ## [2.26.4](https://github.com/team-telnyx/webrtc/compare/webrtc/v2.26.0...webrtc/v2.26.4) (2026-04-29)
 
 - docs: update ts docs

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telnyx/webrtc",
-  "version": "2.26.4",
+  "version": "2.27.0-beta.5",
   "description": "Telnyx WebRTC Client",
   "keywords": [
     "telnyx",


### PR DESCRIPTION
## Release webrtc@2.27.0-beta.5

Beta release prep created manually because previous 2.27.0 beta tags were direct release/tag commits and not ancestors of `main`.

Changes:
- Bumps `packages/js/package.json` to `2.27.0-beta.5`
- Prepends `packages/js/CHANGELOG.md` entry for `webrtc/v2.27.0-beta.5`
- Draft GitHub prerelease created for `webrtc/v2.27.0-beta.5`

Included changes since `webrtc/v2.27.0-beta.4`:
- fix: recover VPN media stalls over relay (#642)
- fix: ignore late SDP responses after hangup (#643)

Validation:
- `cd packages/js && yarn test` — 15 suites / 297 tests passed

Publish note:
- This release is still a draft. Publishing it from GitHub Releases will trigger `Publish release` and publish `@telnyx/webrtc@2.27.0-beta.5` to npm with dist-tag `beta`.