### PR TITLE
Fix: handle TIMEOUT gateway state with auto-reconnect

### DIFF
--- a/packages/js/src/Modules/Verto/tests/services/Connection.test.ts
+++ b/packages/js/src/Modules/Verto/tests/services/Connection.test.ts
@@ -132,6 +132,44 @@ describe('Connection - Safety Timeout', () => {
         }
       );
     });
+
+    it('includes skip_last_voice_sdk_id=true in WebSocket URL when skipLastVoiceSdkId is set and voice_sdk_id exists', () => {
+      (getReconnectToken as jest.Mock).mockReturnValue('stored-voice-sdk-id');
+      mockSession.options.skipLastVoiceSdkId = true;
+
+      connection.connect();
+
+      const ws = (connection as any)._wsClient;
+      expect(ws).not.toBeNull();
+      const wsUrl = new URL(ws.url);
+      expect(wsUrl.searchParams.get('voice_sdk_id')).toBe('stored-voice-sdk-id');
+      expect(wsUrl.searchParams.get('skip_last_voice_sdk_id')).toBe('true');
+    });
+
+    it('does not include skip_last_voice_sdk_id when skipLastVoiceSdkId is set but no voice_sdk_id exists', () => {
+      (getReconnectToken as jest.Mock).mockReturnValue(null);
+      mockSession.options.skipLastVoiceSdkId = true;
+
+      connection.connect();
+
+      const ws = (connection as any)._wsClient;
+      expect(ws).not.toBeNull();
+      const wsUrl = new URL(ws.url);
+      expect(wsUrl.searchParams.has('voice_sdk_id')).toBe(false);
+      expect(wsUrl.searchParams.has('skip_last_voice_sdk_id')).toBe(false);
+    });
+
+    it('does not include skip_last_voice_sdk_id when voice_sdk_id exists but skipLastVoiceSdkId is not set', () => {
+      (getReconnectToken as jest.Mock).mockReturnValue('stored-voice-sdk-id');
+
+      connection.connect();
+
+      const ws = (connection as any)._wsClient;
+      expect(ws).not.toBeNull();
+      const wsUrl = new URL(ws.url);
+      expect(wsUrl.searchParams.get('voice_sdk_id')).toBe('stored-voice-sdk-id');
+      expect(wsUrl.searchParams.has('skip_last_voice_sdk_id')).toBe(false);
+    });
   });
 
   describe('close() method', () => {

--- a/packages/js/src/Modules/Verto/tests/webrtc/VertoHandler.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/VertoHandler.test.ts
@@ -50,6 +50,9 @@ describe('VertoHandler', () => {
     instance.on('telnyx.ready', (notification) => {
       onNotification(notification);
     });
+    instance.on('telnyx.error', (error) => {
+      onNotification(error);
+    });
     handler = new VertoHandler(instance);
   });
 
@@ -460,6 +463,101 @@ describe('VertoHandler', () => {
           type: 'vertoClientReady',
         })
       );
+    });
+  });
+
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  describe('TIMEOUT gateway state', () => {
+    let onError: jest.Mock;
+
+    beforeEach(() => {
+      onError = jest.fn();
+      instance.on('telnyx.error', onError);
+    });
+
+    afterEach(() => {
+      instance.off('telnyx.error');
+    });
+
+    it('should emit GATEWAY_FAILED error when TIMEOUT is received', () => {
+      instance.connection.previousGatewayState = '';
+      const timeoutMsg = JSON.parse(
+        '{"jsonrpc":"2.0","id":"gs-1","result":{"params":{"state":"TIMEOUT"},"sessid":"sess1"}}'
+      );
+      handler.handleMessage(timeoutMsg);
+
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(onError.mock.calls[0][0].error.code).toBe(45004);
+      expect(onError.mock.calls[0][0].error.name).toBe('GATEWAY_FAILED');
+    });
+
+    it('should emit RECONNECTION_EXHAUSTED when autoReconnect is disabled and TIMEOUT is received', () => {
+      (instance as any)._autoReconnect = false;
+      instance.connection.previousGatewayState = '';
+      const timeoutMsg = JSON.parse(
+        '{"jsonrpc":"2.0","id":"gs-2","result":{"params":{"state":"TIMEOUT"},"sessid":"sess1"}}'
+      );
+      handler.handleMessage(timeoutMsg);
+
+      // GATEWAY_FAILED (45004) + RECONNECTION_EXHAUSTED (45003)
+      expect(onError).toHaveBeenCalledTimes(2);
+      expect(onError.mock.calls[0][0].error.code).toBe(45004);
+      expect(onError.mock.calls[1][0].error.code).toBe(45003);
+    });
+
+    it('should set skipLastVoiceSdkId on session options when TIMEOUT is received', () => {
+      instance.connection.previousGatewayState = '';
+      expect(instance.options.skipLastVoiceSdkId).toBeFalsy();
+      const timeoutMsg = JSON.parse(
+        '{"jsonrpc":"2.0","id":"gs-3","result":{"params":{"state":"TIMEOUT"},"sessid":"sess1"}}'
+      );
+      handler.handleMessage(timeoutMsg);
+
+      expect(instance.options.skipLastVoiceSdkId).toBe(true);
+    });
+
+    it('should also set skipLastVoiceSdkId when FAILED is received', () => {
+      instance.connection.previousGatewayState = '';
+      const failedMsg = JSON.parse(
+        '{"jsonrpc":"2.0","id":"gs-4","result":{"params":{"state":"FAILED"},"sessid":"sess1"}}'
+      );
+      handler.handleMessage(failedMsg);
+
+      expect(instance.options.skipLastVoiceSdkId).toBe(true);
+    });
+
+    it('should not emit GATEWAY_FAILED on consecutive TIMEOUT states', () => {
+      instance.connection.previousGatewayState = '';
+      const timeoutMsg = JSON.parse(
+        '{"jsonrpc":"2.0","id":"gs-5","result":{"params":{"state":"TIMEOUT"},"sessid":"sess1"}}'
+      );
+      handler.handleMessage(timeoutMsg);
+      const firstErrorCount = onError.mock.calls.filter(
+        (call: any) => call[0]?.error?.code === 45004
+      ).length;
+
+      // previousGatewayState is now set by Connection's onmessage handler,
+      // but in this test we manually simulate it
+      instance.connection.previousGatewayState = 'TIMEOUT';
+      handler.handleMessage(timeoutMsg);
+      const secondErrorCount = onError.mock.calls.filter(
+        (call: any) => call[0]?.error?.code === 45004
+      ).length;
+
+      // Only one GATEWAY_FAILED should have been emitted
+      expect(secondErrorCount).toBe(firstErrorCount);
+    });
+
+    it('should not reset reconnect attempts on TIMEOUT', () => {
+      (instance as any)._reconnectAttempts = 3;
+      instance.connection.previousGatewayState = '';
+      const timeoutMsg = JSON.parse(
+        '{"jsonrpc":"2.0","id":"gs-6","result":{"params":{"state":"TIMEOUT"},"sessid":"sess1"}}'
+      );
+      handler.handleMessage(timeoutMsg);
+
+      // Reconnect attempts should not be reset until confirmed REGED
+      expect((instance as any)._reconnectAttempts).toBe(3);
     });
   });
 });

