### PR TITLE
fix(webrtc): add null guards to connection state event handlers

### DIFF
--- a/packages/js/src/Modules/Verto/webrtc/Peer.ts
+++ b/packages/js/src/Modules/Verto/webrtc/Peer.ts
@@ -317,12 +317,6 @@ export default class Peer {
   }
 
   private handleConnectionStateChange = async () => {
-    // Guard Clause: Prevent crashes if the peer connection instance is already null during teardown
-    if (!this.instance) {
-      logger.debug('Connection state change ignored: instance is null');
-      return;
-    }
-
     const { connectionState } = this.instance;
     logger.info(
       `[${new Date().toISOString()}] Connection State changed: ${
@@ -591,12 +585,7 @@ export default class Peer {
   }
 
   private _handleIceConnectionStateChange = () => {
-    // Guard Clause: Prevent crashes if the peer connection instance is already null during teardown
-    if (!this.instance) {
-      logger.debug('ICE connection state change ignored: instance is null');
-      return;
-    }
-
+    
     const state = this.instance.iceConnectionState;
     logger.debug(`[${new Date().toISOString()}] ICE Connection State`, state);
 

--- a/packages/js/src/Modules/Verto/webrtc/Peer.ts
+++ b/packages/js/src/Modules/Verto/webrtc/Peer.ts
@@ -317,6 +317,12 @@ export default class Peer {
   }
 
   private handleConnectionStateChange = async () => {
+    // Guard Clause: Prevent crashes if the peer connection instance is already null during teardown
+    if (!this.instance) {
+      logger.debug('Connection state change ignored: instance is null');
+      return;
+    }
+
     const { connectionState } = this.instance;
     logger.info(
       `[${new Date().toISOString()}] Connection State changed: ${
@@ -585,7 +591,12 @@ export default class Peer {
   }
 
   private _handleIceConnectionStateChange = () => {
-    
+    // Guard Clause: Prevent crashes if the peer connection instance is already null during teardown
+    if (!this.instance) {
+      logger.debug('ICE connection state change ignored: instance is null');
+      return;
+    }
+
     const state = this.instance.iceConnectionState;
     logger.debug(`[${new Date().toISOString()}] ICE Connection State`, state);
 

--- a/packages/js/src/Modules/Verto/webrtc/Peer.ts
+++ b/packages/js/src/Modules/Verto/webrtc/Peer.ts
@@ -317,6 +317,12 @@ export default class Peer {
   }
 
   private handleConnectionStateChange = async () => {
+    // Guard Clause: Prevent crashes if the peer connection instance is already null during teardown
+    if (!this.instance) {
+      logger.debug('Connection state change ignored: instance is null');
+      return;
+    }
+
     const { connectionState } = this.instance;
     logger.info(
       `[${new Date().toISOString()}] Connection State changed: ${
@@ -585,6 +591,12 @@ export default class Peer {
   }
 
   private _handleIceConnectionStateChange = () => {
+    // Guard Clause: Prevent crashes if the peer connection instance is already null during teardown
+    if (!this.instance) {
+      logger.debug('ICE connection state change ignored: instance is null');
+      return;
+    }
+
     const state = this.instance.iceConnectionState;
     logger.debug(`[${new Date().toISOString()}] ICE Connection State`, state);
 


### PR DESCRIPTION
## Summary
This PR adds guard clauses to `handleConnectionStateChange` and `_handleIceConnectionStateChange` to prevent potential `TypeError` crashes during call teardown.

## Why this is needed
In mobile and React Native environments, WebRTC events can fire asynchronously during or after call teardown. When `this.instance` is set to `null` but an event is still processed, the SDK attempts to access properties on a null object, which causes the host application to crash.

## Changes
- Added null checks at the beginning of `handleConnectionStateChange` and `_handleIceConnectionStateChange`.
- Added debug logging to identify when these events are triggered post-teardown.

## Testing
- Verified that call teardown no longer triggers unhandled exceptions in the event handlers.
- Confirmed that debug logs correctly capture the ignored events during teardown.