### PR TITLE
fix: clear reconnect sessid after calls end

### DIFF
--- a/packages/js/src/Modules/Verto/tests/webrtc/Call.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/Call.test.ts
@@ -19,6 +19,13 @@ import {
   SwEvent,
 } from '../../util/constants';
 import logger from '../../util/logger';
+import {
+  clearReconnectToken,
+  getReconnectSessionId,
+  getReconnectToken,
+  setReconnectSessionId,
+  setReconnectToken,
+} from '../../util/reconnect';
 import Call from '../../webrtc/Call';
 import Peer from '../../webrtc/Peer';
 import Verto from '../..';
@@ -62,6 +69,7 @@ describe('Call', () => {
   const noop = (): void => {};
 
   beforeEach(async (done) => {
+    clearReconnectToken();
     session = new Verto({
       host: 'example.fs.telnyx',
       login: 'login',
@@ -165,6 +173,33 @@ describe('Call', () => {
       expect(call.prevState).toEqual('ringing');
       call.setState(State.Hangup);
       expect(call.prevState).toEqual('active');
+    });
+  });
+
+  describe('reconnect sessid cleanup', () => {
+    it('clears the persisted reconnect sessid when the last call hangs up but keeps the reconnect token', async () => {
+      setReconnectToken('voice-sdk-id');
+      setReconnectSessionId('previous-sessid');
+
+      await call.hangup({}, false);
+
+      expect(getReconnectToken()).toBe('voice-sdk-id');
+      expect(getReconnectSessionId()).toBeNull();
+    });
+
+    it('keeps the persisted reconnect sessid while another call is still active', async () => {
+      setReconnectToken('voice-sdk-id');
+      setReconnectSessionId('previous-sessid');
+      const secondCall = new Call(session, {
+        ...defaultParams,
+        id: 'second-call',
+      });
+
+      await call.hangup({}, false);
+
+      expect(session.calls).toHaveProperty(secondCall.id);
+      expect(getReconnectToken()).toBe('voice-sdk-id');
+      expect(getReconnectSessionId()).toBe('previous-sessid');
     });
   });
 

--- a/packages/js/src/Modules/Verto/util/reconnect.ts
+++ b/packages/js/src/Modules/Verto/util/reconnect.ts
@@ -47,8 +47,12 @@ export function setReconnectSessionId(
   sessionStorage.setItem(SESSION_ID_STORED_AT_STORAGE_KEY, String(storedAt));
 }
 
-export function clearReconnectToken(): void {
-  sessionStorage.removeItem(STORAGE_KEY);
+export function clearReconnectSessionId(): void {
   sessionStorage.removeItem(SESSION_ID_STORAGE_KEY);
   sessionStorage.removeItem(SESSION_ID_STORED_AT_STORAGE_KEY);
+}
+
+export function clearReconnectToken(): void {
+  sessionStorage.removeItem(STORAGE_KEY);
+  clearReconnectSessionId();
 }

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -45,6 +45,7 @@ import { isFunction, mutateLiveArrayData, objEmpty } from '../util/helpers';
 import { INotificationEventData } from '../util/interfaces';
 import { getIceCandidateErrorDetails } from '../util/debug';
 import logger from '../util/logger';
+import { clearReconnectSessionId } from '../util/reconnect';
 import {
   attachMediaStream,
   detachMediaStream,
@@ -2357,6 +2358,10 @@ export default abstract class BaseCall implements IWebRTCCall {
     deRegister(SwEvent.PeerConnectionSignalingStateClosed, null, this.id);
     this.session.calls[this.id] = null;
     delete this.session.calls[this.id];
+
+    if (Object.keys(this.session.calls).length === 0) {
+      clearReconnectSessionId();
+    }
 
     // Post call report after cleanup. The upload runs in the background,
     // but the session tracks it so disconnect() can wait instead of racing


### PR DESCRIPTION
## Summary
- add a reconnect helper that clears only the persisted reconnect sessid + timestamp
- clear the persisted reconnect sessid when the last call finalizes after hangup
- keep the `voice_sdk_id` reconnect token intact so sticky routing behavior is unchanged
- keep sessid while another call remains active

## Validation
- yarn workspace @telnyx/webrtc test packages/js/src/Modules/Verto/tests/reconnect.test.ts packages/js/src/Modules/Verto/tests/webrtc/Call.test.ts --runInBand
- yarn workspace @telnyx/webrtc eslint src/Modules/Verto/util/reconnect.ts src/Modules/Verto/webrtc/BaseCall.ts src/Modules/Verto/tests/webrtc/Call.test.ts
- yarn workspace @telnyx/webrtc build