### PR TITLE
fix: guard browser online reconnects

### DIFF
--- a/packages/js/src/Modules/Verto/BaseSession.ts
+++ b/packages/js/src/Modules/Verto/BaseSession.ts
@@ -35,7 +35,6 @@ import {
   isFunction,
   isValidAnonymousLoginOptions,
   isValidLoginOptions,
-  randomInt,
 } from './util/helpers';
 import {
   BroadcastParams,
@@ -150,7 +149,10 @@ export default abstract class BaseSession {
   }
 
   get reconnectDelay() {
-    return randomInt(2, 6) * 1000;
+    const attempt = Math.max(this._reconnectAttempts, 1);
+    const baseDelayMs = 1000;
+    const maxDelayMs = 30000;
+    return Math.min(maxDelayMs, baseDelayMs * 2 ** (attempt - 1));
   }
 
   /**

--- a/packages/js/src/Modules/Verto/BrowserSession.ts
+++ b/packages/js/src/Modules/Verto/BrowserSession.ts
@@ -13,7 +13,7 @@ import {
   DEFAULT_DEV_ICE_SERVERS,
   NETWORK_OFFLINE,
 } from './util/constants';
-import { State, DeviceType } from './webrtc/constants';
+import { State, DeviceType, GatewayStateType } from './webrtc/constants';
 import {
   getDevices,
   scanResolutions,
@@ -78,7 +78,7 @@ export default abstract class BrowserSession extends BaseSession {
   }
 
   get reconnectDelay() {
-    return 1000;
+    return super.reconnectDelay;
   }
 
   async getIsRegistered(): Promise<boolean> {
@@ -777,6 +777,48 @@ export default abstract class BrowserSession extends BaseSession {
     return response;
   }
 
+  private _isCallInProgress(call: IWebRTCCall): boolean {
+    const terminalStates = new Set<State>([
+      State.Hangup,
+      State.Destroy,
+      State.Purge,
+    ]);
+
+    const internalState = (call as unknown as { _state?: State })._state;
+    if (internalState !== undefined) {
+      return !terminalStates.has(internalState);
+    }
+
+    return !['done', 'hangup', 'destroy', 'purge'].includes(call.state);
+  }
+
+  private _hasHealthyCallInProgress(): boolean {
+    return Object.values(this.calls).some((call) => {
+      if (!call || !this._isCallInProgress(call)) return false;
+      if (call.signalingStateClosed) return false;
+      return Boolean(call.peer?.isConnectionHealthy?.());
+    });
+  }
+
+  private _shouldSkipOnlineReconnect(): boolean {
+    const gatewayState = this.connection?.previousGatewayState;
+    const isConnected = Boolean(this.connection?.connected);
+    const isRegistered = gatewayState === GatewayStateType.REGED;
+    const hasHealthyCallInProgress = this._hasHealthyCallInProgress();
+
+    if (isConnected || isRegistered || hasHealthyCallInProgress) {
+      logger.debug('Skipping online reconnect', {
+        sessionId: this.sessionid,
+        isConnected,
+        gatewayState,
+        hasHealthyCallInProgress,
+      });
+      return true;
+    }
+
+    return false;
+  }
+
   private _setupNetworkListeners() {
     if (typeof window === 'undefined') {
       return;
@@ -785,16 +827,26 @@ export default abstract class BrowserSession extends BaseSession {
     this._onlineHandler = () => {
       /**
        * Once offline, there's no guarantee the connection across client and server both ways is still alive as PINGs from server may be missed.
-       * Therefore, reconnect to be safe.
+       * Only reconnect when the socket is not already healthy and there is no healthy in-progress call to preserve.
        */
-      if (this._wasOffline) {
-        logger.debug(
-          `Network connectivity restored for session ${this.sessionid}. Reconnecting...`
-        );
-        this._wasOffline = false;
-        this._autoReconnect = true; // Ensure auto-reconnect is enabled
-        this.socketDisconnect(); // This triggers SocketClose → onNetworkClose → connect()
+      if (!this._wasOffline) {
+        return;
       }
+
+      logger.debug(
+        `Network connectivity restored for session ${this.sessionid}. Checking whether reconnect is needed...`
+      );
+      this._wasOffline = false;
+
+      if (this._shouldSkipOnlineReconnect()) {
+        return;
+      }
+
+      logger.debug(
+        `Network connectivity restored for session ${this.sessionid}. Reconnecting...`
+      );
+      this._autoReconnect = true;
+      this.connect();
     };
 
     this._offlineHandler = () => {

--- a/packages/js/src/Modules/Verto/tests/ReconnectAttempts.test.ts
+++ b/packages/js/src/Modules/Verto/tests/ReconnectAttempts.test.ts
@@ -94,6 +94,22 @@ describe('BaseSession - Reconnection Attempt Limit', () => {
     });
   });
 
