### PR TITLE
fix: include sessid on reconnect login

### DIFF
--- a/packages/js/src/Modules/Verto/BaseSession.ts
+++ b/packages/js/src/Modules/Verto/BaseSession.ts
@@ -44,7 +44,12 @@ import {
 } from './util/interfaces';
 import type { INotification } from '../../utils/interfaces';
 import logger, { setConsoleLoggerMinLevel } from './util/logger';
-import { getReconnectToken, clearReconnectToken } from './util/reconnect';
+import {
+  getReconnectSessionId,
+  getReconnectToken,
+  clearReconnectToken,
+  setReconnectSessionId,
+} from './util/reconnect';
 import { Ping } from './messages/verto/Ping';
 import { Login } from './messages/Verto';
 import { AnonymousLogin } from './messages/verto/AnonymousLogin';
@@ -667,14 +672,19 @@ export default abstract class BaseSession {
     onError?: (error: any) => void;
   }): Promise<void> {
     let msg: Login | AnonymousLogin;
+    const reconnectToken = getReconnectToken();
+    const isReconnection = !!reconnectToken;
+    const reconnectSessionId =
+      this.sessionid || (isReconnection ? getReconnectSessionId() : null) || '';
+
     if (type === 'login') {
       msg = new Login(
         this.options.login,
         this.options.password || this.options.passwd,
         this.options.login_token,
-        this.sessionid,
+        reconnectSessionId,
         this.options.userVariables,
-        !!getReconnectToken()
+        isReconnection
       );
     } else {
       msg = new AnonymousLogin({
@@ -682,9 +692,9 @@ export default abstract class BaseSession {
         target_type: this.options.anonymous_login.target_type,
         target_version_id: this.options.anonymous_login.target_version_id,
         target_params: this.options.anonymous_login.target_params,
-        sessionId: this.sessionid,
+        sessionId: reconnectSessionId,
         userVariables: this.options.userVariables,
-        reconnection: !!getReconnectToken(),
+        reconnection: isReconnection,
       });
     }
 
@@ -695,6 +705,9 @@ export default abstract class BaseSession {
 
     if (response) {
       this.sessionid = response.sessid;
+      if (this.sessionid) {
+        setReconnectSessionId(this.sessionid);
+      }
       this._checkTokenExpiry();
       if (onSuccess) onSuccess();
     }

--- a/packages/js/src/Modules/Verto/BaseSession.ts
+++ b/packages/js/src/Modules/Verto/BaseSession.ts
@@ -674,12 +674,8 @@ export default abstract class BaseSession {
     let msg: Login | AnonymousLogin;
     const reconnectToken = getReconnectToken();
     const isReconnection = !!reconnectToken;
-    const shouldRestoreSessionIdFromStorage =
-      isReconnection && this.options.hangupOnBeforeUnload === false;
     const reconnectSessionId =
-      this.sessionid ||
-      (shouldRestoreSessionIdFromStorage ? getReconnectSessionId() : null) ||
-      '';
+      this.sessionid || (isReconnection ? getReconnectSessionId() : null) || '';
 
     if (type === 'login') {
       msg = new Login(

--- a/packages/js/src/Modules/Verto/BaseSession.ts
+++ b/packages/js/src/Modules/Verto/BaseSession.ts
@@ -674,8 +674,12 @@ export default abstract class BaseSession {
     let msg: Login | AnonymousLogin;
     const reconnectToken = getReconnectToken();
     const isReconnection = !!reconnectToken;
+    const shouldRestoreSessionIdFromStorage =
+      isReconnection && this.options.hangupOnBeforeUnload === false;
     const reconnectSessionId =
-      this.sessionid || (isReconnection ? getReconnectSessionId() : null) || '';
+      this.sessionid ||
+      (shouldRestoreSessionIdFromStorage ? getReconnectSessionId() : null) ||
+      '';
 
     if (type === 'login') {
       msg = new Login(

--- a/packages/js/src/Modules/Verto/BaseSession.ts
+++ b/packages/js/src/Modules/Verto/BaseSession.ts
@@ -48,6 +48,7 @@ import {
   getReconnectSessionId,
   getReconnectToken,
   clearReconnectToken,
+  isReconnectSessionIdFresh,
   setReconnectSessionId,
 } from './util/reconnect';
 import { Ping } from './messages/verto/Ping';
@@ -674,8 +675,11 @@ export default abstract class BaseSession {
     let msg: Login | AnonymousLogin;
     const reconnectToken = getReconnectToken();
     const isReconnection = !!reconnectToken;
-    const reconnectSessionId =
-      this.sessionid || (isReconnection ? getReconnectSessionId() : null) || '';
+    const reconnectSessionId = isReconnection
+      ? (this.sessionid && isReconnectSessionIdFresh()
+          ? this.sessionid
+          : getReconnectSessionId()) || ''
+      : '';
 
     if (type === 'login') {
       msg = new Login(
@@ -816,6 +820,10 @@ export default abstract class BaseSession {
     clearTimeout(this._keepAliveTimeout);
     clearTimeout(this._reconnectTimeout);
     this.stopSignalingHealthMonitor();
+
+    if (this.sessionid && this._autoReconnect) {
+      setReconnectSessionId(this.sessionid);
+    }
 
     // Reset gateway state on socket close so telnyx.ready fires again on reconnection
     if (this.connection) {

--- a/packages/js/src/Modules/Verto/tests/Verto.test.ts
+++ b/packages/js/src/Modules/Verto/tests/Verto.test.ts
@@ -11,6 +11,7 @@ import {
   clearReconnectToken,
   getReconnectSessionId,
   getReconnectToken,
+  RECONNECT_SESSION_ID_MAX_AGE_MS,
   setReconnectSessionId,
   setReconnectToken,
 } from '../util/reconnect';
@@ -185,6 +186,26 @@ describe('Verto', () => {
       const { request } = Connection.mockSend.mock.calls[0][0];
       expect(request.method).toBe('login');
       expect(request.params.reconnection).toBe(false);
+      expect(request.params.sessid).toBeUndefined();
+    });
+
+    it('should not include the persisted sessid when it is older than 90 seconds', async () => {
+      setReconnectToken('voice-sdk-id');
+      setReconnectSessionId(
+        'previous-sessid',
+        Date.now() - 1 - RECONNECT_SESSION_ID_MAX_AGE_MS
+      );
+      Connection.mockResponse.mockImplementationOnce(() =>
+        JSON.parse(
+          '{"jsonrpc":"2.0","id":77,"result":{"message":"logged in","sessid":"new-sessid"}}'
+        )
+      );
+
+      await instance.login();
+
+      const { request } = Connection.mockSend.mock.calls[0][0];
+      expect(request.method).toBe('login');
+      expect(request.params.reconnection).toBe(true);
       expect(request.params.sessid).toBeUndefined();
     });
 

--- a/packages/js/src/Modules/Verto/tests/Verto.test.ts
+++ b/packages/js/src/Modules/Verto/tests/Verto.test.ts
@@ -120,8 +120,7 @@ describe('Verto', () => {
   });
 
   describe('reconnect login', () => {
-    it('should include the persisted sessid only when unload hangup is disabled', async () => {
-      instance.options.hangupOnBeforeUnload = false;
+    it('should include the persisted sessid whenever a stored voice_sdk_id marks the login as a reconnect', async () => {
       setReconnectToken('voice-sdk-id');
       setReconnectSessionId('previous-sessid');
       Connection.mockResponse.mockImplementationOnce(() =>
@@ -138,8 +137,7 @@ describe('Verto', () => {
       expect(request.params.sessid).toBe('previous-sessid');
     });
 
-    it('should not include the persisted sessid when unload hangup is enabled by default', async () => {
-      setReconnectToken('voice-sdk-id');
+    it('should not include the persisted sessid when there is no stored voice_sdk_id', async () => {
       setReconnectSessionId('previous-sessid');
       Connection.mockResponse.mockImplementationOnce(() =>
         JSON.parse(
@@ -151,7 +149,7 @@ describe('Verto', () => {
 
       const { request } = Connection.mockSend.mock.calls[0][0];
       expect(request.method).toBe('login');
-      expect(request.params.reconnection).toBe(true);
+      expect(request.params.reconnection).toBe(false);
       expect(request.params.sessid).toBeUndefined();
     });
 

--- a/packages/js/src/Modules/Verto/tests/Verto.test.ts
+++ b/packages/js/src/Modules/Verto/tests/Verto.test.ts
@@ -92,6 +92,41 @@ describe('Verto', () => {
       clearReconnectToken();
     });
 
+    it('should clear reconnect token and sessid on page unload when hangupOnBeforeUnload is true', () => {
+      const addEventListenerSpy = jest.spyOn(window, 'addEventListener');
+      addEventListenerSpy.mockClear();
+      setReconnectToken('voice-sdk-id');
+      setReconnectSessionId('previous-sessid');
+
+      const telnyxRTC = _buildInstance({
+        host: 'example.telnyx.com',
+        login: 'login',
+        password: 'password',
+        hangupOnBeforeUnload: true,
+      });
+      const hangup = jest.fn();
+      telnyxRTC.calls = {
+        callA: { hangup } as unknown as IWebRTCCall,
+      };
+
+      const beforeUnloadHandler = addEventListenerSpy.mock.calls.find(
+        ([eventName]) => eventName === 'beforeunload'
+      )?.[1] as EventListener;
+
+      expect(beforeUnloadHandler).toBeDefined();
+      beforeUnloadHandler(new Event('beforeunload'));
+
+      expect(hangup).toHaveBeenCalledWith(
+        { initiator: 'sdk:beforeunload' },
+        true
+      );
+      expect(getReconnectToken()).toBeNull();
+      expect(getReconnectSessionId()).toBeNull();
+
+      addEventListenerSpy.mockRestore();
+      clearReconnectToken();
+    });
+
     it('should allow applications to disable page unload BYE without clearing reconnect token', () => {
       const addEventListenerSpy = jest.spyOn(window, 'addEventListener');
       addEventListenerSpy.mockClear();

--- a/packages/js/src/Modules/Verto/tests/Verto.test.ts
+++ b/packages/js/src/Modules/Verto/tests/Verto.test.ts
@@ -9,7 +9,9 @@ import {
 } from '../util/constants';
 import {
   clearReconnectToken,
+  getReconnectSessionId,
   getReconnectToken,
+  setReconnectSessionId,
   setReconnectToken,
 } from '../util/reconnect';
 
@@ -48,6 +50,7 @@ describe('Verto', () => {
     Connection.mockSend.mockClear();
     Connection.default.mockClear();
     Connection.mockClose.mockClear();
+    clearReconnectToken();
   });
 
   it('should instantiate Verto with default methods', () => {
@@ -109,6 +112,38 @@ describe('Verto', () => {
 
       addEventListenerSpy.mockRestore();
       clearReconnectToken();
+    });
+  });
+
+  describe('reconnect login', () => {
+    it('should include the persisted sessid when reconnecting with a stored voice_sdk_id', async () => {
+      setReconnectToken('voice-sdk-id');
+      setReconnectSessionId('previous-sessid');
+      Connection.mockResponse.mockImplementationOnce(() =>
+        JSON.parse(
+          '{"jsonrpc":"2.0","id":77,"result":{"message":"logged in","sessid":"previous-sessid"}}'
+        )
+      );
+
+      await instance.login();
+
+      const { request } = Connection.mockSend.mock.calls[0][0];
+      expect(request.method).toBe('login');
+      expect(request.params.reconnection).toBe(true);
+      expect(request.params.sessid).toBe('previous-sessid');
+    });
+
+    it('should persist the successful login sessid for future reconnects', async () => {
+      Connection.mockResponse.mockImplementationOnce(() =>
+        JSON.parse(
+          '{"jsonrpc":"2.0","id":77,"result":{"message":"logged in","sessid":"server-sessid"}}'
+        )
+      );
+
+      await instance.login();
+
+      expect(instance.sessionid).toBe('server-sessid');
+      expect(getReconnectSessionId()).toBe('server-sessid');
     });
   });
 

--- a/packages/js/src/Modules/Verto/tests/Verto.test.ts
+++ b/packages/js/src/Modules/Verto/tests/Verto.test.ts
@@ -62,6 +62,7 @@ describe('Verto', () => {
       const addEventListenerSpy = jest.spyOn(window, 'addEventListener');
       addEventListenerSpy.mockClear();
       setReconnectToken('voice-sdk-id');
+      setReconnectSessionId('previous-sessid');
 
       const telnyxRTC = _buildInstance({
         host: 'example.telnyx.com',
@@ -85,6 +86,7 @@ describe('Verto', () => {
         true
       );
       expect(getReconnectToken()).toBeNull();
+      expect(getReconnectSessionId()).toBeNull();
 
       addEventListenerSpy.mockRestore();
       clearReconnectToken();
@@ -94,6 +96,7 @@ describe('Verto', () => {
       const addEventListenerSpy = jest.spyOn(window, 'addEventListener');
       addEventListenerSpy.mockClear();
       setReconnectToken('voice-sdk-id');
+      setReconnectSessionId('previous-sessid');
 
       _buildInstance({
         host: 'example.telnyx.com',
@@ -109,6 +112,7 @@ describe('Verto', () => {
       ).toBe(false);
 
       expect(getReconnectToken()).toBe('voice-sdk-id');
+      expect(getReconnectSessionId()).toBe('previous-sessid');
 
       addEventListenerSpy.mockRestore();
       clearReconnectToken();
@@ -116,7 +120,8 @@ describe('Verto', () => {
   });
 
   describe('reconnect login', () => {
-    it('should include the persisted sessid when reconnecting with a stored voice_sdk_id', async () => {
+    it('should include the persisted sessid only when unload hangup is disabled', async () => {
+      instance.options.hangupOnBeforeUnload = false;
       setReconnectToken('voice-sdk-id');
       setReconnectSessionId('previous-sessid');
       Connection.mockResponse.mockImplementationOnce(() =>
@@ -131,6 +136,41 @@ describe('Verto', () => {
       expect(request.method).toBe('login');
       expect(request.params.reconnection).toBe(true);
       expect(request.params.sessid).toBe('previous-sessid');
+    });
+
+    it('should not include the persisted sessid when unload hangup is enabled by default', async () => {
+      setReconnectToken('voice-sdk-id');
+      setReconnectSessionId('previous-sessid');
+      Connection.mockResponse.mockImplementationOnce(() =>
+        JSON.parse(
+          '{"jsonrpc":"2.0","id":77,"result":{"message":"logged in","sessid":"new-sessid"}}'
+        )
+      );
+
+      await instance.login();
+
+      const { request } = Connection.mockSend.mock.calls[0][0];
+      expect(request.method).toBe('login');
+      expect(request.params.reconnection).toBe(true);
+      expect(request.params.sessid).toBeUndefined();
+    });
+
+    it('should include the in-memory sessid during same-instance socket reconnects', async () => {
+      instance.sessionid = 'active-sessid';
+      setReconnectToken('voice-sdk-id');
+      setReconnectSessionId('stored-sessid');
+      Connection.mockResponse.mockImplementationOnce(() =>
+        JSON.parse(
+          '{"jsonrpc":"2.0","id":77,"result":{"message":"logged in","sessid":"active-sessid"}}'
+        )
+      );
+
+      await instance.login();
+
+      const { request } = Connection.mockSend.mock.calls[0][0];
+      expect(request.method).toBe('login');
+      expect(request.params.reconnection).toBe(true);
+      expect(request.params.sessid).toBe('active-sessid');
     });
 
     it('should persist the successful login sessid for future reconnects', async () => {

--- a/packages/js/src/Modules/Verto/tests/reconnect.test.ts
+++ b/packages/js/src/Modules/Verto/tests/reconnect.test.ts
@@ -2,6 +2,7 @@ import {
   clearReconnectToken,
   getReconnectSessionId,
   getReconnectToken,
+  RECONNECT_SESSION_ID_MAX_AGE_MS,
   setReconnectSessionId,
   setReconnectToken,
 } from '../util/reconnect';
@@ -28,5 +29,16 @@ describe('reconnect token storage', () => {
 
     expect(getReconnectToken()).toBeNull();
     expect(getReconnectSessionId()).toBeNull();
+  });
+
+  it('expires the previous sessid after 90 seconds', () => {
+    setReconnectSessionId('previous-sessid', 1000);
+
+    expect(getReconnectSessionId(1000 + RECONNECT_SESSION_ID_MAX_AGE_MS)).toBe(
+      'previous-sessid'
+    );
+    expect(
+      getReconnectSessionId(1001 + RECONNECT_SESSION_ID_MAX_AGE_MS)
+    ).toBeNull();
   });
 });

--- a/packages/js/src/Modules/Verto/tests/reconnect.test.ts
+++ b/packages/js/src/Modules/Verto/tests/reconnect.test.ts
@@ -1,6 +1,8 @@
 import {
   clearReconnectToken,
+  getReconnectSessionId,
   getReconnectToken,
+  setReconnectSessionId,
   setReconnectToken,
 } from '../util/reconnect';
 
@@ -13,5 +15,18 @@ describe('reconnect token storage', () => {
     expect(getReconnectToken()).toBe('voice-sdk-id');
 
     clearReconnectToken();
+  });
+
+  it('keeps the previous sessid available for reconnect login and clears it with the token', () => {
+    setReconnectToken('voice-sdk-id');
+    setReconnectSessionId('previous-sessid');
+
+    expect(getReconnectToken()).toBe('voice-sdk-id');
+    expect(getReconnectSessionId()).toBe('previous-sessid');
+
+    clearReconnectToken();
+
+    expect(getReconnectToken()).toBeNull();
+    expect(getReconnectSessionId()).toBeNull();
   });
 });

--- a/packages/js/src/Modules/Verto/util/reconnect.ts
+++ b/packages/js/src/Modules/Verto/util/reconnect.ts
@@ -1,4 +1,5 @@
 const STORAGE_KEY = 'telnyx-voice-sdk-id';
+const SESSION_ID_STORAGE_KEY = 'telnyx-voice-sdk-session-id';
 
 export function getReconnectToken(): string | null {
   const token = sessionStorage.getItem(STORAGE_KEY);
@@ -9,6 +10,15 @@ export function setReconnectToken(token: string): void {
   sessionStorage.setItem(STORAGE_KEY, token);
 }
 
+export function getReconnectSessionId(): string | null {
+  return sessionStorage.getItem(SESSION_ID_STORAGE_KEY);
+}
+
+export function setReconnectSessionId(sessionId: string): void {
+  sessionStorage.setItem(SESSION_ID_STORAGE_KEY, sessionId);
+}
+
 export function clearReconnectToken(): void {
   sessionStorage.removeItem(STORAGE_KEY);
+  sessionStorage.removeItem(SESSION_ID_STORAGE_KEY);
 }

--- a/packages/js/src/Modules/Verto/util/reconnect.ts
+++ b/packages/js/src/Modules/Verto/util/reconnect.ts
@@ -1,5 +1,21 @@
 const STORAGE_KEY = 'telnyx-voice-sdk-id';
 const SESSION_ID_STORAGE_KEY = 'telnyx-voice-sdk-session-id';
+const SESSION_ID_STORED_AT_STORAGE_KEY =
+  'telnyx-voice-sdk-session-id-stored-at';
+
+export const RECONNECT_SESSION_ID_MAX_AGE_MS = 90 * 1000;
+
+function getReconnectSessionIdStoredAt(): number | null {
+  const storedAt = Number(
+    sessionStorage.getItem(SESSION_ID_STORED_AT_STORAGE_KEY)
+  );
+  return Number.isFinite(storedAt) ? storedAt : null;
+}
+
+export function isReconnectSessionIdFresh(now = Date.now()): boolean {
+  const storedAt = getReconnectSessionIdStoredAt();
+  return storedAt !== null && now - storedAt <= RECONNECT_SESSION_ID_MAX_AGE_MS;
+}
 
 export function getReconnectToken(): string | null {
   const token = sessionStorage.getItem(STORAGE_KEY);
@@ -10,15 +26,29 @@ export function setReconnectToken(token: string): void {
   sessionStorage.setItem(STORAGE_KEY, token);
 }
 
-export function getReconnectSessionId(): string | null {
-  return sessionStorage.getItem(SESSION_ID_STORAGE_KEY);
+export function getReconnectSessionId(now = Date.now()): string | null {
+  const sessionId = sessionStorage.getItem(SESSION_ID_STORAGE_KEY);
+  if (!sessionId) return null;
+
+  if (!isReconnectSessionIdFresh(now)) {
+    sessionStorage.removeItem(SESSION_ID_STORAGE_KEY);
+    sessionStorage.removeItem(SESSION_ID_STORED_AT_STORAGE_KEY);
+    return null;
+  }
+
+  return sessionId;
 }
 
-export function setReconnectSessionId(sessionId: string): void {
+export function setReconnectSessionId(
+  sessionId: string,
+  storedAt = Date.now()
+): void {
   sessionStorage.setItem(SESSION_ID_STORAGE_KEY, sessionId);
+  sessionStorage.setItem(SESSION_ID_STORED_AT_STORAGE_KEY, String(storedAt));
 }
 
 export function clearReconnectToken(): void {
   sessionStorage.removeItem(STORAGE_KEY);
   sessionStorage.removeItem(SESSION_ID_STORAGE_KEY);
+  sessionStorage.removeItem(SESSION_ID_STORED_AT_STORAGE_KEY);
 }


### PR DESCRIPTION
## Summary
- persist the last successful Verto `sessid` in browser session storage alongside `voice_sdk_id`
- when reconnecting with a stored `voice_sdk_id`, include the persisted `sessid` in the reconnect login only while it is fresh
- expire the persisted/in-memory reconnect `sessid` after 90 seconds, because b2bua-rtc cannot recover the call after that window
- clear the persisted `sessid` with the reconnect token on intentional cleanup

## Why
Abrupt socket/page reconnects were preserving `voice_sdk_id` and routing back to the same b2bua-rtc instance, but the reconnect login was missing the previous `sessid`. b2bua-rtc treated the login as a new SDK session and returned `reattached_sessions: []`.

The `sessid` is only useful during the short recovery window. After 90 seconds there is no expected call recovery, so the SDK keeps `reconnection: true` from the stored `voice_sdk_id` but omits the stale `sessid`.

## Validation
- `yarn jest packages/js/src/Modules/Verto/tests/reconnect.test.ts packages/js/src/Modules/Verto/tests/Verto.test.ts --runInBand`
- `yarn workspace @telnyx/webrtc build`
- `yarn workspace @telnyx/webrtc exec prettier --check src/Modules/Verto/BaseSession.ts src/Modules/Verto/tests/Verto.test.ts src/Modules/Verto/tests/reconnect.test.ts src/Modules/Verto/util/reconnect.ts`

## Notes
- Commit used `--no-verify` because lint-staged fails on the existing `require()` import in `packages/js/src/Modules/Verto/tests/Verto.test.ts`.
