### PR TITLE
fix: preserve sessid and socket close context

### DIFF
--- a/packages/js/src/Modules/Verto/BaseSession.ts
+++ b/packages/js/src/Modules/Verto/BaseSession.ts
@@ -97,7 +97,10 @@ export default abstract class BaseSession {
   private _tokenExpiryTimeout: ReturnType<typeof setTimeout> | null = null;
   private static readonly TOKEN_EXPIRY_WARNING_SECONDS = 120;
   private static readonly CALL_REPORT_UPLOAD_DRAIN_TIMEOUT_MS = 10000;
+  private static readonly SOCKET_CLOSE_CALL_REPORT_FLUSH_DELAY_MS = 30000;
   private _pendingCallReportUploads = new Set<Promise<void>>();
+  private _socketCloseCallReportWatcher: ReturnType<typeof setTimeout> | null =
+    null;
 
   // ── Signaling health monitor ──────────────────────────────────────────
   /** Handles liveness detection, health probing, and force-reconnect. */
@@ -311,6 +314,7 @@ export default abstract class BaseSession {
     this._autoReconnect = false;
     this._reconnectAttempts = 0;
     this.relayProtocol = null;
+    this._clearSocketCloseCallReportWatcher();
     await this._drainCallReportUploads();
     this._closeConnection();
     await sessionStorage.removeItem(this.signature);
@@ -720,9 +724,44 @@ export default abstract class BaseSession {
    * @return void
    */
   protected async _onSocketOpen() {
+    this._clearSocketCloseCallReportWatcher();
     // Socket liveness is monitored for the session lifetime. Media/peer
     // recovery decisions remain scoped to active calls inside the monitor.
     this.startSignalingHealthMonitor();
+  }
+
+  private _clearSocketCloseCallReportWatcher(): void {
+    if (this._socketCloseCallReportWatcher) {
+      clearTimeout(this._socketCloseCallReportWatcher);
+      this._socketCloseCallReportWatcher = null;
+    }
+  }
+
+  private _ensureGeneratedCallReportId(): void {
+    if (!this.callReportId) {
+      this.callReportId = `gen-${uuidv4()}`;
+    }
+  }
+
+  private _scheduleSocketCloseCallReportWatcher(
+    flushReason: ICallReportFlushReason
+  ): void {
+    this._clearSocketCloseCallReportWatcher();
+
+    this._socketCloseCallReportWatcher = setTimeout(() => {
+      this._socketCloseCallReportWatcher = null;
+
+      if (this.connection?.connected) {
+        return;
+      }
+
+      if (!this.hasActiveCall()) {
+        return;
+      }
+
+      this._ensureGeneratedCallReportId();
+      this._flushIntermediateCallReports(flushReason);
+    }, BaseSession.SOCKET_CLOSE_CALL_REPORT_FLUSH_DELAY_MS);
   }
 
   private _flushIntermediateCallReports(
@@ -809,6 +848,7 @@ export default abstract class BaseSession {
       ...flushReason.socketClose,
     });
     this._flushIntermediateCallReports(flushReason);
+    this._scheduleSocketCloseCallReportWatcher(flushReason);
 
     if (this.relayProtocol) {
       deRegisterAll(this.relayProtocol);

--- a/packages/js/src/Modules/Verto/BaseSession.ts
+++ b/packages/js/src/Modules/Verto/BaseSession.ts
@@ -48,7 +48,6 @@ import {
   getReconnectSessionId,
   getReconnectToken,
   clearReconnectToken,
-  isReconnectSessionIdFresh,
   setReconnectSessionId,
 } from './util/reconnect';
 import { Ping } from './messages/verto/Ping';
@@ -676,9 +675,7 @@ export default abstract class BaseSession {
     const reconnectToken = getReconnectToken();
     const isReconnection = !!reconnectToken;
     const reconnectSessionId = isReconnection
-      ? (this.sessionid && isReconnectSessionIdFresh()
-          ? this.sessionid
-          : getReconnectSessionId()) || ''
+      ? this.sessionid || getReconnectSessionId() || ''
       : '';
 
     if (type === 'login') {

--- a/packages/js/src/Modules/Verto/BaseSession.ts
+++ b/packages/js/src/Modules/Verto/BaseSession.ts
@@ -48,6 +48,7 @@ import {
   getReconnectSessionId,
   getReconnectToken,
   clearReconnectToken,
+  setLastSocketClose,
   setReconnectSessionId,
 } from './util/reconnect';
 import { Ping } from './messages/verto/Ping';
@@ -802,9 +803,12 @@ export default abstract class BaseSession {
     wasClean?: boolean;
     error?: unknown;
   }): void {
-    this._flushIntermediateCallReports(
-      this._createSocketCloseFlushReason(event)
-    );
+    const flushReason = this._createSocketCloseFlushReason(event);
+    setLastSocketClose({
+      type: event?.error ? 'socket-error' : 'socket-close',
+      ...flushReason.socketClose,
+    });
+    this._flushIntermediateCallReports(flushReason);
 
     if (this.relayProtocol) {
       deRegisterAll(this.relayProtocol);

--- a/packages/js/src/Modules/Verto/services/SignalingHealthMonitor.ts
+++ b/packages/js/src/Modules/Verto/services/SignalingHealthMonitor.ts
@@ -34,6 +34,13 @@ const PROBE_TIMEOUT_MS = 5 * 1000; // 5s after probe → give up
 const CHECK_INTERVAL_MS = 3 * 1000;
 
 /**
+ * If an active call exists but there is no OPEN WebSocket for this long, emit
+ * the same socket-close path used by real network closes so call reports are
+ * flushed even when the browser never delivers an onclose event.
+ */
+const NO_OPEN_SOCKET_TIMEOUT_MS = 20 * 1000;
+
+/**
  * If inbound WS activity was received within this window (ms),
  * signaling is considered recently active and a triggered probe
  * is skipped.
@@ -77,6 +84,9 @@ export default class SignalingHealthMonitor {
   /** The periodic check interval. */
   private _intervalId: ReturnType<typeof setInterval> | null = null;
 
+  /** When the monitor first observed that no WebSocket was OPEN. */
+  private _noOpenSocketSince: number = 0;
+
   /** Media recovery to execute only after a probe proves signaling is healthy. */
   private _pendingMediaRecovery: PendingMediaRecovery | null = null;
 
@@ -111,6 +121,7 @@ export default class SignalingHealthMonitor {
     this._lastInboundAt = Date.now();
     this._probeInFlight = false;
     this._lastProbeSentAt = 0;
+    this._noOpenSocketSince = 0;
 
     this._intervalId = setInterval(() => this._check(), CHECK_INTERVAL_MS);
   }
@@ -124,6 +135,7 @@ export default class SignalingHealthMonitor {
       this._intervalId = null;
       this._probeInFlight = false;
       this._lastProbeSentAt = 0;
+      this._noOpenSocketSince = 0;
     }
     this._pendingMediaRecovery = null;
     logger.debug('Signaling health: monitor stopped');
@@ -306,8 +318,11 @@ export default class SignalingHealthMonitor {
    */
   private _check(): void {
     if (!this._session.connection?.connected) {
+      this._checkNoOpenSocket();
       return;
     }
+
+    this._noOpenSocketSince = 0;
 
     const now = Date.now();
     const silenceMs = now - this._lastInboundAt;
@@ -337,6 +352,36 @@ export default class SignalingHealthMonitor {
         'probe'
       );
     }
+  }
+
+  private _checkNoOpenSocket(): void {
+    if (!this._session.hasActiveCall()) {
+      this._noOpenSocketSince = 0;
+      return;
+    }
+
+    const now = Date.now();
+    if (!this._noOpenSocketSince) {
+      this._noOpenSocketSince = now;
+      return;
+    }
+
+    const elapsedMs = now - this._noOpenSocketSince;
+    if (elapsedMs < NO_OPEN_SOCKET_TIMEOUT_MS) {
+      return;
+    }
+
+    logger.warn(
+      `Signaling health: no OPEN WebSocket for ${Math.round(elapsedMs / 1000)}s during active call — treating as abnormal socket close`
+    );
+
+    this._noOpenSocketSince = 0;
+    this._session.onNetworkClose({
+      code: 1006,
+      reason:
+        'NO_OPEN_SOCKET_TIMEOUT: no OPEN WebSocket while an active call is present',
+      wasClean: false,
+    });
   }
 
   /**

--- a/packages/js/src/Modules/Verto/tests/ReconnectAttempts.test.ts
+++ b/packages/js/src/Modules/Verto/tests/ReconnectAttempts.test.ts
@@ -16,6 +16,9 @@ jest.mock('../util/reconnect', () => ({
   getReconnectToken: jest.fn(() => null),
   setReconnectToken: jest.fn(),
   clearReconnectToken: jest.fn(),
+  getReconnectSessionId: jest.fn(() => null),
+  setReconnectSessionId: jest.fn(),
+  setLastSocketClose: jest.fn(),
 }));
 
 const mockTrigger = trigger as jest.MockedFunction<typeof trigger>;

--- a/packages/js/src/Modules/Verto/tests/ReconnectAttempts.test.ts
+++ b/packages/js/src/Modules/Verto/tests/ReconnectAttempts.test.ts
@@ -7,6 +7,7 @@
 import BaseSession from '../BaseSession';
 import { trigger } from '../services/Handler';
 import { SwEvent, RECONNECTION_EXHAUSTED } from '../util/constants';
+import { State } from '../webrtc/constants';
 
 // Mock dependencies
 jest.mock('../services/Connection');
@@ -188,6 +189,63 @@ describe('BaseSession - Reconnection Attempt Limit', () => {
       session.connect();
       expect(session._autoReconnect).toBe(true);
       expect(session._reconnectAttempts).toBe(0);
+    });
+
+    it('flushes active call reports when the socket stays disconnected and generates a gen-prefixed report id', () => {
+      const flushIntermediateCallReport = jest.fn();
+      session.callReportId = null;
+      session.calls = {
+        'active-call': {
+          id: 'active-call',
+          _state: State.Active,
+          flushIntermediateCallReport,
+        },
+      };
+
+      session.onNetworkClose({
+        code: 1006,
+        reason: 'network changed',
+        wasClean: false,
+      });
+      flushIntermediateCallReport.mockClear();
+
+      jest.runAllTimers();
+
+      expect(session.callReportId).toMatch(/^gen-/);
+      expect(flushIntermediateCallReport).toHaveBeenCalledTimes(1);
+      expect(flushIntermediateCallReport).toHaveBeenCalledWith({
+        type: 'socket-close',
+        socketClose: {
+          code: 1006,
+          codeName: 'ABNORMAL_CLOSURE',
+          reason: 'network changed',
+          wasClean: false,
+          error: undefined,
+        },
+      });
+    });
+
+    it('cancels the socket-close call report watcher when reconnect succeeds', () => {
+      const flushIntermediateCallReport = jest.fn();
+      session.callReportId = null;
+      session.calls = {
+        'active-call': {
+          id: 'active-call',
+          _state: State.Active,
+          flushIntermediateCallReport,
+        },
+      };
+
+      session.onNetworkClose({ code: 1006 });
+      flushIntermediateCallReport.mockClear();
+
+      mockConnection.connected = true;
+      session._onSocketOpen();
+      session.stopSignalingHealthMonitor();
+      jest.runAllTimers();
+
+      expect(flushIntermediateCallReport).not.toHaveBeenCalled();
+      expect(session.callReportId).toBeNull();
     });
   });
 

--- a/packages/js/src/Modules/Verto/tests/Verto.test.ts
+++ b/packages/js/src/Modules/Verto/tests/Verto.test.ts
@@ -227,6 +227,27 @@ describe('Verto', () => {
       expect(request.params.sessid).toBe('active-sessid');
     });
 
+    it('should preserve the in-memory sessid when the stored reconnect sessid is stale', async () => {
+      instance.sessionid = 'active-sessid';
+      setReconnectToken('voice-sdk-id');
+      setReconnectSessionId(
+        'stored-sessid',
+        Date.now() - 1 - RECONNECT_SESSION_ID_MAX_AGE_MS
+      );
+      Connection.mockResponse.mockImplementationOnce(() =>
+        JSON.parse(
+          '{"jsonrpc":"2.0","id":77,"result":{"message":"logged in","sessid":"active-sessid"}}'
+        )
+      );
+
+      await instance.login();
+
+      const { request } = Connection.mockSend.mock.calls[0][0];
+      expect(request.method).toBe('login');
+      expect(request.params.reconnection).toBe(true);
+      expect(request.params.sessid).toBe('active-sessid');
+    });
+
     it('should persist the successful login sessid for future reconnects', async () => {
       Connection.mockResponse.mockImplementationOnce(() =>
         JSON.parse(

--- a/packages/js/src/Modules/Verto/tests/behaveLike/BaseSession.spec.ts
+++ b/packages/js/src/Modules/Verto/tests/behaveLike/BaseSession.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-explicit-any */
 import { isQueued } from '../../services/Handler';
 import BaseSession from '../../BaseSession';
+import { getLastSocketClose } from '../../util/reconnect';
 const Connection = require('../../services/Connection');
 
 describe('BaseSession', () => {
@@ -147,6 +148,24 @@ export default (instance: any) => {
               wasClean: undefined,
               error: undefined,
             },
+          });
+        });
+
+        it('stores the last socket close metadata for future call reports', () => {
+          instance._autoReconnect = false;
+
+          instance.onNetworkClose({
+            code: 1006,
+            reason: 'network changed',
+            wasClean: false,
+          });
+
+          expect(getLastSocketClose()).toEqual({
+            type: 'socket-close',
+            code: 1006,
+            codeName: 'ABNORMAL_CLOSURE',
+            reason: 'network changed',
+            wasClean: false,
           });
         });
       });

--- a/packages/js/src/Modules/Verto/tests/reconnect.test.ts
+++ b/packages/js/src/Modules/Verto/tests/reconnect.test.ts
@@ -1,8 +1,10 @@
 import {
   clearReconnectToken,
+  getLastSocketClose,
   getReconnectSessionId,
   getReconnectToken,
   RECONNECT_SESSION_ID_MAX_AGE_MS,
+  setLastSocketClose,
   setReconnectSessionId,
   setReconnectToken,
 } from '../util/reconnect';
@@ -40,5 +42,25 @@ describe('reconnect token storage', () => {
     expect(
       getReconnectSessionId(1001 + RECONNECT_SESSION_ID_MAX_AGE_MS)
     ).toBeNull();
+  });
+
+  it('stores the last socket close metadata in browser session storage', () => {
+    setLastSocketClose({
+      type: 'socket-close',
+      code: 1006,
+      codeName: 'ABNORMAL_CLOSURE',
+      reason: 'network changed',
+      wasClean: false,
+    });
+
+    expect(getLastSocketClose()).toEqual({
+      type: 'socket-close',
+      code: 1006,
+      codeName: 'ABNORMAL_CLOSURE',
+      reason: 'network changed',
+      wasClean: false,
+    });
+
+    clearReconnectToken();
   });
 });

--- a/packages/js/src/Modules/Verto/tests/signaling-health/SignalingHealth.test.ts
+++ b/packages/js/src/Modules/Verto/tests/signaling-health/SignalingHealth.test.ts
@@ -819,6 +819,7 @@ describe('SignalingHealthMonitor – Recovery decision logic', () => {
     mockSession.hasActiveCall = jest.fn(() => true);
     mockSession.triggerIceRestart = jest.fn(() => ({ started: true }));
     mockSession.socketDisconnect = jest.fn();
+    mockSession.onNetworkClose = jest.fn();
     connection = new Connection(mockSession);
     connection.connect();
     await Promise.resolve();
@@ -970,6 +971,22 @@ describe('SignalingHealthMonitor – Recovery decision logic', () => {
 
     expect(connection.send).toHaveBeenCalledTimes(1);
     expect(monitor.isProbeInFlight).toBe(true);
+  });
+
+  it('treats a long-lived non-open socket during an active call as abnormal socket close', () => {
+    mockSession.connection = connection;
+    (connection as any)._wsClient.readyState = WS_STATE.CONNECTING;
+
+    monitor.start();
+    (monitor as any)._noOpenSocketSince = Date.now() - 20_001;
+    jest.advanceTimersByTime(3_001);
+
+    expect(mockSession.onNetworkClose).toHaveBeenCalledWith({
+      code: 1006,
+      reason:
+        'NO_OPEN_SOCKET_TIMEOUT: no OPEN WebSocket while an active call is present',
+      wasClean: false,
+    });
   });
 
   // Test 5: low audio level alone → no recovery

--- a/packages/js/src/Modules/Verto/tests/webrtc/Call.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/Call.test.ts
@@ -323,6 +323,39 @@ describe('Call', () => {
         expect.any(Function)
       );
     });
+
+    it('uses a generated call id for call reports when the call has no id', () => {
+      (session.connection as unknown as { host?: string }).host =
+        'wss://rtc.telnyx.com';
+      session.callReportId = 'call-report-id';
+      session.callReportVoiceSdkId = 'owning-session-voice-sdk-id';
+      (call as unknown as { id: string }).id = '';
+
+      const collector = {
+        flush: jest.fn((summary) => ({
+          summary,
+          stats: [],
+          segment: 0,
+        })),
+        sendPayload: jest.fn().mockResolvedValue(undefined),
+      };
+      (
+        call as unknown as { _callReportCollector: typeof collector }
+      )._callReportCollector = collector;
+
+      (
+        call as unknown as { _flushIntermediateReport: () => void }
+      )._flushIntermediateReport();
+
+      const summary = collector.flush.mock.calls[0][0];
+      expect(summary.callId).toBe('gen-mocked-uuid');
+      expect(collector.sendPayload).toHaveBeenCalledWith(
+        expect.objectContaining({ summary }),
+        'call-report-id',
+        'wss://rtc.telnyx.com',
+        'owning-session-voice-sdk-id'
+      );
+    });
   });
 
   describe('hangup cause codes', () => {

--- a/packages/js/src/Modules/Verto/tests/webrtc/Call.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/Call.test.ts
@@ -19,6 +19,7 @@ import {
   SwEvent,
 } from '../../util/constants';
 import logger from '../../util/logger';
+import { setLastSocketClose } from '../../util/reconnect';
 import Call from '../../webrtc/Call';
 import Peer from '../../webrtc/Peer';
 import Verto from '../..';
@@ -225,6 +226,13 @@ describe('Call', () => {
     it('uses the owning session voice_sdk_id when posting the report', async () => {
       (session.connection as unknown as { host?: string }).host =
         'wss://rtc.telnyx.com';
+      setLastSocketClose({
+        type: 'socket-close',
+        code: 1006,
+        codeName: 'ABNORMAL_CLOSURE',
+        reason: 'network changed',
+        wasClean: false,
+      });
       session.callReportId = 'call-report-id';
       session.callReportVoiceSdkId = 'owning-session-voice-sdk-id';
 
@@ -242,7 +250,17 @@ describe('Call', () => {
       )._postCallReport();
 
       expect(collector.postReport).toHaveBeenCalledWith(
-        expect.objectContaining({ callId: call.id }),
+        expect.objectContaining({
+          callId: call.id,
+          voiceSdkSessionId: session.sessionid,
+          lastSocketClose: {
+            type: 'socket-close',
+            code: 1006,
+            codeName: 'ABNORMAL_CLOSURE',
+            reason: 'network changed',
+            wasClean: false,
+          },
+        }),
         'call-report-id',
         'wss://rtc.telnyx.com',
         'owning-session-voice-sdk-id'
@@ -253,6 +271,10 @@ describe('Call', () => {
     it('submits and tracks intermediate reports with the owning session voice_sdk_id', () => {
       (session.connection as unknown as { host?: string }).host =
         'wss://rtc.telnyx.com';
+      setLastSocketClose({
+        type: 'socket-error',
+        error: 'socket hang up',
+      });
       session.callReportId = 'call-report-id';
       session.callReportVoiceSdkId = 'owning-session-voice-sdk-id';
       const payload = {
@@ -278,6 +300,17 @@ describe('Call', () => {
         call as unknown as { _flushIntermediateReport: () => void }
       )._flushIntermediateReport();
 
+      expect(collector.flush).toHaveBeenCalledWith(
+        expect.objectContaining({
+          callId: call.id,
+          voiceSdkSessionId: session.sessionid,
+          lastSocketClose: {
+            type: 'socket-error',
+            error: 'socket hang up',
+          },
+        }),
+        expect.anything()
+      );
       expect(collector.sendPayload).toHaveBeenCalledWith(
         payload,
         'call-report-id',

--- a/packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts
@@ -507,6 +507,38 @@ describe('CallReportCollector cadence', () => {
 });
 
 describe('CallReportCollector intermediate flushes', () => {
+  it('returns an empty-stats socket-close payload so network closes still produce a report', () => {
+    const collector = createCollector();
+
+    const payload = collector.flush(
+      { callId: 'call-id' },
+      {
+        type: 'socket-close',
+        socketClose: {
+          code: 1006,
+          codeName: 'ABNORMAL_CLOSURE',
+          reason: 'network close',
+          wasClean: false,
+        },
+      }
+    );
+
+    expect(payload).toMatchObject({
+      summary: { callId: 'call-id' },
+      stats: [],
+      segment: 0,
+      flushReason: {
+        type: 'socket-close',
+        socketClose: {
+          code: 1006,
+          codeName: 'ABNORMAL_CLOSURE',
+          reason: 'network close',
+          wasClean: false,
+        },
+      },
+    });
+  });
+
   it('requests time-based intermediate flushes while a call is active', async () => {
     const collector = new CallReportCollector({
       enabled: true,

--- a/packages/js/src/Modules/Verto/util/interfaces/SignalingHealth.ts
+++ b/packages/js/src/Modules/Verto/util/interfaces/SignalingHealth.ts
@@ -22,6 +22,12 @@ export interface ISignalingHealthSession {
   connection: Connection | null;
   hasActiveCall(): boolean;
   socketDisconnect(): void;
+  onNetworkClose(event?: {
+    code?: number;
+    reason?: string;
+    wasClean?: boolean;
+    error?: unknown;
+  }): void;
   /**
    * Trigger ICE restart on the call identified by callId.
    * Called by the health monitor when media/peer is unhealthy but

--- a/packages/js/src/Modules/Verto/util/reconnect.ts
+++ b/packages/js/src/Modules/Verto/util/reconnect.ts
@@ -2,8 +2,18 @@ const STORAGE_KEY = 'telnyx-voice-sdk-id';
 const SESSION_ID_STORAGE_KEY = 'telnyx-voice-sdk-session-id';
 const SESSION_ID_STORED_AT_STORAGE_KEY =
   'telnyx-voice-sdk-session-id-stored-at';
+const LAST_SOCKET_CLOSE_STORAGE_KEY = 'telnyx-voice-sdk-last-socket-close';
 
 export const RECONNECT_SESSION_ID_MAX_AGE_MS = 90 * 1000;
+
+export interface ILastSocketClose {
+  type: 'socket-close' | 'socket-error';
+  code?: number;
+  codeName?: string;
+  reason?: string;
+  wasClean?: boolean;
+  error?: string;
+}
 
 function getReconnectSessionIdStoredAt(): number | null {
   const storedAt = Number(
@@ -47,8 +57,28 @@ export function setReconnectSessionId(
   sessionStorage.setItem(SESSION_ID_STORED_AT_STORAGE_KEY, String(storedAt));
 }
 
+export function getLastSocketClose(): ILastSocketClose | null {
+  const value = sessionStorage.getItem(LAST_SOCKET_CLOSE_STORAGE_KEY);
+  if (!value) return null;
+
+  try {
+    return JSON.parse(value) as ILastSocketClose;
+  } catch {
+    sessionStorage.removeItem(LAST_SOCKET_CLOSE_STORAGE_KEY);
+    return null;
+  }
+}
+
+export function setLastSocketClose(socketClose: ILastSocketClose): void {
+  sessionStorage.setItem(
+    LAST_SOCKET_CLOSE_STORAGE_KEY,
+    JSON.stringify(socketClose)
+  );
+}
+
 export function clearReconnectToken(): void {
   sessionStorage.removeItem(STORAGE_KEY);
   sessionStorage.removeItem(SESSION_ID_STORAGE_KEY);
   sessionStorage.removeItem(SESSION_ID_STORED_AT_STORAGE_KEY);
+  sessionStorage.removeItem(LAST_SOCKET_CLOSE_STORAGE_KEY);
 }

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -102,6 +102,7 @@ export default abstract class BaseCall implements IWebRTCCall {
   private _webRTCStats: WebRTCStats | null;
   private _callReportCollector: CallReportCollector | null = null;
   private _mediaDeviceCollector: MediaDeviceCollector | null = null;
+  private _generatedCallReportCallId: string | null = null;
 
   /**
    * The call identifier.
@@ -2535,6 +2536,18 @@ export default abstract class BaseCall implements IWebRTCCall {
     return this.session.callReportVoiceSdkId || undefined;
   }
 
+  private _getCallReportCallId(): string {
+    if (this.id) {
+      return this.id;
+    }
+
+    if (!this._generatedCallReportCallId) {
+      this._generatedCallReportCallId = `gen-${uuidv4()}`;
+    }
+
+    return this._generatedCallReportCallId;
+  }
+
   /**
    * Flush an intermediate call report segment mid-call.
    * Used for periodic, size-limit, and socket-close safety flushes without
@@ -2568,7 +2581,7 @@ export default abstract class BaseCall implements IWebRTCCall {
     }
 
     const summary = {
-      callId: this.id,
+      callId: this._getCallReportCallId(),
       destinationNumber: this.options.destinationNumber,
       callerNumber: this.options.callerNumber,
       direction: (this.direction === Direction.Inbound
@@ -2587,6 +2600,7 @@ export default abstract class BaseCall implements IWebRTCCall {
 
     logger.info('Flushing intermediate call report', {
       callId: this.id,
+      reportCallId: summary.callId,
       flushReason,
       segment: payload.segment,
     });
@@ -2623,7 +2637,7 @@ export default abstract class BaseCall implements IWebRTCCall {
     }
 
     const summary = {
-      callId: this.id,
+      callId: this._getCallReportCallId(),
       destinationNumber: this.options.destinationNumber,
       callerNumber: this.options.callerNumber,
       direction: (this.direction === Direction.Inbound

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -47,6 +47,7 @@ import { isFunction, mutateLiveArrayData, objEmpty } from '../util/helpers';
 import { INotificationEventData } from '../util/interfaces';
 import { getIceCandidateErrorDetails } from '../util/debug';
 import logger from '../util/logger';
+import { getLastSocketClose } from '../util/reconnect';
 import {
   attachMediaStream,
   detachMediaStream,
@@ -2576,6 +2577,8 @@ export default abstract class BaseCall implements IWebRTCCall {
       state: this.state,
       telnyxSessionId: this.options.telnyxSessionId,
       telnyxLegId: this.options.telnyxLegId,
+      voiceSdkSessionId: this.session.sessionid,
+      lastSocketClose: getLastSocketClose() || undefined,
       sdkVersion: SDK_VERSION,
     };
 
@@ -2629,6 +2632,8 @@ export default abstract class BaseCall implements IWebRTCCall {
       state: this.state,
       telnyxSessionId: this.options.telnyxSessionId,
       telnyxLegId: this.options.telnyxLegId,
+      voiceSdkSessionId: this.session.sessionid,
+      lastSocketClose: getLastSocketClose() || undefined,
       sdkVersion: SDK_VERSION,
     };
 

--- a/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
+++ b/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
@@ -478,7 +478,15 @@ export class CallReportCollector {
     summary: ICallSummary,
     flushReason?: ICallReportFlushReason
   ): ICallReportPayload | null {
-    if (this._flushing || this.statsBuffer.length === 0) {
+    const isSocketFlush =
+      flushReason?.type === 'socket-close' ||
+      flushReason?.type === 'socket-error';
+    const logCount = this.logCollector?.getLogCount() ?? 0;
+
+    if (
+      this._flushing ||
+      (this.statsBuffer.length === 0 && logCount === 0 && !isSocketFlush)
+    ) {
       return null;
     }
 

--- a/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
+++ b/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
@@ -34,6 +34,7 @@ import {
   LOW_BYTES_SENT,
   ICE_CANDIDATE_PAIR_CHANGED,
 } from '../../../Modules/Verto/util/constants/errorCodes';
+import type { ILastSocketClose } from '../../../Modules/Verto/util/reconnect';
 
 /**
  * Extended RTCInboundRtpStreamStats with additional audio quality metrics
@@ -243,6 +244,7 @@ export interface ICallSummary {
   telnyxSessionId?: string;
   telnyxLegId?: string;
   voiceSdkSessionId?: string;
+  lastSocketClose?: ILastSocketClose;
   sdkVersion?: string;
   startTimestamp?: string;
   endTimestamp?: string;


### PR DESCRIPTION
## Summary
- Preserve the Voice SDK session id across transient socket/TCP network drops and reconnects.
- Persist the last socket close/error metadata in session storage during network close handling.
- Include `voiceSdkSessionId` and `lastSocketClose` context in final and intermediate call-report summaries.
- Add a socket-close watcher that flushes a call report when the socket stays closed, generating a `gen-` prefixed report id when no call id exists.
- Add regression coverage for sessid preservation, stored socket close metadata, and call-report summary metadata.

## Why a socket was terminated — call-report context
This PR makes call reports answer "why was this socket terminated?" by capturing close context at the point of failure and attaching it to the next report.

- `BaseSession.onNetworkClose(event)` builds an `ICallReportFlushReason` and persists `lastSocketClose` to `sessionStorage` with:
  - `type`: `socket-close` | `socket-error`
  - `code`: raw WebSocket close code
  - `codeName`: human-readable name mapped from `WS_CLOSE_CODES` (e.g. `1000 NORMAL_CLOSURE`, `1001 GOING_AWAY`, `1006 ABNORMAL_CLOSURE`, `1011 INTERNAL_ERROR`)
  - `reason`: close reason string (includes `STUCK_WS_TIMEOUT...` for the stuck-`CLOSING` safety path)
  - `wasClean`: clean vs. abnormal close
  - `error`: error message when the close originated from a socket error
- `BaseCall` final and intermediate report summaries include `lastSocketClose` + `voiceSdkSessionId`, so a report uploaded after reconnect still carries the cause of the prior socket termination.
- A socket-close watcher (`SOCKET_CLOSE_CALL_REPORT_FLUSH_DELAY_MS`) flushes a report via `_createSocketCloseFlushReason` when the socket remains closed and there is an active call; if no call id is present it generates a `gen-<uuid>` report id so the termination is still reported.

## Split out
- Deferred session-level call reports and SDK log persistence were split into #683.

## Test Plan
- `./.yarn/releases/yarn-4.3.1.cjs jest packages/js/src/Modules/Verto/tests/ReconnectAttempts.test.ts --runInBand --silent=false`
- `./.yarn/releases/yarn-4.3.1.cjs jest packages/js/src/Modules/Verto/tests/ReconnectAttempts.test.ts packages/js/src/Modules/Verto/tests/reconnect.test.ts packages/js/src/Modules/Verto/tests/Verto.test.ts packages/js/src/Modules/Verto/tests/webrtc/Call.test.ts --runInBand --silent=false`
- `./.yarn/releases/yarn-4.3.1.cjs exec tsc -p packages/js/tsconfig.json --noEmit`
- `./.yarn/releases/yarn-4.3.1.cjs workspace @telnyx/webrtc exec prettier --check src/Modules/Verto/tests/ReconnectAttempts.test.ts src/Modules/Verto/BaseSession.ts src/Modules/Verto/util/reconnect.ts src/Modules/Verto/webrtc/BaseCall.ts src/Modules/Verto/webrtc/CallReportCollector.ts src/Modules/Verto/tests/reconnect.test.ts src/Modules/Verto/tests/behaveLike/BaseSession.spec.ts src/Modules/Verto/tests/webrtc/Call.test.ts`
- `./.yarn/releases/yarn-4.3.1.cjs workspace @telnyx/webrtc exec eslint src/Modules/Verto/tests/ReconnectAttempts.test.ts`
- `git diff --check`
