### PR TITLE
fix: defer session call reports with sdk logs

### DIFF
--- a/packages/js/src/Modules/Verto/BaseSession.ts
+++ b/packages/js/src/Modules/Verto/BaseSession.ts
@@ -1,5 +1,6 @@
 import type { Logger } from 'loglevel';
 import { v4 as uuidv4 } from 'uuid';
+import pkg from '../../../package.json';
 import BaseMessage from './messages/BaseMessage';
 import Connection from './services/Connection';
 import {
@@ -55,15 +56,33 @@ import { Ping } from './messages/verto/Ping';
 import { Login } from './messages/Verto';
 import { AnonymousLogin } from './messages/verto/AnonymousLogin';
 import { ERROR_TYPE } from './webrtc/constants';
-import type { ICallReportFlushReason } from './webrtc/CallReportCollector';
+import {
+  CallReportCollector,
+  type ICallReportFlushReason,
+  type ICallReportPayload,
+} from './webrtc/CallReportCollector';
 import type { ITelnyxWarningEvent } from './util/constants/warnings';
 import type { RestartIceResult } from './webrtc/Peer';
+import { getGlobalLogCollector, type ILogEntry } from './util/LogCollector';
 
 /**
  * b2bua-rtc ping interval is 30 seconds, timeout in VSP is 60 seconds.
  * Using intervals here that are in between both to make sure we don't let the session expire without acting first.
  */
 const KEEPALIVE_INTERVAL = 35 * 1000;
+const SDK_VERSION = pkg.version;
+const PENDING_SESSION_CALL_REPORTS_STORAGE_KEY =
+  'telnyx-voice-sdk-pending-session-call-reports';
+const MAX_PENDING_SESSION_CALL_REPORTS = 5;
+
+interface IPendingSessionCallReport {
+  id: string;
+  payload: ICallReportPayload;
+  storedAt: string;
+  sourceSessionId?: string;
+  sourceSessionUuid: string;
+  sourceVoiceSdkId?: string;
+}
 
 export default abstract class BaseSession {
   public uuid: string = uuidv4();
@@ -727,6 +746,178 @@ export default abstract class BaseSession {
     this.startSignalingHealthMonitor();
   }
 
+  private _getPendingSessionCallReports(): IPendingSessionCallReport[] {
+    const value = sessionStorage.getItem(
+      PENDING_SESSION_CALL_REPORTS_STORAGE_KEY
+    );
+    if (!value) return [];
+
+    try {
+      const parsed = JSON.parse(value) as IPendingSessionCallReport[];
+      return Array.isArray(parsed) ? parsed : [];
+    } catch {
+      sessionStorage.removeItem(PENDING_SESSION_CALL_REPORTS_STORAGE_KEY);
+      return [];
+    }
+  }
+
+  private _setPendingSessionCallReports(
+    reports: IPendingSessionCallReport[]
+  ): void {
+    if (reports.length === 0) {
+      sessionStorage.removeItem(PENDING_SESSION_CALL_REPORTS_STORAGE_KEY);
+      return;
+    }
+
+    sessionStorage.setItem(
+      PENDING_SESSION_CALL_REPORTS_STORAGE_KEY,
+      JSON.stringify(reports.slice(-MAX_PENDING_SESSION_CALL_REPORTS))
+    );
+  }
+
+  private _removePendingSessionCallReport(id: string): void {
+    this._setPendingSessionCallReports(
+      this._getPendingSessionCallReports().filter((report) => report.id !== id)
+    );
+  }
+
+  private _storePendingSessionCallReport(
+    flushReason: ICallReportFlushReason
+  ): void {
+    if (this.hasActiveCall()) return;
+
+    const socketClose = flushReason.socketClose;
+    const hasSocketReference = Boolean(
+      socketClose?.code !== undefined ||
+      socketClose?.reason ||
+      socketClose?.error ||
+      socketClose?.wasClean !== undefined
+    );
+    const capturedLogs = getGlobalLogCollector()?.getLogs() ?? [];
+
+    if (!hasSocketReference && capturedLogs.length === 0) {
+      return;
+    }
+
+    const storedAt = new Date().toISOString();
+    const pendingReportId = uuidv4();
+    const generatedCallId = `gen-${uuidv4()}`;
+    const sourceSessionId = this.sessionid || undefined;
+    const sourceVoiceSdkId = this.callReportVoiceSdkId || undefined;
+    const referenceLog: ILogEntry = {
+      timestamp: storedAt,
+      level: socketClose?.error ? 'error' : 'warn',
+      message:
+        'WebSocket closed without an active call; deferring session call report until the next successful SDK init',
+      context: {
+        pendingReportId,
+        generatedCallId,
+        sourceSessionId,
+        sourceSessionUuid: this.uuid,
+        sourceVoiceSdkId,
+        socketClose,
+      },
+    };
+
+    const payload: ICallReportPayload = {
+      summary: {
+        callId: generatedCallId,
+        state: 'session',
+        voiceSdkSessionId: sourceSessionId,
+        lastSocketClose: socketClose
+          ? {
+              type:
+                flushReason.type === 'socket-error'
+                  ? 'socket-error'
+                  : 'socket-close',
+              ...socketClose,
+            }
+          : undefined,
+        sdkVersion: SDK_VERSION,
+        startTimestamp: capturedLogs[0]?.timestamp ?? storedAt,
+        endTimestamp: storedAt,
+      },
+      stats: [],
+      logs: [...capturedLogs, referenceLog],
+      segment: 0,
+      flushReason,
+    };
+
+    this._setPendingSessionCallReports([
+      ...this._getPendingSessionCallReports(),
+      {
+        id: pendingReportId,
+        payload,
+        storedAt,
+        sourceSessionId,
+        sourceSessionUuid: this.uuid,
+        sourceVoiceSdkId,
+      },
+    ]);
+
+    logger.info('Stored deferred session call report', {
+      pendingReportId,
+      generatedCallId,
+      sourceSessionId,
+      sourceVoiceSdkId,
+      logEntries: payload.logs?.length ?? 0,
+      flushReason,
+    });
+  }
+
+  public flushPendingSessionCallReports(): void {
+    const callReportId = this.callReportId;
+    const host = this.connection?.host;
+
+    if (!callReportId || !host) return;
+
+    const pendingReports = this._getPendingSessionCallReports();
+    if (pendingReports.length === 0) return;
+
+    const sender = new CallReportCollector({ enabled: true, interval: 5000 });
+    const currentSessionId = this.sessionid || undefined;
+    const currentVoiceSdkId = this.callReportVoiceSdkId || undefined;
+
+    pendingReports.forEach((report) => {
+      const uploadedAt = new Date().toISOString();
+      const payload: ICallReportPayload = {
+        ...report.payload,
+        logs: [
+          ...(report.payload.logs ?? []),
+          {
+            timestamp: uploadedAt,
+            level: 'info',
+            message:
+              'Uploading deferred session call report after successful SDK init',
+            context: {
+              pendingReportId: report.id,
+              sourceSessionId: report.sourceSessionId,
+              sourceSessionUuid: report.sourceSessionUuid,
+              sourceVoiceSdkId: report.sourceVoiceSdkId,
+              currentSessionId,
+              currentVoiceSdkId,
+              storedAt: report.storedAt,
+            },
+          },
+        ],
+      };
+
+      const upload = sender
+        .sendPayload(payload, callReportId, host, currentVoiceSdkId)
+        .then(() => {
+          this._removePendingSessionCallReport(report.id);
+        })
+        .catch((error) => {
+          logger.error('Failed to upload deferred session call report', {
+            pendingReportId: report.id,
+            error,
+          });
+        });
+
+      this.trackCallReportUpload(upload);
+    });
+  }
+
   private _flushIntermediateCallReports(
     flushReason: ICallReportFlushReason
   ): void {
@@ -805,9 +996,9 @@ export default abstract class BaseSession {
     wasClean?: boolean;
     error?: unknown;
   }): void {
-    this._flushIntermediateCallReports(
-      this._createSocketCloseFlushReason(event)
-    );
+    const flushReason = this._createSocketCloseFlushReason(event);
+    this._flushIntermediateCallReports(flushReason);
+    this._storePendingSessionCallReport(flushReason);
 
     if (this.relayProtocol) {
       deRegisterAll(this.relayProtocol);

--- a/packages/js/src/Modules/Verto/BaseSession.ts
+++ b/packages/js/src/Modules/Verto/BaseSession.ts
@@ -44,7 +44,10 @@ import {
   IVertoOptions,
 } from './util/interfaces';
 import type { INotification } from '../../utils/interfaces';
-import logger, { setConsoleLoggerMinLevel } from './util/logger';
+import logger, {
+  drainStoredSdkLogs,
+  setConsoleLoggerMinLevel,
+} from './util/logger';
 import {
   getReconnectSessionId,
   getReconnectToken,
@@ -746,17 +749,27 @@ export default abstract class BaseSession {
     this.startSignalingHealthMonitor();
   }
 
+  private _getBrowserStorage(): Storage | null {
+    if (typeof window === 'undefined') return null;
+    try {
+      return window.localStorage ?? null;
+    } catch {
+      return null;
+    }
+  }
+
   private _getPendingSessionCallReports(): IPendingSessionCallReport[] {
-    const value = sessionStorage.getItem(
-      PENDING_SESSION_CALL_REPORTS_STORAGE_KEY
-    );
+    const storage = this._getBrowserStorage();
+    if (!storage) return [];
+
+    const value = storage.getItem(PENDING_SESSION_CALL_REPORTS_STORAGE_KEY);
     if (!value) return [];
 
     try {
       const parsed = JSON.parse(value) as IPendingSessionCallReport[];
       return Array.isArray(parsed) ? parsed : [];
     } catch {
-      sessionStorage.removeItem(PENDING_SESSION_CALL_REPORTS_STORAGE_KEY);
+      storage.removeItem(PENDING_SESSION_CALL_REPORTS_STORAGE_KEY);
       return [];
     }
   }
@@ -764,15 +777,28 @@ export default abstract class BaseSession {
   private _setPendingSessionCallReports(
     reports: IPendingSessionCallReport[]
   ): void {
+    const storage = this._getBrowserStorage();
+    if (!storage) return;
+
     if (reports.length === 0) {
-      sessionStorage.removeItem(PENDING_SESSION_CALL_REPORTS_STORAGE_KEY);
+      storage.removeItem(PENDING_SESSION_CALL_REPORTS_STORAGE_KEY);
       return;
     }
 
-    sessionStorage.setItem(
+    storage.setItem(
       PENDING_SESSION_CALL_REPORTS_STORAGE_KEY,
       JSON.stringify(reports.slice(-MAX_PENDING_SESSION_CALL_REPORTS))
     );
+  }
+
+  private _dedupeLogs(logs: ILogEntry[]): ILogEntry[] {
+    const seen = new Set<string>();
+    return logs.filter((log) => {
+      const key = `${log.timestamp}|${log.level}|${log.message}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
   }
 
   private _removePendingSessionCallReport(id: string): void {
@@ -793,7 +819,10 @@ export default abstract class BaseSession {
       socketClose?.error ||
       socketClose?.wasClean !== undefined
     );
-    const capturedLogs = getGlobalLogCollector()?.getLogs() ?? [];
+    const capturedLogs = this._dedupeLogs([
+      ...drainStoredSdkLogs(),
+      ...(getGlobalLogCollector()?.getLogs() ?? []),
+    ]).slice(-500);
 
     if (!hasSocketReference && capturedLogs.length === 0) {
       return;

--- a/packages/js/src/Modules/Verto/tests/ReconnectAttempts.test.ts
+++ b/packages/js/src/Modules/Verto/tests/ReconnectAttempts.test.ts
@@ -7,6 +7,7 @@
 import BaseSession from '../BaseSession';
 import { trigger } from '../services/Handler';
 import { SwEvent, RECONNECTION_EXHAUSTED } from '../util/constants';
+import { State } from '../webrtc/constants';
 
 // Mock dependencies
 jest.mock('../services/Connection');
@@ -19,6 +20,8 @@ jest.mock('../util/reconnect', () => ({
 }));
 
 const mockTrigger = trigger as jest.MockedFunction<typeof trigger>;
+const PENDING_SESSION_CALL_REPORTS_STORAGE_KEY =
+  'telnyx-voice-sdk-pending-session-call-reports';
 
 /**
  * Concrete subclass for testing the abstract BaseSession
@@ -32,6 +35,7 @@ class TestSession extends BaseSession {
 describe('BaseSession - Reconnection Attempt Limit', () => {
   let session: any;
   let mockConnection: any;
+  let originalFetch: typeof fetch | undefined;
 
   const createSession = (options: any = {}) => {
     return new TestSession({
@@ -44,6 +48,8 @@ describe('BaseSession - Reconnection Attempt Limit', () => {
   beforeEach(() => {
     jest.useFakeTimers();
     mockTrigger.mockClear();
+    sessionStorage.removeItem(PENDING_SESSION_CALL_REPORTS_STORAGE_KEY);
+    originalFetch = global.fetch;
 
     session = createSession();
     mockConnection = {
@@ -59,6 +65,12 @@ describe('BaseSession - Reconnection Attempt Limit', () => {
   });
 
   afterEach(() => {
+    sessionStorage.removeItem(PENDING_SESSION_CALL_REPORTS_STORAGE_KEY);
+    if (originalFetch) {
+      global.fetch = originalFetch;
+    } else {
+      delete (global as unknown as { fetch?: typeof fetch }).fetch;
+    }
     jest.useRealTimers();
   });
 
@@ -185,6 +197,124 @@ describe('BaseSession - Reconnection Attempt Limit', () => {
       session.connect();
       expect(session._autoReconnect).toBe(true);
       expect(session._reconnectAttempts).toBe(0);
+    });
+
+    it('stores socket-close logs without an active call and uploads them after the next successful SDK init', async () => {
+      session.callReportId = null;
+      session.sessionid = 'old-session-id';
+      session.callReportVoiceSdkId = 'old-voice-sdk-id';
+
+      session.onNetworkClose({
+        code: 1006,
+        reason: 'network changed',
+        wasClean: false,
+      });
+
+      expect(session.callReportId).toBeNull();
+
+      const pending = JSON.parse(
+        sessionStorage.getItem(PENDING_SESSION_CALL_REPORTS_STORAGE_KEY) || '[]'
+      );
+      expect(pending).toHaveLength(1);
+      expect(pending[0].sourceSessionId).toBe('old-session-id');
+      expect(pending[0].sourceVoiceSdkId).toBe('old-voice-sdk-id');
+      expect(pending[0].payload).toMatchObject({
+        summary: {
+          callId: 'gen-mocked-uuid',
+          state: 'session',
+          voiceSdkSessionId: 'old-session-id',
+          lastSocketClose: {
+            type: 'socket-close',
+            code: 1006,
+            codeName: 'ABNORMAL_CLOSURE',
+            reason: 'network changed',
+            wasClean: false,
+          },
+        },
+        stats: [],
+        segment: 0,
+        flushReason: {
+          type: 'socket-close',
+          socketClose: {
+            code: 1006,
+            codeName: 'ABNORMAL_CLOSURE',
+            reason: 'network changed',
+            wasClean: false,
+          },
+        },
+      });
+      expect(pending[0].payload.logs[0]).toMatchObject({
+        level: 'warn',
+        context: {
+          generatedCallId: 'gen-mocked-uuid',
+          sourceSessionId: 'old-session-id',
+          sourceVoiceSdkId: 'old-voice-sdk-id',
+        },
+      });
+
+      const fetchMock = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 202,
+        text: () => Promise.resolve(''),
+      });
+      global.fetch = fetchMock as unknown as typeof fetch;
+
+      session.callReportId = 'new-call-report-id';
+      session.sessionid = 'new-session-id';
+      session.callReportVoiceSdkId = 'new-voice-sdk-id';
+      mockConnection.host = 'wss://rtc.telnyx.com';
+      session.flushPendingSessionCallReports();
+      await session._drainCallReportUploads();
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock.mock.calls[0][0]).toBe(
+        'https://rtc.telnyx.com/call_report'
+      );
+      expect(fetchMock.mock.calls[0][1].headers).toMatchObject({
+        'x-call-report-id': 'new-call-report-id',
+        'x-call-id': 'gen-mocked-uuid',
+        'x-voice-sdk-id': 'new-voice-sdk-id',
+      });
+
+      const uploadedBody = JSON.parse(fetchMock.mock.calls[0][1].body);
+      expect(uploadedBody.logs).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            message:
+              'Uploading deferred session call report after successful SDK init',
+            context: expect.objectContaining({
+              sourceSessionId: 'old-session-id',
+              sourceVoiceSdkId: 'old-voice-sdk-id',
+              currentSessionId: 'new-session-id',
+              currentVoiceSdkId: 'new-voice-sdk-id',
+            }),
+          }),
+        ])
+      );
+
+      expect(
+        sessionStorage.getItem(PENDING_SESSION_CALL_REPORTS_STORAGE_KEY)
+      ).toBeNull();
+    });
+
+    it('does not store deferred session reports when an active call owns the socket-close report', () => {
+      const flushIntermediateCallReport = jest.fn();
+      session.callReportId = null;
+      session.calls = {
+        'active-call': {
+          id: 'active-call',
+          _state: State.Active,
+          flushIntermediateCallReport,
+        },
+      };
+
+      session.onNetworkClose({ code: 1006 });
+
+      expect(flushIntermediateCallReport).toHaveBeenCalledTimes(1);
+      expect(session.callReportId).toBeNull();
+      expect(
+        sessionStorage.getItem(PENDING_SESSION_CALL_REPORTS_STORAGE_KEY)
+      ).toBeNull();
     });
   });
 

--- a/packages/js/src/Modules/Verto/tests/ReconnectAttempts.test.ts
+++ b/packages/js/src/Modules/Verto/tests/ReconnectAttempts.test.ts
@@ -7,19 +7,36 @@
 import BaseSession from '../BaseSession';
 import { trigger } from '../services/Handler';
 import { SwEvent, RECONNECTION_EXHAUSTED } from '../util/constants';
+import { drainStoredSdkLogs } from '../util/logger';
 import { State } from '../webrtc/constants';
 
 // Mock dependencies
 jest.mock('../services/Connection');
 jest.mock('../services/Handler');
-jest.mock('../util/logger');
+jest.mock('../util/logger', () => ({
+  __esModule: true,
+  default: {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+  drainStoredSdkLogs: jest.fn(() => []),
+  setConsoleLoggerMinLevel: jest.fn(),
+}));
 jest.mock('../util/reconnect', () => ({
+  getReconnectSessionId: jest.fn(() => null),
   getReconnectToken: jest.fn(() => null),
+  setReconnectSessionId: jest.fn(),
   setReconnectToken: jest.fn(),
   clearReconnectToken: jest.fn(),
+  isReconnectSessionIdFresh: jest.fn(() => false),
 }));
 
 const mockTrigger = trigger as jest.MockedFunction<typeof trigger>;
+const mockDrainStoredSdkLogs = drainStoredSdkLogs as jest.MockedFunction<
+  typeof drainStoredSdkLogs
+>;
 const PENDING_SESSION_CALL_REPORTS_STORAGE_KEY =
   'telnyx-voice-sdk-pending-session-call-reports';
 
@@ -48,7 +65,9 @@ describe('BaseSession - Reconnection Attempt Limit', () => {
   beforeEach(() => {
     jest.useFakeTimers();
     mockTrigger.mockClear();
-    sessionStorage.removeItem(PENDING_SESSION_CALL_REPORTS_STORAGE_KEY);
+    mockDrainStoredSdkLogs.mockClear();
+    mockDrainStoredSdkLogs.mockReturnValue([]);
+    localStorage.removeItem(PENDING_SESSION_CALL_REPORTS_STORAGE_KEY);
     originalFetch = global.fetch;
 
     session = createSession();
@@ -65,7 +84,7 @@ describe('BaseSession - Reconnection Attempt Limit', () => {
   });
 
   afterEach(() => {
-    sessionStorage.removeItem(PENDING_SESSION_CALL_REPORTS_STORAGE_KEY);
+    localStorage.removeItem(PENDING_SESSION_CALL_REPORTS_STORAGE_KEY);
     if (originalFetch) {
       global.fetch = originalFetch;
     } else {
@@ -203,6 +222,20 @@ describe('BaseSession - Reconnection Attempt Limit', () => {
       session.callReportId = null;
       session.sessionid = 'old-session-id';
       session.callReportVoiceSdkId = 'old-voice-sdk-id';
+      mockDrainStoredSdkLogs.mockReturnValue([
+        {
+          timestamp: '2026-06-17T20:52:00.000Z',
+          level: 'debug',
+          message: 'WebSocket connection created',
+          context: { socketGeneration: 1 },
+        },
+        {
+          timestamp: '2026-06-17T20:52:01.000Z',
+          level: 'error',
+          message: 'WebSocket error',
+          context: { error: 'network changed' },
+        },
+      ]);
 
       session.onNetworkClose({
         code: 1006,
@@ -211,9 +244,10 @@ describe('BaseSession - Reconnection Attempt Limit', () => {
       });
 
       expect(session.callReportId).toBeNull();
+      expect(mockDrainStoredSdkLogs).toHaveBeenCalledTimes(1);
 
       const pending = JSON.parse(
-        sessionStorage.getItem(PENDING_SESSION_CALL_REPORTS_STORAGE_KEY) || '[]'
+        localStorage.getItem(PENDING_SESSION_CALL_REPORTS_STORAGE_KEY) || '[]'
       );
       expect(pending).toHaveLength(1);
       expect(pending[0].sourceSessionId).toBe('old-session-id');
@@ -243,14 +277,26 @@ describe('BaseSession - Reconnection Attempt Limit', () => {
           },
         },
       });
-      expect(pending[0].payload.logs[0]).toMatchObject({
-        level: 'warn',
-        context: {
-          generatedCallId: 'gen-mocked-uuid',
-          sourceSessionId: 'old-session-id',
-          sourceVoiceSdkId: 'old-voice-sdk-id',
-        },
-      });
+      expect(pending[0].payload.logs).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            level: 'debug',
+            message: 'WebSocket connection created',
+          }),
+          expect.objectContaining({
+            level: 'error',
+            message: 'WebSocket error',
+          }),
+          expect.objectContaining({
+            level: 'warn',
+            context: expect.objectContaining({
+              generatedCallId: 'gen-mocked-uuid',
+              sourceSessionId: 'old-session-id',
+              sourceVoiceSdkId: 'old-voice-sdk-id',
+            }),
+          }),
+        ])
+      );
 
       const fetchMock = jest.fn().mockResolvedValue({
         ok: true,
@@ -293,7 +339,7 @@ describe('BaseSession - Reconnection Attempt Limit', () => {
       );
 
       expect(
-        sessionStorage.getItem(PENDING_SESSION_CALL_REPORTS_STORAGE_KEY)
+        localStorage.getItem(PENDING_SESSION_CALL_REPORTS_STORAGE_KEY)
       ).toBeNull();
     });
 
@@ -313,7 +359,7 @@ describe('BaseSession - Reconnection Attempt Limit', () => {
       expect(flushIntermediateCallReport).toHaveBeenCalledTimes(1);
       expect(session.callReportId).toBeNull();
       expect(
-        sessionStorage.getItem(PENDING_SESSION_CALL_REPORTS_STORAGE_KEY)
+        localStorage.getItem(PENDING_SESSION_CALL_REPORTS_STORAGE_KEY)
       ).toBeNull();
     });
   });

--- a/packages/js/src/Modules/Verto/tests/logger.test.ts
+++ b/packages/js/src/Modules/Verto/tests/logger.test.ts
@@ -1,0 +1,62 @@
+import logger, {
+  clearStoredSdkLogs,
+  drainStoredSdkLogs,
+  getStoredSdkLogs,
+} from '../util/logger';
+
+describe('SDK stored logs', () => {
+  let consoleInfoSpy: jest.SpyInstance;
+  let consoleWarnSpy: jest.SpyInstance;
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleInfoSpy = jest.spyOn(console, 'info').mockImplementation(jest.fn());
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(jest.fn());
+    consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(jest.fn());
+    logger.setLevel('debug', false);
+    clearStoredSdkLogs();
+  });
+
+  afterEach(() => {
+    clearStoredSdkLogs();
+    logger.disableAll();
+    consoleInfoSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('stores all SDK log levels in browser storage for deferred reports', () => {
+    logger.debug('debug setup log', { socketGeneration: 1 });
+    logger.info('info setup log');
+    logger.warn('warn setup log');
+    logger.error('error setup log', { error: 'network changed' });
+
+    expect(getStoredSdkLogs()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          level: 'debug',
+          message: 'debug setup log',
+          context: { socketGeneration: 1 },
+        }),
+        expect.objectContaining({ level: 'info', message: 'info setup log' }),
+        expect.objectContaining({ level: 'warn', message: 'warn setup log' }),
+        expect.objectContaining({
+          level: 'error',
+          message: 'error setup log',
+          context: { error: 'network changed' },
+        }),
+      ])
+    );
+  });
+
+  it('drains stored SDK logs after they are copied into a deferred report', () => {
+    logger.debug('debug setup log');
+
+    expect(drainStoredSdkLogs()).toEqual([
+      expect.objectContaining({ level: 'debug', message: 'debug setup log' }),
+    ]);
+    expect(getStoredSdkLogs()).toEqual([]);
+  });
+});

--- a/packages/js/src/Modules/Verto/util/logger.ts
+++ b/packages/js/src/Modules/Verto/util/logger.ts
@@ -1,5 +1,5 @@
 import log from 'loglevel';
-import { getGlobalLogCollector, LogLevel } from './LogCollector';
+import { getGlobalLogCollector, ILogEntry, LogLevel } from './LogCollector';
 
 const datetime = () =>
   new Date().toISOString().replace('T', ' ').replace('Z', '');
@@ -17,6 +17,8 @@ const CONSOLE_LEVEL_PRIORITY: Record<string, number> = {
   error: 4,
 };
 let consoleMinLevel = CONSOLE_LEVEL_PRIORITY['info'];
+export const STORED_SDK_LOGS_STORAGE_KEY = 'telnyx-voice-sdk-stored-logs';
+const MAX_STORED_SDK_LOGS = 500;
 
 /**
  * Set the minimum log level that prints to the browser console.
@@ -83,6 +85,84 @@ function toSerializable(value: unknown): unknown {
   return { value: String(value) };
 }
 
+function getStorage(): Storage | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    return window.localStorage ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function getStoredSdkLogs(): ILogEntry[] {
+  const storage = getStorage();
+  if (!storage) return [];
+
+  const value = storage.getItem(STORED_SDK_LOGS_STORAGE_KEY);
+  if (!value) return [];
+
+  try {
+    const parsed = JSON.parse(value) as ILogEntry[];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    storage.removeItem(STORED_SDK_LOGS_STORAGE_KEY);
+    return [];
+  }
+}
+
+export function clearStoredSdkLogs(): void {
+  getStorage()?.removeItem(STORED_SDK_LOGS_STORAGE_KEY);
+}
+
+export function drainStoredSdkLogs(): ILogEntry[] {
+  const logs = getStoredSdkLogs();
+  clearStoredSdkLogs();
+  return logs;
+}
+
+function appendStoredSdkLog(entry: ILogEntry): void {
+  const storage = getStorage();
+  if (!storage) return;
+
+  try {
+    const logs = getStoredSdkLogs();
+    logs.push(entry);
+    storage.setItem(
+      STORED_SDK_LOGS_STORAGE_KEY,
+      JSON.stringify(logs.slice(-MAX_STORED_SDK_LOGS))
+    );
+  } catch {
+    // Best effort only. Logging must never throw from storage quota/access issues.
+  }
+}
+
+function createLogEntry(methodName: string, logArgs: unknown[]): ILogEntry {
+  const [firstArg, ...restArgs] = logArgs;
+  const message =
+    typeof firstArg === 'string' ? firstArg : JSON.stringify(firstArg);
+  const level = methodName === 'trace' ? 'debug' : (methodName as LogLevel);
+
+  let context: Record<string, unknown> | undefined;
+  if (restArgs.length > 0) {
+    if (
+      restArgs.length === 1 &&
+      typeof restArgs[0] === 'object' &&
+      restArgs[0] !== null
+    ) {
+      context = toSerializable(restArgs[0]) as Record<string, unknown>;
+    } else {
+      context = { args: restArgs.map(toSerializable) };
+    }
+  }
+
+  return {
+    timestamp: new Date().toISOString(),
+    level,
+    message,
+    ...(context && Object.keys(context).length > 0 ? { context } : {}),
+  };
+}
+
 const originalFactory = logger.methodFactory;
 logger.methodFactory = (methodName, logLevel, loggerName) => {
   const rawMethod = originalFactory(methodName, logLevel, loggerName);
@@ -96,32 +176,13 @@ logger.methodFactory = (methodName, logLevel, loggerName) => {
       rawMethod(...messages);
     }
 
+    const entry = createLogEntry(methodName, logArgs);
+    appendStoredSdkLog(entry);
+
     // Forward ALL levels to log collector if active
     const collector = getGlobalLogCollector();
     if (collector?.isActive()) {
-      // Extract message and context from arguments
-      const [firstArg, ...restArgs] = logArgs;
-      const message =
-        typeof firstArg === 'string' ? firstArg : JSON.stringify(firstArg);
-
-      // If there's a second argument and it's an object, use it as context
-      // Serialize to plain objects so DOM Events and similar host objects
-      // retain their properties when the call report is JSON.stringified.
-      let context: Record<string, unknown> | undefined;
-      if (restArgs.length > 0) {
-        if (
-          restArgs.length === 1 &&
-          typeof restArgs[0] === 'object' &&
-          restArgs[0] !== null
-        ) {
-          context = toSerializable(restArgs[0]) as Record<string, unknown>;
-        } else {
-          // Multiple extra args, wrap them
-          context = { args: restArgs.map(toSerializable) };
-        }
-      }
-
-      collector.addEntry(methodName as LogLevel, message, context);
+      collector.addEntry(entry.level, entry.message, entry.context);
     }
   };
 };

--- a/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
+++ b/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
@@ -233,6 +233,15 @@ export interface IStatsInterval {
   transport?: ITransportStats;
 }
 
+export interface ICallSummarySocketClose {
+  type: 'socket-close' | 'socket-error';
+  code?: number;
+  codeName?: string;
+  reason?: string;
+  wasClean?: boolean;
+  error?: string;
+}
+
 export interface ICallSummary {
   callId: string;
   destinationNumber?: string;
@@ -243,6 +252,7 @@ export interface ICallSummary {
   telnyxSessionId?: string;
   telnyxLegId?: string;
   voiceSdkSessionId?: string;
+  lastSocketClose?: ICallSummarySocketClose;
   sdkVersion?: string;
   startTimestamp?: string;
   endTimestamp?: string;

--- a/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
+++ b/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
@@ -367,6 +367,7 @@ class VertoHandler {
                     'Captured call_report_id from REGED:',
                     callReportId
                   );
+                  session.flushPendingSessionCallReports?.();
                 }
 
                 const dc = msg?.result?.params?.dc;


### PR DESCRIPTION
## Summary
- Defer session-level call reports when a socket closes without an active call.
- Upload pending deferred reports after the next successful SDK init using the current call-report credentials.
- Preserve captured SDK logs in the deferred payload and add upload/reference log entries.
- Add regression coverage for deferred session reports and logger capture behavior.

## Split from
- Split out of #677 so the sessid/socket-close preservation work can stay focused.

## Test Plan
- `./.yarn/releases/yarn-4.3.1.cjs jest packages/js/src/Modules/Verto/tests/ReconnectAttempts.test.ts packages/js/src/Modules/Verto/tests/logger.test.ts --runInBand --silent=false`
- `./.yarn/releases/yarn-4.3.1.cjs exec tsc -p packages/js/tsconfig.json --noEmit`
