### PR TITLE
docs: clarify AI conversation id target params

### DIFF
--- a/packages/js/README.md
+++ b/packages/js/README.md
@@ -257,6 +257,33 @@ const client = new TelnyxRTC({
 client.connect();
 ```
 
+By default, anonymous login starts a new AI Assistant conversation. Do not pass
+`target_params.conversation_id` for application session tracking or as a
+customer-generated correlation ID.
+
+`target_params.conversation_id` is only for joining an existing Telnyx AI
+conversation:
+
+```js
+const client = new TelnyxRTC({
+  anonymous_login: {
+    target_id: 'assistant-UUID',
+    target_type: 'ai_assistant',
+    target_params: {
+      conversation_id: 'existing-telnyx-conversation-id',
+    },
+  },
+});
+```
+
+When `conversation_id` is omitted, the TeXML endpoint starts a new conversation
+with `<AIAssistant id="...">`. When it is provided, voice-sdk-proxy forwards it
+as the `X-AI-Assistant-Conversation-ID` SIP header and the TeXML endpoint uses
+`<AIAssistant join="...">` to attach the call to that existing conversation. If
+the conversation does not exist or does not belong to the caller's
+project/account, the join fails (for example with AI Assistant error code
+`10007`: `The conversation does not exist or does not belong to this user`).
+
 ### Making Calls to AI Assistants
 
 Making calls to the AI assistant is similar to making calls with a SIP connection. You can use the `newCall` method to initiate a call, the destination number can be left blank.

--- a/packages/js/docs/ts/interfaces/IClientOptions.md
+++ b/packages/js/docs/ts/interfaces/IClientOptions.md
@@ -13,6 +13,7 @@ IClientOptions
 - [enableCallReports](#enablecallreports)
 - [env](#env)
 - [forceRelayCandidate](#forcerelaycandidate)
+- [hangupOnBeforeUnload](#hanguponbeforeunload)
 - [iceServers](#iceservers)
 - [keepConnectionAliveOnSocketClose](#keepconnectionaliveonsocketclose)
 - [login](#login)
@@ -41,12 +42,12 @@ anonymous_login login options
 
 #### Type declaration
 
-| Name                 | Type                                                                                              | Description                                                                                                                                                                                                                                 |
-| :------------------- | :------------------------------------------------------------------------------------------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `target_id`          | `string`                                                                                          | The target ID to use for the anonymous login. this is typically the ID of the AI assistant you want to connect to.                                                                                                                          |
-| `target_params?`     | [`TargetParams`](https://developers.telnyx.com/development/webrtc/js-sdk/interfaces/targetparams) | Optional parameters to pass to the target. These are forwarded to voice-sdk-proxy and mapped to custom headers on the SIP INVITE. **`See`** [TargetParams](https://developers.telnyx.com/development/webrtc/js-sdk/interfaces/targetparams) |
-| `target_type`        | `string`                                                                                          | A string indicating the target type, for now only `ai_assistant` is supported.                                                                                                                                                              |
-| `target_version_id?` | `string`                                                                                          | The target version ID to use for the anonymous login. This is optional and can be used to specify a particular version of the AI assistant.                                                                                                 |
+| Name                 | Type                                                                                              | Description                                                                                                                                                                                                                                                                                                                                                           |
+| :------------------- | :------------------------------------------------------------------------------------------------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `target_id`          | `string`                                                                                          | The target ID to use for the anonymous login. this is typically the ID of the AI assistant you want to connect to.                                                                                                                                                                                                                                                    |
+| `target_params?`     | [`TargetParams`](https://developers.telnyx.com/development/webrtc/js-sdk/interfaces/targetparams) | Optional parameters to pass to the target. These are forwarded to voice-sdk-proxy and mapped to custom headers on the SIP INVITE. Use `target_params.conversation_id` only to join an existing Telnyx AI conversation; omit it to start a new conversation. **`See`** [TargetParams](https://developers.telnyx.com/development/webrtc/js-sdk/interfaces/targetparams) |
+| `target_type`        | `string`                                                                                          | A string indicating the target type, for now only `ai_assistant` is supported.                                                                                                                                                                                                                                                                                        |
+| `target_version_id?` | `string`                                                                                          | The target version ID to use for the anonymous login. This is optional and can be used to specify a particular version of the AI assistant.                                                                                                                                                                                                                           |
 
 ---
 
@@ -128,6 +129,23 @@ So far this property is only for internal purposes.
 • `Optional` **forceRelayCandidate**: `boolean`
 
 Force the use of a relay ICE candidate.
+
+---
+
+### hangupOnBeforeUnload
+
+• `Optional` **hangupOnBeforeUnload**: `boolean`
+
+Controls whether the SDK attempts to send BYE for active calls during
+browser page unload. Enabled by default to preserve graceful call cleanup,
+but applications that handle page lifecycle themselves can disable it to
+avoid best-effort unload BYE races.
+
+**`Default`**
+
+```ts
+true;
+```
 
 ---
 

--- a/packages/js/docs/ts/interfaces/TargetParams.md
+++ b/packages/js/docs/ts/interfaces/TargetParams.md
@@ -4,11 +4,33 @@ These are forwarded to voice-sdk-proxy and mapped to custom headers on the SIP I
 Known keys are typed explicitly for discoverability and autocomplete.
 Unknown keys are still accepted and forwarded as-is.
 
+`conversation_id` is not a customer-defined correlation ID. Set it only
+when you want the WebRTC call to join an existing Telnyx AI conversation
+that belongs to the same project/account. Omit it to start a new AI
+Assistant conversation.
+
 **`Example`**
 
+Start a new AI Assistant conversation (most common)
+
 ```ts
-target_params: {
-  conversation_id: 'conv-123',  // → X-AI-Assistant-Conversation-ID
+anonymous_login: {
+  target_id: 'assistant-UUID',
+  target_type: 'ai_assistant',
+}
+```
+
+**`Example`**
+
+Join an existing Telnyx AI conversation
+
+```ts
+anonymous_login: {
+  target_id: 'assistant-UUID',
+  target_type: 'ai_assistant',
+  target_params: {
+    conversation_id: 'existing-telnyx-conversation-id', // → X-AI-Assistant-Conversation-ID
+  },
 }
 ```
 
@@ -24,5 +46,16 @@ target_params: {
 
 • `Optional` **conversation_id**: `string`
 
-The conversation ID to join an existing conversation.
-Mapped to `X-AI-Assistant-Conversation-ID` on the SIP INVITE.
+Telnyx AI conversation ID to join.
+
+When omitted, the TeXML endpoint starts a new conversation by rendering
+`<AIAssistant id="...">`. When provided, voice-sdk-proxy maps the value
+to `X-AI-Assistant-Conversation-ID` on the SIP INVITE, and the TeXML
+endpoint renders `<AIAssistant join="...">` to attach the call to that
+existing conversation.
+
+Do not use this field for application session tracking or as an external
+correlation ID. If the ID does not exist, or does not belong to the caller's
+project/account, the join attempt fails (for example with AI Assistant
+error code `10007`: `The conversation does not exist or does not belong to
+this user`).

--- a/packages/js/src/utils/interfaces.ts
+++ b/packages/js/src/utils/interfaces.ts
@@ -17,17 +17,45 @@ export interface ICredentials {
  * Known keys are typed explicitly for discoverability and autocomplete.
  * Unknown keys are still accepted and forwarded as-is.
  *
- * @example
+ * `conversation_id` is not a customer-defined correlation ID. Set it only
+ * when you want the WebRTC call to join an existing Telnyx AI conversation
+ * that belongs to the same project/account. Omit it to start a new AI
+ * Assistant conversation.
+ *
+ * @example Start a new AI Assistant conversation (most common)
  * ```ts
- * target_params: {
- *   conversation_id: 'conv-123',  // → X-AI-Assistant-Conversation-ID
+ * anonymous_login: {
+ *   target_id: 'assistant-UUID',
+ *   target_type: 'ai_assistant',
+ * }
+ * ```
+ *
+ * @example Join an existing Telnyx AI conversation
+ * ```ts
+ * anonymous_login: {
+ *   target_id: 'assistant-UUID',
+ *   target_type: 'ai_assistant',
+ *   target_params: {
+ *     conversation_id: 'existing-telnyx-conversation-id', // → X-AI-Assistant-Conversation-ID
+ *   },
  * }
  * ```
  */
 export interface TargetParams {
   /**
-   * The conversation ID to join an existing conversation.
-   * Mapped to `X-AI-Assistant-Conversation-ID` on the SIP INVITE.
+   * Telnyx AI conversation ID to join.
+   *
+   * When omitted, the TeXML endpoint starts a new conversation by rendering
+   * `<AIAssistant id="...">`. When provided, voice-sdk-proxy maps the value
+   * to `X-AI-Assistant-Conversation-ID` on the SIP INVITE, and the TeXML
+   * endpoint renders `<AIAssistant join="...">` to attach the call to that
+   * existing conversation.
+   *
+   * Do not use this field for application session tracking or as an external
+   * correlation ID. If the ID does not exist, or does not belong to the caller's
+   * project/account, the join attempt fails (for example with AI Assistant
+   * error code `10007`: `The conversation does not exist or does not belong to
+   * this user`).
    */
   conversation_id?: string;
   /** Allow additional pass-through parameters. */
@@ -134,6 +162,8 @@ export interface IClientOptions {
     /**
      * Optional parameters to pass to the target.
      * These are forwarded to voice-sdk-proxy and mapped to custom headers on the SIP INVITE.
+     * Use `target_params.conversation_id` only to join an existing Telnyx AI
+     * conversation; omit it to start a new conversation.
      * @see {@link TargetParams}
      */
     target_params?: TargetParams;


### PR DESCRIPTION
## Summary
- document that `target_params.conversation_id` joins an existing Telnyx AI conversation
- clarify that omitting it starts a new AI Assistant conversation
- warn not to use it as a customer-generated session/correlation ID
- document the `<AIAssistant id="...">` vs `<AIAssistant join="...">` behavior and invalid conversation failure case

## Validation
- `yarn docs`
- `git diff --check`

Note: `yarn lint` still fails on pre-existing repo lint issues unrelated to this docs-only change.