### PR TITLE
fix: allow disabling beforeunload BYE

### DIFF
--- a/packages/js/src/Modules/Verto/index.ts
+++ b/packages/js/src/Modules/Verto/index.ts
@@ -28,21 +28,24 @@ export default class Verto extends BrowserSession {
   constructor(options: IVertoOptions) {
     super(options);
     this._vertoHandler = new VertoHandler(this);
-    // hang up current call when browser closes or refreshes.
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    window.addEventListener('beforeunload', (_e) => {
-      if (this.calls) {
-        Object.keys(this.calls).forEach((callId) => {
-          if (this.calls[callId]) {
-            logger.info(`Hanging up call due to window unload: ${callId}`);
-            void this.calls[callId].hangup(
-              { initiator: 'sdk:beforeunload' },
-              true
-            );
-          }
-        });
-      }
-    });
+
+    if (options.hangupOnBeforeUnload !== false) {
+      // hang up current call when browser closes or refreshes.
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      window.addEventListener('beforeunload', (_e) => {
+        if (this.calls) {
+          Object.keys(this.calls).forEach((callId) => {
+            if (this.calls[callId]) {
+              logger.info(`Hanging up call due to window unload: ${callId}`);
+              void this.calls[callId].hangup(
+                { initiator: 'sdk:beforeunload' },
+                true
+              );
+            }
+          });
+        }
+      });
+    }
   }
 
   validateOptions() {

--- a/packages/js/src/Modules/Verto/tests/Verto.test.ts
+++ b/packages/js/src/Modules/Verto/tests/Verto.test.ts
@@ -2,6 +2,7 @@ import behaveLikeBaseSession from './behaveLike/BaseSession.spec';
 import { isQueued } from '../services/Handler';
 import Verto, { VERTO_PROTOCOL } from '..';
 import { IVertoOptions } from '../util/interfaces';
+import { IWebRTCCall } from '../webrtc/interfaces';
 import {
   DEFAULT_DEV_ICE_SERVERS,
   DEFAULT_PROD_ICE_SERVERS,
@@ -46,6 +47,57 @@ describe('Verto', () => {
 
   it('should instantiate Verto with default methods', () => {
     expect(instance).toBeInstanceOf(Verto);
+  });
+
+  describe('beforeunload hangup', () => {
+    it('should attempt a BYE for active calls on page unload by default', () => {
+      const addEventListenerSpy = jest.spyOn(window, 'addEventListener');
+      addEventListenerSpy.mockClear();
+
+      const telnyxRTC = _buildInstance({
+        host: 'example.telnyx.com',
+        login: 'login',
+        password: 'password',
+      });
+      const hangup = jest.fn();
+      telnyxRTC.calls = {
+        callA: { hangup } as unknown as IWebRTCCall,
+      };
+
+      const beforeUnloadHandler = addEventListenerSpy.mock.calls.find(
+        ([eventName]) => eventName === 'beforeunload'
+      )?.[1] as EventListener;
+
+      expect(beforeUnloadHandler).toBeDefined();
+      beforeUnloadHandler(new Event('beforeunload'));
+
+      expect(hangup).toHaveBeenCalledWith(
+        { initiator: 'sdk:beforeunload' },
+        true
+      );
+
+      addEventListenerSpy.mockRestore();
+    });
+
+    it('should allow applications to disable page unload BYE', () => {
+      const addEventListenerSpy = jest.spyOn(window, 'addEventListener');
+      addEventListenerSpy.mockClear();
+
+      _buildInstance({
+        host: 'example.telnyx.com',
+        login: 'login',
+        password: 'password',
+        hangupOnBeforeUnload: false,
+      });
+
+      expect(
+        addEventListenerSpy.mock.calls.some(
+          ([eventName]) => eventName === 'beforeunload'
+        )
+      ).toBe(false);
+
+      addEventListenerSpy.mockRestore();
+    });
   });
 
   it('should set env equal production ', () => {

--- a/packages/js/src/Modules/Verto/util/interfaces.ts
+++ b/packages/js/src/Modules/Verto/util/interfaces.ts
@@ -35,6 +35,15 @@ export interface IVertoOptions {
    * when the WebSocket connection is closed unexpectedly (e.g. network interruption, device sleep, etc).
    */
   keepConnectionAliveOnSocketClose?: boolean;
+  /**
+   * Controls whether the SDK attempts to send BYE for active calls during
+   * browser page unload. Enabled by default to preserve graceful call cleanup,
+   * but applications that handle page lifecycle themselves can disable it to
+   * avoid best-effort unload BYE races.
+   *
+   * @default true
+   */
+  hangupOnBeforeUnload?: boolean;
   useCanaryRtcServer?: boolean;
   region?: string;
   /**

--- a/packages/js/src/utils/interfaces.ts
+++ b/packages/js/src/utils/interfaces.ts
@@ -97,6 +97,16 @@ export interface IClientOptions {
   keepConnectionAliveOnSocketClose?: boolean;
 
   /**
+   * Controls whether the SDK attempts to send BYE for active calls during
+   * browser page unload. Enabled by default to preserve graceful call cleanup,
+   * but applications that handle page lifecycle themselves can disable it to
+   * avoid best-effort unload BYE races.
+   *
+   * @default true
+   */
+  hangupOnBeforeUnload?: boolean;
+
+  /**
    * Region to use for the connection.
    */
   region?: string;


### PR DESCRIPTION
## Summary
- add `hangupOnBeforeUnload` client option, defaulting to current behavior
- skip registering the SDK beforeunload BYE handler when `hangupOnBeforeUnload: false`
- add Verto tests for default beforeunload BYE and disabled behavior

## Why
`beforeunload` can represent refresh/navigation/page lifecycle transitions, not always an intentional user hangup. This keeps backwards-compatible graceful cleanup by default while letting apps that manage page lifecycle themselves avoid best-effort unload BYE races.

## Test plan
- `yarn run test packages/js/src/Modules/Verto/tests/Verto.test.ts packages/js/src/Modules/Verto/tests/webrtc/VertoHandler.test.ts packages/js/src/Modules/Verto/tests/behaveLike/BaseSession.spec.ts packages/js/src/Modules/Verto/tests/ReconnectAttempts.test.ts --runInBand`