### PR TITLE
fix: allow socket-close log-only call report flushes

### DIFF
--- a/packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts
@@ -83,6 +83,92 @@ const createStatsEntry = (audioLevelAvg: number): IStatsInterval => ({
 });
 
 describe('CallReportCollector intermediate reports', () => {
+  it('allows socket-close intermediate reports with logs but no stats', () => {
+    const collector = createCollector();
+    const logEntry = {
+      timestamp: '2026-06-17T20:49:00.000Z',
+      level: 'warn' as const,
+      message: 'socket closed after safety flush',
+      context: { socketGeneration: 2 },
+    };
+    (collector as unknown as { logCollector: unknown }).logCollector = {
+      getLogCount: jest.fn(() => 1),
+      drain: jest.fn(() => [logEntry]),
+    };
+
+    const payload = collector.flush(
+      { callId: 'call-id' },
+      {
+        type: 'socket-close',
+        socketClose: {
+          code: 1006,
+          codeName: 'ABNORMAL_CLOSURE',
+          reason: 'network changed',
+          wasClean: false,
+        },
+      }
+    );
+
+    expect(payload).toEqual(
+      expect.objectContaining({
+        segment: 0,
+        stats: [],
+        logs: [logEntry],
+        flushReason: {
+          type: 'socket-close',
+          socketClose: {
+            code: 1006,
+            codeName: 'ABNORMAL_CLOSURE',
+            reason: 'network changed',
+            wasClean: false,
+          },
+        },
+      })
+    );
+  });
+
+  it('allows socket-close intermediate reports with metadata but no stats or logs', () => {
+    const collector = createCollector();
+
+    const payload = collector.flush(
+      { callId: 'call-id' },
+      {
+        type: 'socket-close',
+        socketClose: {
+          code: 1006,
+          codeName: 'ABNORMAL_CLOSURE',
+          reason: 'network changed',
+          wasClean: false,
+        },
+      }
+    );
+
+    expect(payload).toEqual(
+      expect.objectContaining({
+        segment: 0,
+        stats: [],
+        flushReason: expect.objectContaining({ type: 'socket-close' }),
+      })
+    );
+  });
+
+  it('logs why non-socket intermediate flushes are skipped when nothing is buffered', () => {
+    const debugSpy = jest.spyOn(logger, 'debug').mockImplementation(jest.fn());
+    const collector = createCollector();
+
+    expect(collector.flush({ callId: 'call-id' })).toBeNull();
+    expect(debugSpy).toHaveBeenCalledWith(
+      'CallReportCollector: Skipping intermediate flush',
+      expect.objectContaining({
+        reason: 'no-stats-or-logs',
+        statsIntervals: 0,
+        logEntries: 0,
+      })
+    );
+
+    debugSpy.mockRestore();
+  });
+
   it('includes flush reason metadata in intermediate report payloads', () => {
     const collector = createCollector();
     const statsEntry = createStatsEntry(0.5);

--- a/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
+++ b/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
@@ -476,7 +476,20 @@ export class CallReportCollector {
     summary: ICallSummary,
     flushReason?: ICallReportFlushReason
   ): ICallReportPayload | null {
-    if (this._flushing || this.statsBuffer.length === 0) {
+    const statsCount = this.statsBuffer.length;
+    const logCount = this.logCollector?.getLogCount() ?? 0;
+    const isSocketFlush =
+      flushReason?.type === 'socket-close' ||
+      flushReason?.type === 'socket-error';
+    const hasFlushableData = statsCount > 0 || logCount > 0 || isSocketFlush;
+
+    if (this._flushing || !hasFlushableData) {
+      logger.debug('CallReportCollector: Skipping intermediate flush', {
+        reason: this._flushing ? 'already-flushing' : 'no-stats-or-logs',
+        flushReason,
+        statsIntervals: statsCount,
+        logEntries: logCount,
+      });
       return null;
     }
 
@@ -1064,16 +1077,20 @@ export class CallReportCollector {
   }
 
   private _requestIntermediateFlushIfNeeded(now: Date): void {
-    if (
-      !this.onFlushNeeded ||
-      this._flushing ||
-      this.statsBuffer.length === 0
-    ) {
+    const statsCount = this.statsBuffer.length;
+    const logCount = this.logCollector?.getLogCount() ?? 0;
+
+    if (!this.onFlushNeeded || this._flushing) {
       return;
     }
 
-    const statsCount = this.statsBuffer.length;
-    const logCount = this.logCollector?.getLogCount() ?? 0;
+    if (statsCount === 0 && logCount === 0) {
+      logger.debug(
+        'CallReportCollector: Skipping intermediate flush request — no stats or logs buffered'
+      );
+      return;
+    }
+
     const intermediateReportInterval = this._getIntermediateReportInterval();
     const msSinceLastFlush =
       now.getTime() - this._lastIntermediateFlushTime.getTime();


### PR DESCRIPTION
## Summary
- allow intermediate call-report flushes when socket-close/socket-error metadata exists even if stats were just drained
- allow log-only intermediate flush requests instead of requiring statsBuffer entries
- add debug logging when non-socket intermediate flushes are skipped because there are no stats/logs
- add regression coverage for socket-close payloads after safety/intermediate flush drained stats

## Test plan
- npx jest packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts --runInBand
- npx tsc -p packages/js/tsconfig.json --noEmit