--- a/packages/js/src/Modules/Verto/util/constants/errors.ts
+++ b/packages/js/src/Modules/Verto/util/constants/errors.ts
@@ -214,7 +214,7 @@ export const SDK_ERRORS = {
     name: 'GATEWAY_FAILED',
     message: 'Gateway connection failed',
     description:
-      'The upstream gateway reported a FAILED or FAIL_WAIT state. The signaling server could not establish or maintain a connection to the gateway. When autoReconnect is disabled, this is immediately fatal. When enabled, the SDK will retry until RECONNECTION_EXHAUSTED.',
+      'The upstream gateway reported a FAILED, FAIL_WAIT, or TIMEOUT state. The signaling server could not establish or maintain a connection to the gateway. When autoReconnect is disabled, this is immediately fatal. When enabled, the SDK will retry until RECONNECTION_EXHAUSTED.',
     causes: [
       'Gateway down or unreachable',
       'Server-side infrastructure issue',

--- a/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
+++ b/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
@@ -289,7 +289,12 @@ class VertoHandler {
             // If the user is REGED tell the client that it is ready to make calls
             case GatewayStateType.REGISTER:
             case GatewayStateType.REGED: {
-              if (!this.isDuplicateGatewayState(gateWayState)) {
+              if (
+                !this.isDuplicateGatewayState(gateWayState, [
+                  GatewayStateType.REGED,
+                  GatewayStateType.REGISTER,
+                ])
+              ) {
                 this.session._triggerKeepAliveTimeoutCheck();
                 this.retriedRegister = 0;
 
@@ -370,7 +375,13 @@ class VertoHandler {
             case GatewayStateType.FAILED:
             case GatewayStateType.FAIL_WAIT:
             case GatewayStateType.TIMEOUT: {
-              if (!this.isDuplicateGatewayState(gateWayState)) {
+              if (
+                !this.isDuplicateGatewayState(gateWayState, [
+                  GatewayStateType.FAILED,
+                  GatewayStateType.FAIL_WAIT,
+                  GatewayStateType.TIMEOUT,
+                ])
+              ) {
                 // Emit gateway failure on first occurrence
                 const gatewayError = createTelnyxError(
                   GATEWAY_FAILED,
@@ -479,13 +490,19 @@ class VertoHandler {
   }
 
   /**
-   * Checks whether the previous gateway state matches the current state.
-   * Logs a debug message when a duplicate state is detected so the guard
-   * condition is visible in session/call reports.
+   * Checks whether the previous gateway state matches any of the states in the
+   * given bucket (e.g. [FAILED, FAIL_WAIT, TIMEOUT] or [REGED, REGISTER]).
+   * Logs a debug message when a duplicate/overlapping state is detected so the
+   * guard condition is visible in session/call reports.
    */
-  private isDuplicateGatewayState(currentState: GatewayStateType): boolean {
+  private isDuplicateGatewayState(
+    currentState: GatewayStateType,
+    states: GatewayStateType[]
+  ): boolean {
     const { previousGatewayState } = this.session.connection;
-    const isDuplicate = previousGatewayState === currentState;
+    const isDuplicate = states.includes(
+      previousGatewayState as GatewayStateType
+    );
 
     if (isDuplicate) {
       logger.debug(

--- a/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
+++ b/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
@@ -373,12 +373,15 @@ class VertoHandler {
                 break;
               }
             case GatewayStateType.FAILED:
-            case GatewayStateType.FAIL_WAIT: {
+            case GatewayStateType.FAIL_WAIT:
+            case GatewayStateType.TIMEOUT: {
               if (
                 session.connection.previousGatewayState !==
                   GatewayStateType.FAILED &&
                 session.connection.previousGatewayState !==
-                  GatewayStateType.FAIL_WAIT
+                  GatewayStateType.FAIL_WAIT &&
+                session.connection.previousGatewayState !==
+                  GatewayStateType.TIMEOUT
               ) {
                 // Emit gateway failure on first occurrence
                 const gatewayError = createTelnyxError(
@@ -394,11 +397,15 @@ class VertoHandler {
                   session.uuid
                 );
 
+                // Avoid sticky reconnect to the same b2bua-rtc target by
+                // requesting a different instance on the next connect().
+                session.options.skipLastVoiceSdkId = true;
+
                 if (!this.session.hasAutoReconnect()) {
                   this.retriedConnect = 0;
                   const originalError = new ErrorResponse(
                     `Fail to connect the server, the server tried ${RETRY_CONNECT_TIME} times`,
-                    'FAILED|FAIL_WAIT'
+                    'FAILED|FAIL_WAIT|TIMEOUT'
                   );
                   const telnyxError = createTelnyxError(
                     RECONNECTION_EXHAUSTED,

--- a/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
+++ b/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
@@ -333,6 +333,11 @@ class VertoHandler {
 
                 params.type = NOTIFICATION_TYPE.vertoClientReady;
                 trigger(SwEvent.Ready, params, session.uuid);
+              } else {
+                logger.debug(
+                  `Received duplicate gateway state '${gateWayState}' matching previous state '${session.connection.previousGatewayState}' — ` +
+                    `skipping re-emission of client ready event (sessionId=${session.sessionid})`
+                );
               }
               break;
             }
@@ -400,6 +405,9 @@ class VertoHandler {
                 // Avoid sticky reconnect to the same b2bua-rtc target by
                 // requesting a different instance on the next connect().
                 session.options.skipLastVoiceSdkId = true;
+                logger.debug(
+                  `Set skipLastVoiceSdkId=true on session options to avoid sticky reconnect to same b2bua-rtc instance (sessionId=${session.sessionid})`
+                );
 
                 if (!this.session.hasAutoReconnect()) {
                   this.retriedConnect = 0;
@@ -472,6 +480,11 @@ class VertoHandler {
                     });
                   }, this.reconnectDelay());
                 }
+              } else {
+                logger.debug(
+                  `Received duplicate gateway state '${gateWayState}' matching previous state '${session.connection.previousGatewayState}' — ` +
+                    `skipping re-emission of gateway failure event (sessionId=${session.sessionid})`
+                );
               }
               break;
             }

--- a/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
+++ b/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
@@ -290,10 +290,10 @@ class VertoHandler {
             case GatewayStateType.REGISTER:
             case GatewayStateType.REGED: {
               if (
-                session.connection.previousGatewayState !==
-                  GatewayStateType.REGED &&
-                session.connection.previousGatewayState !==
-                  GatewayStateType.REGISTER
+                !this.isDuplicateGatewayState(gateWayState, [
+                  GatewayStateType.REGED,
+                  GatewayStateType.REGISTER,
+                ])
               ) {
                 this.session._triggerKeepAliveTimeoutCheck();
                 this.retriedRegister = 0;
@@ -333,11 +333,6 @@ class VertoHandler {
 
                 params.type = NOTIFICATION_TYPE.vertoClientReady;
                 trigger(SwEvent.Ready, params, session.uuid);
-              } else {
-                logger.debug(
-                  `Received duplicate gateway state '${gateWayState}' matching previous state '${session.connection.previousGatewayState}' — ` +
-                    `skipping re-emission of client ready event (sessionId=${session.sessionid})`
-                );
               }
               break;
             }
@@ -381,12 +376,11 @@ class VertoHandler {
             case GatewayStateType.FAIL_WAIT:
             case GatewayStateType.TIMEOUT: {
               if (
-                session.connection.previousGatewayState !==
-                  GatewayStateType.FAILED &&
-                session.connection.previousGatewayState !==
-                  GatewayStateType.FAIL_WAIT &&
-                session.connection.previousGatewayState !==
-                  GatewayStateType.TIMEOUT
+                !this.isDuplicateGatewayState(gateWayState, [
+                  GatewayStateType.FAILED,
+                  GatewayStateType.FAIL_WAIT,
+                  GatewayStateType.TIMEOUT,
+                ])
               ) {
                 // Emit gateway failure on first occurrence
                 const gatewayError = createTelnyxError(
@@ -480,11 +474,6 @@ class VertoHandler {
                     });
                   }, this.reconnectDelay());
                 }
-              } else {
-                logger.debug(
-                  `Received duplicate gateway state '${gateWayState}' matching previous state '${session.connection.previousGatewayState}' — ` +
-                    `skipping re-emission of gateway failure event (sessionId=${session.sessionid})`
-                );
               }
               break;
             }
@@ -498,6 +487,31 @@ class VertoHandler {
         break;
       }
     }
+  }
+
+  /**
+   * Checks whether the previous gateway state matches any of the states in the
+   * given bucket (e.g. [FAILED, FAIL_WAIT, TIMEOUT] or [REGED, REGISTER]).
+   * Logs a debug message when a duplicate/overlapping state is detected so the
+   * guard condition is visible in session/call reports.
+   */
+  private isDuplicateGatewayState(
+    currentState: GatewayStateType,
+    states: GatewayStateType[]
+  ): boolean {
+    const { previousGatewayState } = this.session.connection;
+    const isDuplicate = states.includes(
+      previousGatewayState as GatewayStateType
+    );
+
+    if (isDuplicate) {
+      logger.debug(
+        `Gateway state '${currentState}' received but previous state was '${previousGatewayState}' — ` +
+          `guard condition met, skipping re-emission (sessionId=${this.session.sessionid})`
+      );
+    }
+
+    return isDuplicate;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
+++ b/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
@@ -289,12 +289,7 @@ class VertoHandler {
             // If the user is REGED tell the client that it is ready to make calls
             case GatewayStateType.REGISTER:
             case GatewayStateType.REGED: {
-              if (
-                !this.isDuplicateGatewayState(gateWayState, [
-                  GatewayStateType.REGED,
-                  GatewayStateType.REGISTER,
-                ])
-              ) {
+              if (!this.isDuplicateGatewayState(gateWayState)) {
                 this.session._triggerKeepAliveTimeoutCheck();
                 this.retriedRegister = 0;
 
@@ -375,13 +370,7 @@ class VertoHandler {
             case GatewayStateType.FAILED:
             case GatewayStateType.FAIL_WAIT:
             case GatewayStateType.TIMEOUT: {
-              if (
-                !this.isDuplicateGatewayState(gateWayState, [
-                  GatewayStateType.FAILED,
-                  GatewayStateType.FAIL_WAIT,
-                  GatewayStateType.TIMEOUT,
-                ])
-              ) {
+              if (!this.isDuplicateGatewayState(gateWayState)) {
                 // Emit gateway failure on first occurrence
                 const gatewayError = createTelnyxError(
                   GATEWAY_FAILED,
@@ -490,19 +479,13 @@ class VertoHandler {
   }
 
   /**
-   * Checks whether the previous gateway state matches any of the states in the
-   * given bucket (e.g. [FAILED, FAIL_WAIT, TIMEOUT] or [REGED, REGISTER]).
-   * Logs a debug message when a duplicate/overlapping state is detected so the
-   * guard condition is visible in session/call reports.
+   * Checks whether the previous gateway state matches the current state.
+   * Logs a debug message when a duplicate state is detected so the guard
+   * condition is visible in session/call reports.
    */
-  private isDuplicateGatewayState(
-    currentState: GatewayStateType,
-    states: GatewayStateType[]
-  ): boolean {
+  private isDuplicateGatewayState(currentState: GatewayStateType): boolean {
     const { previousGatewayState } = this.session.connection;
-    const isDuplicate = states.includes(
-      previousGatewayState as GatewayStateType
-    );
+    const isDuplicate = previousGatewayState === currentState;
 
     if (isDuplicate) {
       logger.debug(

--- a/packages/js/src/Modules/Verto/webrtc/constants.ts
+++ b/packages/js/src/Modules/Verto/webrtc/constants.ts
@@ -115,6 +115,7 @@ export enum GatewayStateType {
   NOREG = 'NOREG',
   FAILED = 'FAILED',
   FAIL_WAIT = 'FAIL_WAIT',
+  TIMEOUT = 'TIMEOUT',
   REGISTER = 'REGISTER',
   TRYING = 'TRYING',
   EXPIRED = 'EXPIRED',


### PR DESCRIPTION
## What changed

- **Add `TIMEOUT` to `GatewayStateType` enum** — the server can return this state when the SIP registrar is unresponsive
- **Route `TIMEOUT` through the same terminal gateway-failure recovery path** as `FAILED` / `FAIL_WAIT` — emits `GATEWAY_FAILED` (45004) and attempts auto-reconnect
- **Set `skipLastVoiceSdkId = true` on gateway failure** — when the connection fails due to FAILED, FAIL_WAIT, or TIMEOUT, the SDK now requests a different b2bua-rtc instance on reconnect instead of sticky-routing to the same unresponsive target
- **Update `GATEWAY_FAILED` error description** to include TIMEOUT state
- **Add unit tests** for TIMEOUT gateway state handling

## Why

When the SIP registrar times out, the server returns a `TIMEOUT` gateway state. The client was not handling this state, leaving sessions stuck without recovery. This routes TIMEOUT through the same proven recovery path used for FAILED/FAIL_WAIT, and ensures reconnect attempts avoid the same broken b2bua-rtc instance.

## Linear

[VSUP-84](https://linear.app/telnyx/issue/VSUP-84/handle-timeout-and-failed-gateway-states-on-client)

## Test plan

- [x] Unit tests pass (354/354)
- [ ] TIMEOUT triggers `GATEWAY_FAILED` + auto-reconnect
- [ ] TIMEOUT with autoReconnect disabled emits terminal `RECONNECTION_EXHAUSTED`
- [ ] FAILED/TIMEOUT recovery does not reuse the same `voice_sdk_id`
- [ ] No reconnect-attempt reset occurs until confirmed `REGED`