+  describe('reconnect backoff', () => {
+    it('should use exponential reconnect backoff capped at 30 seconds', () => {
+      session._reconnectAttempts = 1;
+      expect(session.reconnectDelay).toBe(1000);
+
+      session._reconnectAttempts = 2;
+      expect(session.reconnectDelay).toBe(2000);
+
+      session._reconnectAttempts = 3;
+      expect(session.reconnectDelay).toBe(4000);
+
+      session._reconnectAttempts = 6;
+      expect(session.reconnectDelay).toBe(30000);
+    });
+  });
+
   describe('with maxReconnectAttempts set', () => {
     it('should increment _reconnectAttempts on each onNetworkClose call', () => {
       session.options.maxReconnectAttempts = 5;

--- a/packages/js/src/Modules/Verto/tests/Verto.test.ts
+++ b/packages/js/src/Modules/Verto/tests/Verto.test.ts
@@ -3,6 +3,7 @@ import { isQueued } from '../services/Handler';
 import Verto, { VERTO_PROTOCOL } from '..';
 import { IVertoOptions } from '../util/interfaces';
 import { IWebRTCCall } from '../webrtc/interfaces';
+import { State } from '../webrtc/constants';
 import {
   DEFAULT_DEV_ICE_SERVERS,
   DEFAULT_PROD_ICE_SERVERS,
@@ -16,6 +17,7 @@ import {
   setReconnectToken,
 } from '../util/reconnect';
 
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 const Connection = require('../services/Connection');
 
 describe('Verto', () => {
@@ -51,11 +53,150 @@ describe('Verto', () => {
     Connection.mockSend.mockClear();
     Connection.default.mockClear();
     Connection.mockClose.mockClear();
+    Connection.mockConnect.mockClear();
+    Connection.connected.mockReturnValue(true);
+    Connection.isAlive.mockReturnValue(true);
     clearReconnectToken();
   });
 
   it('should instantiate Verto with default methods', () => {
     expect(instance).toBeInstanceOf(Verto);
+  });
+
+  describe('browser online reconnect guard', () => {
+    const markWasOffline = (telnyxRTC: Verto) => {
+      (telnyxRTC as unknown as { _wasOffline: boolean })._wasOffline = true;
+    };
+
+    const buildInstanceWithNetworkHandlers = () => {
+      const addEventListenerSpy = jest.spyOn(window, 'addEventListener');
+      addEventListenerSpy.mockClear();
+
+      const telnyxRTC = _buildInstance({
+        host: 'example.telnyx.com',
+        login: 'login',
+        password: 'password',
+      });
+      const onlineHandler = addEventListenerSpy.mock.calls.find(
+        ([eventName]) => eventName === 'online'
+      )?.[1] as EventListener;
+
+      expect(onlineHandler).toBeDefined();
+
+      return { telnyxRTC, onlineHandler, addEventListenerSpy };
+    };
+
+    it('does not force socketDisconnect on browser online when the socket is already connected', () => {
+      Connection.connected.mockReturnValue(true);
+      Connection.isAlive.mockReturnValue(true);
+      const { telnyxRTC, onlineHandler, addEventListenerSpy } =
+        buildInstanceWithNetworkHandlers();
+
+      markWasOffline(telnyxRTC);
+      onlineHandler(new Event('online'));
+
+      expect(Connection.mockClose).not.toHaveBeenCalled();
+      expect(Connection.mockConnect).not.toHaveBeenCalled();
+
+      addEventListenerSpy.mockRestore();
+    });
+
+    it('does not force socketDisconnect on browser online when the session is already registered', () => {
+      Connection.connected.mockReturnValue(false);
+      Connection.isAlive.mockReturnValue(false);
+      const { telnyxRTC, onlineHandler, addEventListenerSpy } =
+        buildInstanceWithNetworkHandlers();
+      telnyxRTC.connection.previousGatewayState = 'REGED';
+
+      markWasOffline(telnyxRTC);
+      onlineHandler(new Event('online'));
+
+      expect(Connection.mockClose).not.toHaveBeenCalled();
+      expect(Connection.mockConnect).not.toHaveBeenCalled();
+
+      addEventListenerSpy.mockRestore();
+    });
+
+    it.each([
+      ['being set up', State.Trying, 'connecting'],
+      ['active', State.Active, 'active'],
+    ])(
+      'does not reconnect on browser online while a call is %s and healthy',
+      (_description, state, publicState) => {
+        Connection.connected.mockReturnValue(false);
+        Connection.isAlive.mockReturnValue(false);
+        const { telnyxRTC, onlineHandler, addEventListenerSpy } =
+          buildInstanceWithNetworkHandlers();
+        telnyxRTC.calls = {
+          callA: {
+            _state: state,
+            state: publicState,
+            signalingStateClosed: false,
+            peer: { isConnectionHealthy: jest.fn(() => true) },
+          } as unknown as IWebRTCCall,
+        };
+
+        markWasOffline(telnyxRTC);
+        onlineHandler(new Event('online'));
+
+        expect(Connection.mockClose).not.toHaveBeenCalled();
+        expect(Connection.mockConnect).not.toHaveBeenCalled();
+
+        addEventListenerSpy.mockRestore();
+      }
+    );
+
+    it.each([
+      ['active but peer unhealthy', State.Active, 'active', false],
+      [
+        'being set up but peer health is unknown',
+        State.Trying,
+        'connecting',
+        undefined,
+      ],
+    ])(
+      'reconnects on browser online when a call is %s',
+      (_description, state, publicState, isHealthy) => {
+        Connection.connected.mockReturnValue(false);
+        Connection.isAlive.mockReturnValue(false);
+        const { telnyxRTC, onlineHandler, addEventListenerSpy } =
+          buildInstanceWithNetworkHandlers();
+        telnyxRTC.calls = {
+          callA: {
+            _state: state,
+            state: publicState,
+            signalingStateClosed: false,
+            peer:
+              isHealthy === undefined
+                ? undefined
+                : { isConnectionHealthy: jest.fn(() => isHealthy) },
+          } as unknown as IWebRTCCall,
+        };
+
+        markWasOffline(telnyxRTC);
+        onlineHandler(new Event('online'));
+
+        expect(Connection.mockClose).not.toHaveBeenCalled();
+        expect(Connection.mockConnect).toHaveBeenCalledTimes(1);
+
+        addEventListenerSpy.mockRestore();
+      }
+    );
+
+    it('reconnects without socketDisconnect on browser online when the socket is not connected and there are no calls', () => {
+      Connection.connected.mockReturnValue(false);
+      Connection.isAlive.mockReturnValue(false);
+      const { telnyxRTC, onlineHandler, addEventListenerSpy } =
+        buildInstanceWithNetworkHandlers();
+
+      markWasOffline(telnyxRTC);
+      onlineHandler(new Event('online'));
+
+      expect(Connection.mockClose).not.toHaveBeenCalled();
+      expect(Connection.mockConnect).toHaveBeenCalledTimes(1);
+
+      addEventListenerSpy.mockRestore();
+    });
   });
 
   describe('beforeunload hangup', () => {


### PR DESCRIPTION
## Summary
- avoid forcing `socketDisconnect()` from the browser `online` event when the SDK is already connected/registered
- skip online reconnect only when an in-progress call can be confirmed healthy (`peer.isConnectionHealthy()` and signaling is not closed)
- allow online recovery to reconnect when an active call is unhealthy or call health is unknown
- reconnect directly when offline recovery finds no live socket/call instead of closing a socket first
- replace the 1s browser reconnect loop with exponential backoff capped at 30s
- keep the existing `maxReconnectAttempts` cap behavior and add coverage for the backoff

## Validation
- `yarn test packages/js/src/Modules/Verto/tests/Verto.test.ts packages/js/src/Modules/Verto/tests/ReconnectAttempts.test.ts --runInBand`
- `yarn eslint src/Modules/Verto/BrowserSession.ts src/Modules/Verto/tests/Verto.test.ts`
- `yarn build`