### PR TITLE
fix: include selected ICE evidence in call reports

### DIFF
--- a/packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts
@@ -590,6 +590,108 @@ describe('CallReportCollector cadence', () => {
     expect(peerConnection.getStats).toHaveBeenCalledTimes(1);
     expect(collector.getStatsBuffer()).toHaveLength(1);
   });
+
+  it('records selected ICE pair ids, candidate URL, and RTT source from getStats', async () => {
+    const selectedPair = {
+      id: 'CP_selected',
+      type: 'candidate-pair',
+      state: 'succeeded',
+      nominated: true,
+      localCandidateId: 'local_srflx',
+      remoteCandidateId: 'remote_media',
+      currentRoundTripTime: 0.42,
+      requestsSent: 7,
+      responsesReceived: 7,
+    };
+    const stats = new Map<string, unknown>([
+      [
+        'transport_0',
+        {
+          id: 'transport_0',
+          type: 'transport',
+          iceState: 'connected',
+          selectedCandidatePairId: 'CP_selected',
+          selectedCandidatePairChanges: 1,
+        },
+      ],
+      [
+        'CP_old',
+        {
+          id: 'CP_old',
+          type: 'candidate-pair',
+          state: 'succeeded',
+          nominated: true,
+          localCandidateId: 'local_old',
+          remoteCandidateId: 'remote_old',
+          currentRoundTripTime: 0.01,
+        },
+      ],
+      ['CP_selected', selectedPair],
+      [
+        'local_srflx',
+        {
+          id: 'local_srflx',
+          type: 'local-candidate',
+          address: '203.0.113.10',
+          port: 50000,
+          candidateType: 'srflx',
+          protocol: 'udp',
+          networkType: 'wifi',
+          url: 'stun:stun.telnyx.com:3478',
+        },
+      ],
+      [
+        'remote_media',
+        {
+          id: 'remote_media',
+          type: 'remote-candidate',
+          address: '64.16.248.141',
+          port: 20000,
+          candidateType: 'host',
+          protocol: 'udp',
+        },
+      ],
+    ]);
+    const collector = createCollector();
+    collector.peerConnection = {
+      getStats: jest.fn().mockResolvedValue(stats as unknown as RTCStatsReport),
+      getSenders: () => [],
+    };
+    (collector as unknown as { intervalStartTime: Date }).intervalStartTime =
+      new Date(Date.now() - 5000);
+
+    await collector._collectStats(true);
+
+    expect(
+      (collector as unknown as CallReportCollector).getStatsBuffer()[0]
+    ).toEqual(
+      expect.objectContaining({
+        connection: expect.objectContaining({
+          currentRoundTripTime: 0.42,
+          roundTripTimeSource: 'candidate-pair.currentRoundTripTime',
+        }),
+        ice: expect.objectContaining({
+          id: 'CP_selected',
+          localCandidateId: 'local_srflx',
+          remoteCandidateId: 'remote_media',
+          currentRoundTripTime: 0.42,
+          local: expect.objectContaining({
+            id: 'local_srflx',
+            candidateType: 'srflx',
+            url: 'stun:stun.telnyx.com:3478',
+          }),
+          remote: expect.objectContaining({
+            id: 'remote_media',
+            address: '64.16.248.141',
+          }),
+        }),
+        transport: expect.objectContaining({
+          selectedCandidatePairId: 'CP_selected',
+          selectedCandidatePairChanges: 1,
+        }),
+      })
+    );
+  });
 });
 
 describe('CallReportCollector intermediate flushes', () => {

--- a/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
+++ b/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
@@ -147,11 +147,14 @@ interface ExtendedCandidatePairStats extends RTCIceCandidatePairStats {
  * ICE candidate info extracted from local-candidate / remote-candidate stats
  */
 interface ICECandidateInfo {
+  id?: string;
   address?: string;
   port?: number;
   candidateType?: string; // host | srflx | prflx | relay
   protocol?: string; // udp | tcp
   networkType?: string; // wifi | cellular | ethernet | vpn | unknown
+  url?: string;
+  relayProtocol?: string;
 }
 
 /**
@@ -159,9 +162,12 @@ interface ICECandidateInfo {
  */
 export interface IICECandidatePair {
   id?: string;
+  localCandidateId?: string;
+  remoteCandidateId?: string;
   state?: string; // frozen | waiting | in-progress | failed | succeeded
   nominated?: boolean;
   writable?: boolean;
+  currentRoundTripTime?: number;
   local?: ICECandidateInfo;
   remote?: ICECandidateInfo;
   requestsSent?: number;
@@ -177,6 +183,7 @@ export interface ITransportStats {
   srtpCipher?: string;
   tlsVersion?: string;
   selectedCandidatePairChanges?: number;
+  selectedCandidatePairId?: string;
 }
 
 export interface ICallReportOptions {
@@ -224,6 +231,8 @@ export interface IStatsInterval {
   };
   connection?: {
     roundTripTimeAvg?: number;
+    currentRoundTripTime?: number;
+    roundTripTimeSource?: string;
     packetsSent?: number;
     packetsReceived?: number;
     bytesSent?: number;
@@ -931,6 +940,7 @@ export class CallReportCollector {
       let outboundAudio: ExtendedOutboundRtpStreamStats | null = null;
       let inboundAudio: ExtendedInboundRtpStreamStats | null = null;
       let candidatePair: ExtendedCandidatePairStats | null = null;
+      const candidatePairs: ExtendedCandidatePairStats[] = [];
       let transportStats: ExtendedTransportStats | null = null;
 
       stats.forEach((report) => {
@@ -950,7 +960,7 @@ export class CallReportCollector {
               (report as ExtendedCandidatePairStats).nominated ||
               (report as ExtendedCandidatePairStats).state === 'succeeded'
             ) {
-              candidatePair = report as ExtendedCandidatePairStats;
+              candidatePairs.push(report as ExtendedCandidatePairStats);
             }
             break;
           case 'transport':
@@ -958,6 +968,26 @@ export class CallReportCollector {
             break;
         }
       });
+
+      const selectedCandidatePairId = transportStats?.selectedCandidatePairId;
+      const selectedCandidatePair = selectedCandidatePairId
+        ? ((
+            stats as unknown as { get?: (id: string) => RTCStats | undefined }
+          ).get?.(selectedCandidatePairId) as
+            | ExtendedCandidatePairStats
+            | undefined)
+        : undefined;
+
+      if (selectedCandidatePair?.type === 'candidate-pair') {
+        candidatePair = selectedCandidatePair;
+      } else if (selectedCandidatePairId) {
+        candidatePair =
+          candidatePairs.find((pair) => pair.id === selectedCandidatePairId) ||
+          candidatePairs[candidatePairs.length - 1] ||
+          null;
+      } else {
+        candidatePair = candidatePairs[candidatePairs.length - 1] || null;
+      }
 
       // Collect sample values for averaging
       if (outboundAudio) {
@@ -1046,9 +1076,12 @@ export class CallReportCollector {
       if (candidatePair) {
         currentCandidatePairSnapshot = {
           id: candidatePair.id,
+          localCandidateId: candidatePair.localCandidateId,
+          remoteCandidateId: candidatePair.remoteCandidateId,
           state: candidatePair.state,
           nominated: candidatePair.nominated,
           writable: candidatePair.writable,
+          currentRoundTripTime: candidatePair.currentRoundTripTime,
           requestsSent: candidatePair.requestsSent,
           responsesReceived: candidatePair.responsesReceived,
           ...(localCandidate ? { local: localCandidate } : {}),
@@ -1455,6 +1488,10 @@ export class CallReportCollector {
     if (candidatePair) {
       entry.connection = {
         roundTripTimeAvg: this._average(this.intervalRTTs),
+        currentRoundTripTime: candidatePair.currentRoundTripTime,
+        ...(candidatePair.currentRoundTripTime !== undefined
+          ? { roundTripTimeSource: 'candidate-pair.currentRoundTripTime' }
+          : {}),
         packetsSent: candidatePair.packetsSent,
         packetsReceived: candidatePair.packetsReceived,
         bytesSent: candidatePair.bytesSent,
@@ -1464,9 +1501,12 @@ export class CallReportCollector {
       // ICE candidate pair details
       entry.ice = {
         id: candidatePair.id,
+        localCandidateId: candidatePair.localCandidateId,
+        remoteCandidateId: candidatePair.remoteCandidateId,
         state: candidatePair.state,
         nominated: candidatePair.nominated,
         writable: candidatePair.writable,
+        currentRoundTripTime: candidatePair.currentRoundTripTime,
         requestsSent: candidatePair.requestsSent,
         responsesReceived: candidatePair.responsesReceived,
         ...(localCandidate ? { local: localCandidate } : {}),
@@ -1494,6 +1534,9 @@ export class CallReportCollector {
               selectedCandidatePairChanges:
                 transportStats.selectedCandidatePairChanges,
             }
+          : {}),
+        ...(transportStats.selectedCandidatePairId !== undefined
+          ? { selectedCandidatePairId: transportStats.selectedCandidatePairId }
           : {}),
       };
     }
@@ -1526,6 +1569,7 @@ export class CallReportCollector {
     }
 
     const info: ICECandidateInfo = {};
+    if (report.id !== undefined) info.id = report.id;
     // Fallback from report.address to report.ip for browser compatibility
     // (Firefox uses 'ip' while Chrome uses 'address')
     if (report.address !== undefined) {
@@ -1539,6 +1583,11 @@ export class CallReportCollector {
     if (report.protocol !== undefined) info.protocol = report.protocol;
     // networkType is only available on local candidates and may be absent in some browsers
     if (report.networkType !== undefined) info.networkType = report.networkType;
+    // url identifies the ICE server used to discover local srflx/relay candidates.
+    // relayProtocol is present for TURN relay candidates in Chromium.
+    if (report.url !== undefined) info.url = report.url;
+    if (report.relayProtocol !== undefined)
+      info.relayProtocol = report.relayProtocol;
 
     if (Object.keys(info).length === 0) {
       logger.debug(


### PR DESCRIPTION
## Summary
- prefer `transport.selectedCandidatePairId` when selecting the candidate pair from `getStats()`
- include selected pair ids, local/remote candidate ids, candidate `url`, `relayProtocol`, and `currentRoundTripTime` in Voice SDK call report stats
- annotate RTT with `roundTripTimeSource: candidate-pair.currentRoundTripTime` so reports can distinguish media-path RTT from ICE-server candidate gathering

## Why
This lets `voice-sdk-call-report` prove whether high RTT is on the selected ICE/media path. For `srflx` candidates, `local.url=stun:stun.telnyx.com:3478` is preserved as candidate-gathering evidence, while the selected remote candidate address remains visible as the actual RTT endpoint.

## Validation
- `yarn jest packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts --runInBand`
- `yarn workspace @telnyx/webrtc build`