### PR TITLE
fix: relax signaling health probe cadence

### DIFF
--- a/packages/js/src/Modules/Verto/services/SignalingHealthMonitor.ts
+++ b/packages/js/src/Modules/Verto/services/SignalingHealthMonitor.ts
@@ -20,7 +20,7 @@ import { VertoMethod } from '../webrtc/constants';
  * Threshold (ms) of WS silence during an active call before a health
  * probe (Ping) is sent.
  */
-const PROBE_THRESHOLD_MS = 12 * 1000; // 12s silence → probe
+const PROBE_THRESHOLD_MS = 20 * 1000; // 20s silence → probe
 
 /**
  * After sending a health probe, if no inbound WS activity of any kind

--- a/packages/js/src/Modules/Verto/tests/signaling-health/SignalingHealth.test.ts
+++ b/packages/js/src/Modules/Verto/tests/signaling-health/SignalingHealth.test.ts
@@ -966,7 +966,7 @@ describe('SignalingHealthMonitor – Recovery decision logic', () => {
 
     monitor.start();
     (monitor as any)._lastInboundAt = 0;
-    jest.advanceTimersByTime(12_001);
+    jest.advanceTimersByTime(21_001);
 
     expect(connection.send).toHaveBeenCalledTimes(1);
     expect(monitor.isProbeInFlight).toBe(true);


### PR DESCRIPTION
## Summary
- increase the signaling health silence threshold from 12s to 20s before sending a probe Ping
- update the focused signaling-health test for the new threshold

## Validation
- `yarn jest packages/js/src/Modules/Verto/tests/Verto.test.ts packages/js/src/Modules/Verto/tests/signaling-health/SignalingHealth.test.ts --runInBand`
- `yarn workspace @telnyx/webrtc build`

## Notes
- The requested `hangupOnBeforeUnload` default change was removed from this PR; this only adjusts the signaling health probe cadence.
