### PR TITLE
fix: recover reattached calls through socket reconnect

### DIFF
--- a/packages/js/src/Modules/Verto/BaseSession.ts
+++ b/packages/js/src/Modules/Verto/BaseSession.ts
@@ -13,6 +13,7 @@ import SignalingHealthMonitor from './services/SignalingHealthMonitor';
 import type {
   ISignalingHealthSession,
   PeerFailureEvidence,
+  TriggerIceRestartResult,
 } from './util/interfaces/SignalingHealth';
 import { State } from './webrtc/constants';
 import {
@@ -1036,12 +1037,16 @@ export default abstract class BaseSession {
    * Called by the health monitor when media/peer is unhealthy but
    * signaling is healthy.
    */
-  triggerIceRestart(callId: string): void {
+  triggerIceRestart(callId: string): TriggerIceRestartResult {
     const calls = (
       this as unknown as {
         calls?: Record<
           string,
-          { peer?: { restartIce?: () => RestartIceResult } }
+          {
+            options?: { attach?: boolean };
+            recoveredCallId?: string;
+            peer?: { restartIce?: () => RestartIceResult };
+          }
         >;
       }
     ).calls;
@@ -1050,14 +1055,26 @@ export default abstract class BaseSession {
       logger.warn(
         `Signaling health: cannot trigger ICE restart — call ${callId} not found`
       );
-      return;
+      return { started: false, reason: 'call not found' };
     }
+
+    if (call.options?.attach || call.recoveredCallId) {
+      logger.warn(
+        `Signaling health: ICE restart skipped for call ${callId}: call was recovered via attach`
+      );
+      return {
+        started: false,
+        reason: 'call recovered via attach',
+        recoverSignaling: true,
+      };
+    }
+
     const peer = call.peer;
     if (!peer?.restartIce) {
       logger.warn(
         `Signaling health: cannot trigger ICE restart — no peer for call ${callId}`
       );
-      return;
+      return { started: false, reason: 'no peer' };
     }
     const result = peer.restartIce();
     if (!result.started) {
@@ -1065,6 +1082,7 @@ export default abstract class BaseSession {
         `Signaling health: ICE restart skipped for call ${callId}: ${result.reason}`
       );
     }
+    return result;
   }
 
   /**

--- a/packages/js/src/Modules/Verto/services/SignalingHealthMonitor.ts
+++ b/packages/js/src/Modules/Verto/services/SignalingHealthMonitor.ts
@@ -43,6 +43,7 @@ const RECENT_ACTIVITY_THRESHOLD_MS = 3 * 1000;
 type PendingMediaRecovery = {
   callId: string;
   reason: string;
+  source: 'peer_failure' | 'no_rtp';
 };
 
 /**
@@ -176,7 +177,7 @@ export default class SignalingHealthMonitor {
       logger.info(
         `Signaling health: signaling probe resolved, triggering pending ICE restart for call ${pending.callId}`
       );
-      this._triggerIceRestart(pending.callId, pending.reason);
+      this._triggerIceRestart(pending.callId, pending.reason, pending.source);
     }
   }
 
@@ -394,7 +395,7 @@ export default class SignalingHealthMonitor {
       logger.info(
         `Signaling health: signaling is healthy, triggering ICE restart for call ${callId}`
       );
-      this._triggerIceRestart(callId, mediaReason);
+      this._triggerIceRestart(callId, mediaReason, signalingSource);
       return;
     }
 
@@ -402,7 +403,11 @@ export default class SignalingHealthMonitor {
       logger.info(
         `Signaling health: signaling health is unknown, deferring ICE restart decision for call ${callId}`
       );
-      this._pendingMediaRecovery = { callId, reason: mediaReason };
+      this._pendingMediaRecovery = {
+        callId,
+        reason: mediaReason,
+        source: signalingSource,
+      };
       this._probeIfNeeded(
         `${signalingSource} detected with stale/unknown signaling`
       );
@@ -493,7 +498,29 @@ export default class SignalingHealthMonitor {
    * @param callId The call to restart ICE on.
    * @param reason Human-readable reason for diagnostics.
    */
-  private _triggerIceRestart(callId: string, reason: string): void {
+  private _triggerIceRestart(
+    callId: string,
+    reason: string,
+    signalingSource: 'peer_failure' | 'no_rtp'
+  ): void {
+    logger.info(`Signaling health: triggering ICE restart for call ${callId}`);
+    const result = this._session.triggerIceRestart(callId);
+
+    if (!result.started) {
+      logger.info(
+        `Signaling health: ICE restart not started for call ${callId}: ${result.reason}`
+      );
+
+      if (result.recoverSignaling) {
+        this._triggerSignalingRecovery(
+          `${reason}; ICE restart disabled for reattached call, forcing socket reconnect`,
+          signalingSource
+        );
+      }
+
+      return;
+    }
+
     const warning = createTelnyxWarning(MEDIA_RECOVERY_REQUIRED);
     trigger(
       SwEvent.Warning,
@@ -505,8 +532,5 @@ export default class SignalingHealthMonitor {
       },
       this._session.uuid
     );
-
-    logger.info(`Signaling health: triggering ICE restart for call ${callId}`);
-    this._session.triggerIceRestart(callId);
   }
 }

--- a/packages/js/src/Modules/Verto/tests/signaling-health/SignalingHealth.test.ts
+++ b/packages/js/src/Modules/Verto/tests/signaling-health/SignalingHealth.test.ts
@@ -817,7 +817,7 @@ describe('SignalingHealthMonitor – Recovery decision logic', () => {
     mockSession = makeMockSession();
     // Add the methods ISignalingHealthSession expects
     mockSession.hasActiveCall = jest.fn(() => true);
-    mockSession.triggerIceRestart = jest.fn();
+    mockSession.triggerIceRestart = jest.fn(() => ({ started: true }));
     mockSession.socketDisconnect = jest.fn();
     connection = new Connection(mockSession);
     connection.connect();
@@ -992,6 +992,80 @@ describe('SignalingHealthMonitor – Recovery decision logic', () => {
     // No recovery should be triggered
     expect(mockSession.triggerIceRestart).not.toHaveBeenCalled();
     expect(mockSession.socketDisconnect).not.toHaveBeenCalled();
+  });
+
+  it('recovers reattached calls through socket reconnect instead of ICE restart', () => {
+    mockSession.connection = connection;
+    mockSession.triggerIceRestart.mockReturnValue({
+      started: false,
+      reason: 'call recovered via attach',
+      recoverSignaling: true,
+    });
+    monitor.onSocketActivity();
+
+    monitor.onPeerFailure('call-1', 'ice_failed');
+
+    expect(mockSession.triggerIceRestart).toHaveBeenCalledWith('call-1');
+    expect(mockSession.socketDisconnect).toHaveBeenCalledTimes(1);
+    expect(trigger).toHaveBeenCalledWith(
+      SwEvent.Warning,
+      expect.objectContaining({ source: 'peer_failure' }),
+      mockSession.uuid
+    );
+    expect(trigger).not.toHaveBeenCalledWith(
+      SwEvent.Warning,
+      expect.objectContaining({ callId: 'call-1' }),
+      mockSession.uuid
+    );
+  });
+
+  it('BaseSession.triggerIceRestart skips calls created by attach recovery', () => {
+    const restartIce = jest.fn(() => ({ started: true }));
+    const sessionLike = {
+      calls: {
+        'call-1': {
+          options: { attach: true },
+          peer: { restartIce },
+        },
+      },
+    };
+
+    const result = BaseSession.prototype.triggerIceRestart.call(
+      sessionLike as any,
+      'call-1'
+    );
+
+    expect(restartIce).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      started: false,
+      reason: 'call recovered via attach',
+      recoverSignaling: true,
+    });
+  });
+
+  it('BaseSession.triggerIceRestart skips calls with recoveredCallId', () => {
+    const restartIce = jest.fn(() => ({ started: true }));
+    const sessionLike = {
+      calls: {
+        'call-1': {
+          recoveredCallId: 'previous-call-1',
+          options: {},
+          peer: { restartIce },
+        },
+      },
+    };
+
+    const result = BaseSession.prototype.triggerIceRestart.call(
+      sessionLike as any,
+      'call-1'
+    );
+
+    expect(restartIce).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      started: false,
+      reason: 'call recovered via attach',
+      recoverSignaling: true,
+    });
   });
 
   it('BaseSession.execute rethrows stale request errors without invoking signaling recovery', async () => {

--- a/packages/js/src/Modules/Verto/util/interfaces/SignalingHealth.ts
+++ b/packages/js/src/Modules/Verto/util/interfaces/SignalingHealth.ts
@@ -5,6 +5,12 @@ import type Connection from '../../services/Connection';
  */
 export type PeerFailureEvidence = 'ice_failed' | 'connection_failed';
 
+export type TriggerIceRestartResult = {
+  started: boolean;
+  reason?: string;
+  recoverSignaling?: boolean;
+};
+
 /**
  * Interface that SignalingHealthMonitor uses to interact with its owning session.
  * Decouples the monitor from BaseSession so it can be extracted into its own file
@@ -21,5 +27,5 @@ export interface ISignalingHealthSession {
    * Called by the health monitor when media/peer is unhealthy but
    * signaling is healthy.
    */
-  triggerIceRestart(callId: string): void;
+  triggerIceRestart(callId: string): TriggerIceRestartResult;
 }


### PR DESCRIPTION
## Summary
- detect calls recovered through `telnyx_rtc.attach` / reattach before calling `restartIce()`
- route those reattached-call media failures through socket reconnect + reattach recovery instead of ICE restart
- return a structured ICE restart result so the health monitor can distinguish normal ICE restart, skipped restart, and signaling-recovery fallback
- avoid emitting `MEDIA_RECOVERY_REQUIRED` when ICE restart is intentionally bypassed for reattached calls
- add regression coverage for attach/recovered calls and socket-reconnect fallback behavior

## Context
For calls re-attached after signaling recovery, triggering another ICE restart can break media. This keeps the reattach flow unchanged and only changes the later SDK media-recovery decision: normal calls still use `restartIce()`, but recovered/reattached calls force WebSocket reconnect so the existing socket reconnection + attach path recovers the call.

## Verification
- [x] `yarn jest src/Modules/Verto/tests/signaling-health/SignalingHealth.test.ts --runInBand`
- [x] `../../node_modules/.bin/tsc --noEmit --project tsconfig.json`
- [x] `yarn eslint src/Modules/Verto/BaseSession.ts src/Modules/Verto/services/SignalingHealthMonitor.ts src/Modules/Verto/util/interfaces/SignalingHealth.ts src/Modules/Verto/tests/signaling-health/SignalingHealth.test.ts`
- [x] `git diff --check`

Note: full `yarn lint` still fails on existing repository-wide lint/doc issues unrelated to this change.
