### PR TITLE
feat: recover outbound media capture failures

### DIFF
--- a/packages/js/docs/error-handling.md
+++ b/packages/js/docs/error-handling.md
@@ -78,7 +78,7 @@ type ITelnyxErrorEvent =
   | ITelnyxMediaRecoveryErrorEvent;
 ```
 
-`recoverable: true` is used only for inbound media-permission recovery when `mediaPermissionsRecovery.enabled` is configured and the initial `getUserMedia()` attempt fails while answering a call.
+`recoverable: true` is used for media-permission/device recovery when `mediaPermissionsRecovery.enabled` is configured and the initial `getUserMedia()` attempt fails while creating local media for an inbound or outbound call.
 
 ### Basic example
 
@@ -442,4 +442,4 @@ The SDK still exposes low-level RTC events, but new integrations should prefer `
 3. Keep `telnyx.notification` for `callUpdate` and any compatibility notifications you still depend on.
 4. Treat `telnyx.ready` as the only readiness signal.
 5. Prefer `TELNYX_ERROR_CODES` and `TELNYX_WARNING_CODES` over hard-coded numeric literals.
-6. If you support inbound permission recovery, enable `mediaPermissionsRecovery` and handle `isMediaRecoveryErrorEvent(event)`.
+6. If you support media permission/device recovery, enable `mediaPermissionsRecovery` and handle `isMediaRecoveryErrorEvent(event)`.

--- a/packages/js/src/Modules/Verto/tests/webrtc/Call.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/Call.test.ts
@@ -436,6 +436,51 @@ describe('Call', () => {
       expect(startNegotiationSpy).not.toHaveBeenCalled();
     });
 
+    it('invite() should emit recoverable media error and retry when recovery is enabled', async () => {
+      session.options.mediaPermissionsRecovery = {
+        enabled: true,
+        timeout: 1000,
+        onSuccess: jest.fn(),
+        onError: jest.fn(),
+      };
+      const recoveredStream = new MediaStream();
+      const retrieveLocalStreamSpy = jest
+        .spyOn(
+          Peer.prototype as unknown as {
+            _retrieveLocalStream: () => Promise<MediaStream>;
+          },
+          '_retrieveLocalStream'
+        )
+        .mockRejectedValueOnce(mediaError)
+        .mockResolvedValueOnce(recoveredStream);
+      const hangupSpy = jest.spyOn(call, 'hangup').mockResolvedValue(undefined);
+      const errorHandler = jest.fn((event) => {
+        if (event.recoverable) {
+          event.resume();
+        }
+      });
+
+      register(SwEvent.Error, errorHandler, session.uuid);
+
+      await call.invite();
+
+      expect(errorHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          callId: call.id,
+          recoverable: true,
+          resume: expect.any(Function),
+          reject: expect.any(Function),
+        })
+      );
+      expect(retrieveLocalStreamSpy).toHaveBeenCalledTimes(2);
+      expect(session.options.mediaPermissionsRecovery.onSuccess).toHaveBeenCalled();
+      expect(session.options.mediaPermissionsRecovery.onError).not.toHaveBeenCalled();
+      expect(call.options.localStream).toBe(recoveredStream);
+      expect(hangupSpy).not.toHaveBeenCalled();
+
+      deRegister(SwEvent.Error, undefined, session.uuid);
+    });
+
     it('answer() should call hangup and not proceed with negotiation when media fails', async () => {
       jest
         .spyOn(

--- a/packages/js/src/Modules/Verto/util/errors.ts
+++ b/packages/js/src/Modules/Verto/util/errors.ts
@@ -67,7 +67,7 @@ export interface ITelnyxMediaRecoveryErrorEvent {
   error: ITelnyxMediaError;
   /** Current SDK session identifier */
   sessionId: string;
-  /** Inbound call being recovered */
+  /** Call being recovered */
   callId: string;
   /** Indicates that the app can still recover by resuming the flow */
   recoverable: true;

--- a/packages/js/src/Modules/Verto/util/interfaces.ts
+++ b/packages/js/src/Modules/Verto/util/interfaces.ts
@@ -105,11 +105,11 @@ export interface IVertoOptions {
   skipLastVoiceSdkId?: boolean;
 
   /**
-   * Configuration for media permissions recovery on inbound calls.
-   * When enabled and the initial `getUserMedia` call fails while answering,
-   * the SDK emits a recoverable `telnyx.error` event with `resume()` and
-   * `reject()` callbacks so the app can prompt the user to fix permissions
-   * before the call fails.
+   * Configuration for media permissions recovery on inbound and outbound calls.
+   * When enabled and the initial `getUserMedia` call fails while creating local
+   * media, the SDK emits a recoverable `telnyx.error` event with `resume()` and
+   * `reject()` callbacks so the app can prompt the user to fix permissions or
+   * reconnect/select a microphone before the call fails.
    */
   mediaPermissionsRecovery?: {
     /** Enable the recovery flow. */

--- a/packages/js/src/Modules/Verto/webrtc/Peer.ts
+++ b/packages/js/src/Modules/Verto/webrtc/Peer.ts
@@ -481,10 +481,10 @@ export default class Peer {
       async (error) => {
         const recovery = this._session.options.mediaPermissionsRecovery;
 
-        // Only run recovery for answers. We keep the invite flow simple so the
-        // caller can fix local media issues and start the call again without
-        // requiring extra recovery handling from us.
-        if (recovery?.enabled && this._isAnswer()) {
+        // Recovery is opt-in and applies to local media capture for both
+        // outbound offers and inbound answers. Receive-only calls can proceed
+        // without local media and should not block on recovery.
+        if (recovery?.enabled && !isReceiveOnly) {
           let recoveredStream: MediaStream | null = null;
           let safetyTimeout: ReturnType<typeof setTimeout> | null = null;
 

--- a/packages/js/src/utils/interfaces.ts
+++ b/packages/js/src/utils/interfaces.ts
@@ -212,16 +212,15 @@ export interface IClientOptions {
   callReportFlushInterval?: number;
 
   /**
-   * Configuration for media permissions recovery on inbound calls.
-   * When enabled and the initial `getUserMedia` call fails while answering,
-   * the SDK emits a recoverable `telnyx.error` event with `resume()` and
-   * `reject()` callbacks so the app can prompt the user to fix permissions
-   * before the call fails.
+   * Configuration for media permissions recovery on inbound and outbound calls.
+   * When enabled and the initial `getUserMedia` call fails while creating local
+   * media, the SDK emits a recoverable `telnyx.error` event with `resume()` and
+   * `reject()` callbacks so the app can prompt the user to fix permissions or
+   * reconnect/select a microphone before the call fails.
    *
-   * Recovery is attempted only for inbound calls. If the app calls
-   * `resume()`, the SDK retries `getUserMedia`. If the app calls `reject()`
-   * or does not respond before `timeout`, recovery fails and the call is
-   * terminated with the usual media error flow.
+   * If the app calls `resume()`, the SDK retries `getUserMedia`. If the app
+   * calls `reject()` or does not respond before `timeout`, recovery fails and
+   * the call is terminated with the usual media error flow.
    *
    * @example
    * ```js


### PR DESCRIPTION
## Summary
- extend opt-in `mediaPermissionsRecovery` to outbound local media capture failures
- emit the existing recoverable media error event so apps can prompt the user and call `resume()`
- keep receive-only behavior unchanged and update docs/types from inbound-only to inbound/outbound

## Test plan
- `yarn workspace @telnyx/webrtc test packages/js/src/Modules/Verto/tests/webrtc/Call.test.ts --runInBand`
