### PR TITLE
VSDK-213: add skipTrailing option to skip VSP trailing pre-routing

### DIFF
--- a/packages/js/src/Modules/Verto/services/Connection.ts
+++ b/packages/js/src/Modules/Verto/services/Connection.ts
@@ -179,6 +179,14 @@ export default class Connection {
       websocketUrl.searchParams.set('skip_last_voice_sdk_id', 'true');
     }
 
+    // When skipTrailing is set, tell VSP to skip pre-routing identity
+    // resolution (telephony-tokens validation and UsersClass trailing
+    // checks) for this connection. Used by internal/test-infra (e.g. BBT)
+    // where the connection should not participate in trailing routing.
+    if (this.session.options.skipTrailing) {
+      websocketUrl.searchParams.set('skip_trailing', 'true');
+    }
+
     try {
       const previousSocketGeneration = this.socketGeneration;
       this._wsClient = new WebSocketClass(websocketUrl.toString());

--- a/packages/js/src/Modules/Verto/tests/services/Connection.test.ts
+++ b/packages/js/src/Modules/Verto/tests/services/Connection.test.ts
@@ -547,6 +547,51 @@ describe('Connection - Safety Timeout', () => {
     });
   });
 
+  describe('skip_trailing query parameter', () => {
+    it('should append skip_trailing=true when skipTrailing option is set', () => {
+      mockSession.options.skipTrailing = true;
+
+      connection.connect();
+
+      const ws = (connection as any)._wsClient as MockWebSocket;
+      expect(ws).not.toBeNull();
+      const url = new URL(ws.url);
+      expect(url.searchParams.get('skip_trailing')).toBe('true');
+    });
+
+    it('should NOT append skip_trailing when skipTrailing is false', () => {
+      mockSession.options.skipTrailing = false;
+
+      connection.connect();
+
+      const ws = (connection as any)._wsClient as MockWebSocket;
+      const url = new URL(ws.url);
+      expect(url.searchParams.has('skip_trailing')).toBe(false);
+    });
+
+    it('should NOT append skip_trailing when skipTrailing is not set', () => {
+      connection.connect();
+
+      const ws = (connection as any)._wsClient as MockWebSocket;
+      const url = new URL(ws.url);
+      expect(url.searchParams.has('skip_trailing')).toBe(false);
+    });
+
+    it('should include skip_trailing alongside other query parameters', () => {
+      mockSession.options.skipTrailing = true;
+      mockSession.options.useCanaryRtcServer = true;
+
+      // Re-create connection since useCanaryRtcServer is read in constructor
+      connection = new Connection(mockSession);
+      connection.connect();
+
+      const ws = (connection as any)._wsClient as MockWebSocket;
+      const url = new URL(ws.url);
+      expect(url.searchParams.get('skip_trailing')).toBe('true');
+      expect(url.searchParams.get('canary')).toBe('true');
+    });
+  });
+
   describe('State getters', () => {
     it('should correctly report connected state', async () => {
       connection.connect();

--- a/packages/js/src/Modules/Verto/util/interfaces.ts
+++ b/packages/js/src/Modules/Verto/util/interfaces.ts
@@ -114,6 +114,21 @@ export interface IVertoOptions {
   skipLastVoiceSdkId?: boolean;
 
   /**
+   * When set to `true`, appends `skip_trailing=true` to the VSP WebSocket
+   * URL so VSP skips pre-routing identity resolution (telephony-tokens
+   * validation and UsersClass trailing checks) for this connection.
+   *
+   * This is intended for internal/test-infra usage (e.g. BBT-generated
+   * credentials) where the connection should not participate in trailing
+   * release routing. The actual login still goes to the upstream RTC
+   * service for normal authentication — this only skips VSP's pre-routing
+   * lookup used for trailing target selection.
+   *
+   * @default false
+   */
+  skipTrailing?: boolean;
+
+  /**
    * Configuration for media permissions recovery on inbound calls.
    * When enabled and the initial `getUserMedia` call fails while answering,
    * the SDK emits a recoverable `telnyx.error` event with `resume()` and

--- a/packages/js/src/utils/interfaces.ts
+++ b/packages/js/src/utils/interfaces.ts
@@ -197,6 +197,21 @@ export interface IClientOptions {
   skipLastVoiceSdkId?: boolean;
 
   /**
+   * When set to `true`, appends `skip_trailing=true` to the VSP WebSocket
+   * URL so VSP skips pre-routing identity resolution (telephony-tokens
+   * validation and UsersClass trailing checks) for this connection.
+   *
+   * This is intended for internal/test-infra usage (e.g. BBT-generated
+   * credentials) where the connection should not participate in trailing
+   * release routing. The actual login still goes to the upstream RTC
+   * service for normal authentication — this only skips VSP's pre-routing
+   * lookup used for trailing target selection.
+   *
+   * @default false
+   */
+  skipTrailing?: boolean;
+
+  /**
    *  Environment to use for the connection.
    *  So far this property is only for internal purposes.
    */


### PR DESCRIPTION
## Summary

Implements SDK-side changes for VSDK-213: adds a `skipTrailing` client option that appends `skip_trailing=true` to the VSP WebSocket URL, telling VSP to bypass pre-routing identity resolution (telephony-tokens validation and UsersClass trailing checks).

## Changes

- Added `skipTrailing?: boolean` to `IVertoOptions` and `IClientOptions`
- When `skipTrailing: true`, appends `skip_trailing=true` query param to the WebSocket URL in `Connection.connect()`
- Added 4 unit tests for the new query parameter behavior

## Related PRs

- team-telnyx/blackbox-testing-webrtc#VSDK-213 (BBT changes)
- team-telnyx/webrtc-demo-js#VSDK-213 (demo app switch)
- team-telnyx/voice-sdk-proxy#VSDK-213 (VSP server changes)

## Testing

- All 357 existing SDK tests pass
- 4 new Connection tests for `skip_trailing` query parameter