### PR TITLE
fix: preserve sessid during socket reconnect

### DIFF
--- a/packages/js/src/Modules/Verto/BaseSession.ts
+++ b/packages/js/src/Modules/Verto/BaseSession.ts
@@ -48,7 +48,6 @@ import {
   getReconnectSessionId,
   getReconnectToken,
   clearReconnectToken,
-  isReconnectSessionIdFresh,
   setReconnectSessionId,
 } from './util/reconnect';
 import { Ping } from './messages/verto/Ping';
@@ -676,9 +675,7 @@ export default abstract class BaseSession {
     const reconnectToken = getReconnectToken();
     const isReconnection = !!reconnectToken;
     const reconnectSessionId = isReconnection
-      ? (this.sessionid && isReconnectSessionIdFresh()
-          ? this.sessionid
-          : getReconnectSessionId()) || ''
+      ? this.sessionid || getReconnectSessionId() || ''
       : '';
 
     if (type === 'login') {

--- a/packages/js/src/Modules/Verto/tests/Verto.test.ts
+++ b/packages/js/src/Modules/Verto/tests/Verto.test.ts
@@ -227,6 +227,27 @@ describe('Verto', () => {
       expect(request.params.sessid).toBe('active-sessid');
     });
 
+    it('should preserve the in-memory sessid when the stored reconnect sessid is stale', async () => {
+      instance.sessionid = 'active-sessid';
+      setReconnectToken('voice-sdk-id');
+      setReconnectSessionId(
+        'stored-sessid',
+        Date.now() - 1 - RECONNECT_SESSION_ID_MAX_AGE_MS
+      );
+      Connection.mockResponse.mockImplementationOnce(() =>
+        JSON.parse(
+          '{"jsonrpc":"2.0","id":77,"result":{"message":"logged in","sessid":"active-sessid"}}'
+        )
+      );
+
+      await instance.login();
+
+      const { request } = Connection.mockSend.mock.calls[0][0];
+      expect(request.method).toBe('login');
+      expect(request.params.reconnection).toBe(true);
+      expect(request.params.sessid).toBe('active-sessid');
+    });
+
     it('should persist the successful login sessid for future reconnects', async () => {
       Connection.mockResponse.mockImplementationOnce(() =>
         JSON.parse(


### PR DESCRIPTION
## Summary
- Preserve the active in-memory Verto `sessid` when reconnecting an existing socket/session.
- Keep the stored reconnect `sessid` freshness guard for cross-instance/page reload reconnects.
- Add regression coverage for the TCP-path-drop case where the stored reconnect `sessid` has aged out but the live session still has the correct `sessid`.

## Test Plan
- `corepack yarn test packages/js/src/Modules/Verto/tests/Verto.test.ts --runInBand`
- `corepack yarn test packages/js/src/Modules/Verto/tests/reconnect.test.ts packages/js/src/Modules/Verto/tests/ReconnectAttempts.test.ts packages/js/src/Modules/Verto/tests/services/Connection.test.ts packages/js/src/Modules/Verto/tests/signaling-health/SignalingHealth.test.ts --runInBand`
- `corepack yarn exec tsc -p packages/js/tsconfig.json --noEmit`
- `git diff --check`

## Notes
- `corepack yarn workspace @telnyx/webrtc lint` still fails on pre-existing repo-wide lint issues (README/docs markdown anchors/fences, CommonJS config globals, legacy `any`/`Function` usage, test mocks, etc.). The changed files are covered by the targeted tests and TypeScript check above.

Linear: VSDK-255