### PR TITLE
fix: preflight microphone availability before media capture

### DIFF
--- a/packages/js/src/Modules/Verto/tests/webrtc/helpers.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/helpers.test.ts
@@ -10,6 +10,7 @@ import {
   getWebRTCSupportedBrowserList,
   SUPPORTED_WEBRTC,
   getUserMedia,
+  preflightAudioInput,
   isDeviceNotFoundError,
   getConstraintsWithoutDeviceId,
 } from '../../webrtc/helpers';
@@ -766,6 +767,60 @@ describe('Helpers browser functions', () => {
     // navigator.mediaDevices is reset between describe blocks in this test file.
     // The fallback logic is tested via the isDeviceNotFoundError and
     // getConstraintsWithoutDeviceId unit tests above.
+  });
+
+  describe('preflightAudioInput', () => {
+    beforeEach(() => {
+      Object.defineProperty(global, 'navigator', {
+        value: {
+          mediaDevices: {
+            enumerateDevices: jest.fn().mockResolvedValue([
+              {
+                deviceId: 'mic-1',
+                kind: 'audioinput',
+                label: 'Microphone',
+                groupId: 'group-1',
+              },
+            ]),
+            getUserMedia: jest.fn(async () => new MediaStream()),
+          },
+        },
+        writable: true,
+      });
+    });
+
+    it('should probe microphone access when no audioinput is enumerated', async () => {
+      const enumerateDevices = navigator.mediaDevices
+        .enumerateDevices as jest.Mock;
+      const getUserMediaMock = navigator.mediaDevices.getUserMedia as jest.Mock;
+
+      enumerateDevices.mockResolvedValueOnce([
+        {
+          deviceId: 'camera-1',
+          kind: 'videoinput',
+          label: 'Camera',
+          groupId: 'group-1',
+        },
+      ]);
+      getUserMediaMock.mockClear();
+
+      await preflightAudioInput(true);
+
+      expect(getUserMediaMock).toHaveBeenCalledWith({
+        audio: true,
+        video: false,
+      });
+
+    });
+
+    it('should not probe microphone access when an audioinput is enumerated', async () => {
+      const getUserMediaMock = navigator.mediaDevices.getUserMedia as jest.Mock;
+      getUserMediaMock.mockClear();
+
+      await preflightAudioInput(true);
+
+      expect(getUserMediaMock).not.toHaveBeenCalled();
+    });
   });
 
   describe('detachMediaStream', () => {

--- a/packages/js/src/Modules/Verto/webrtc/Peer.ts
+++ b/packages/js/src/Modules/Verto/webrtc/Peer.ts
@@ -47,6 +47,7 @@ import {
   getMediaConstraints,
   getPreferredCodecs,
   getUserMedia,
+  preflightAudioInput,
 } from './helpers';
 import { IVertoCallOptions } from './interfaces';
 
@@ -965,6 +966,7 @@ export default class Peer {
     if (streamIsValid(this.options.localStream)) {
       return this.options.localStream;
     }
+    await preflightAudioInput(this.options.audio);
     const constraints = await getMediaConstraints(this.options);
     return getUserMedia(constraints);
   }

--- a/packages/js/src/Modules/Verto/webrtc/helpers.ts
+++ b/packages/js/src/Modules/Verto/webrtc/helpers.ts
@@ -53,6 +53,31 @@ const getConstraintsWithoutDeviceId = (
   return { audio: newAudio, video: newVideo };
 };
 
+const preflightAudioInput = async (
+  audio: boolean | MediaTrackConstraints
+): Promise<void> => {
+  if (!audio || typeof navigator === 'undefined' || !navigator.mediaDevices) {
+    return;
+  }
+
+  const devices = await navigator.mediaDevices
+    .enumerateDevices()
+    .catch((error) => {
+      logger.warn('Unable to enumerate media devices before getUserMedia', error);
+      return [] as MediaDeviceInfo[];
+    });
+
+  if (devices.some((device) => device.kind === DeviceType.AudioIn)) {
+    return;
+  }
+
+  logger.warn(
+    'No audio input devices reported before getUserMedia; probing microphone access'
+  );
+  const stream = await WebRTC.getUserMedia({ audio: true, video: false });
+  WebRTC.stopStream(stream);
+};
+
 const getUserMedia = async (
   constraints: MediaStreamConstraints
 ): Promise<MediaStream | null> => {
@@ -849,6 +874,7 @@ export {
   stopAudio,
   hasVideo,
   getPreferredCodecs,
+  preflightAudioInput,
   // Exported for testing
   isDeviceNotFoundError,
   getConstraintsWithoutDeviceId,


### PR DESCRIPTION
## Summary
- add a microphone preflight before `getUserMedia()` when audio capture is requested
- enumerate available input devices first and probe `{ audio: true }` when no audio inputs are reported
- preserve existing call flow while surfacing structured warnings for preflight/enumeration failures

## Test plan
- `yarn workspace @telnyx/webrtc test packages/js/src/Modules/Verto/tests/webrtc/helpers.test.ts --runInBand`
