### PR TITLE
fix: flush call reports with logs

### DIFF
--- a/packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts
@@ -52,6 +52,13 @@ type TestableCallReportCollector = {
     stats: RTCStatsReport,
     outboundAudio: RTCOutboundRtpStreamStats & { mediaSourceId?: string }
   ) => number | null;
+  logCollector?: {
+    addEntry: (
+      level: 'debug' | 'info' | 'warn' | 'error',
+      message: string,
+      context?: Record<string, unknown>
+    ) => void;
+  };
   _logLocalAudioTrackSnapshot: (
     localAudioTrack?: ILocalAudioTrackSnapshot,
     localAudioSource?: ILocalAudioSourceStats
@@ -61,11 +68,16 @@ type TestableCallReportCollector = {
   _sendPayload: SendPayload;
 };
 
-const createCollector = (): TestableCallReportCollector =>
-  new CallReportCollector({
-    enabled: true,
-    interval: 5000,
-  }) as unknown as TestableCallReportCollector;
+const createCollector = (
+  logCollectorOptions?: ConstructorParameters<typeof CallReportCollector>[1]
+): TestableCallReportCollector =>
+  new CallReportCollector(
+    {
+      enabled: true,
+      interval: 5000,
+    },
+    logCollectorOptions
+  ) as unknown as TestableCallReportCollector;
 
 const createStatsEntry = (audioLevelAvg: number): IStatsInterval => ({
   intervalStartUtc: '2026-05-15T00:00:00.000Z',
@@ -83,6 +95,44 @@ const createStatsEntry = (audioLevelAvg: number): IStatsInterval => ({
 });
 
 describe('CallReportCollector intermediate reports', () => {
+  it('flushes logs even when no RTP stats were collected', () => {
+    const collector = createCollector({
+      enabled: true,
+      level: 'debug',
+      maxEntries: 1000,
+    });
+
+    collector.logCollector?.addEntry('warn', 'socket closed before stats', {
+      code: 1006,
+    });
+
+    const payload = collector.flush(
+      { callId: 'call-id' },
+      {
+        type: 'socket-close',
+        socketClose: { code: 1006, codeName: 'ABNORMAL_CLOSURE' },
+      }
+    );
+
+    expect(payload).toEqual(
+      expect.objectContaining({
+        segment: 0,
+        stats: [],
+        logs: [
+          expect.objectContaining({
+            level: 'warn',
+            message: 'socket closed before stats',
+            context: { code: 1006 },
+          }),
+        ],
+        flushReason: {
+          type: 'socket-close',
+          socketClose: { code: 1006, codeName: 'ABNORMAL_CLOSURE' },
+        },
+      })
+    );
+  });
+
   it('includes flush reason metadata in intermediate report payloads', () => {
     const collector = createCollector();
     const statsEntry = createStatsEntry(0.5);

--- a/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
+++ b/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
@@ -476,7 +476,8 @@ export class CallReportCollector {
     summary: ICallSummary,
     flushReason?: ICallReportFlushReason
   ): ICallReportPayload | null {
-    if (this._flushing || this.statsBuffer.length === 0) {
+    const logCount = this.logCollector?.getLogCount() ?? 0;
+    if (this._flushing || (this.statsBuffer.length === 0 && logCount === 0)) {
       return null;
     }
 
@@ -1064,16 +1065,16 @@ export class CallReportCollector {
   }
 
   private _requestIntermediateFlushIfNeeded(now: Date): void {
+    const statsCount = this.statsBuffer.length;
+    const logCount = this.logCollector?.getLogCount() ?? 0;
+
     if (
       !this.onFlushNeeded ||
       this._flushing ||
-      this.statsBuffer.length === 0
+      (statsCount === 0 && logCount === 0)
     ) {
       return;
     }
-
-    const statsCount = this.statsBuffer.length;
-    const logCount = this.logCollector?.getLogCount() ?? 0;
     const intermediateReportInterval = this._getIntermediateReportInterval();
     const msSinceLastFlush =
       now.getTime() - this._lastIntermediateFlushTime.getTime();


### PR DESCRIPTION
## Summary
- Allow intermediate call-report flushes when buffered logs exist even if no RTP stats interval was collected yet.
- Keep the existing skip behavior only when both RTP stats and logs are empty.
- Add regression coverage for logs-only intermediate flush payloads.

## Why
Short/early failure paths can have useful SDK logs before the first RTP stats interval exists. Those should still be uploaded when the call report is flushed.

## Test Plan
- `./.yarn/releases/yarn-4.3.1.cjs jest packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts --runInBand --silent=false`
- `./.yarn/releases/yarn-4.3.1.cjs exec tsc -p packages/js/tsconfig.json --noEmit`
- `git diff --check`
