### PR TITLE
feat: add LOW_INBOUND_AUDIO warning to detect one-way audio with RTP flow

### DIFF
--- a/packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts
@@ -2,6 +2,7 @@ import logger from '../../util/logger';
 import {
   LOW_BYTES_RECEIVED,
   LOW_LOCAL_AUDIO,
+  LOW_INBOUND_AUDIO,
 } from '../../util/constants/errorCodes';
 import type { ITelnyxWarning } from '../../util/constants/warnings';
 import {
@@ -81,6 +82,38 @@ const createStatsEntry = (audioLevelAvg: number): IStatsInterval => ({
     },
   },
 });
+
+/**
+ * Create a stats entry with an inbound audioLevelAvg, simulating
+ * one-way audio (RTP flowing but carrying silence/comfort-noise).
+ * Outbound is set to a healthy level to isolate the inbound check.
+ * bytesReceived increments across calls to simulate RTP flowing
+ * (prevents LOW_BYTES_RECEIVED from firing).
+ */
+let _inboundBytesCounter = 1000;
+const createInboundStatsEntry = (
+  inboundAudioLevelAvg: number
+): IStatsInterval => {
+  _inboundBytesCounter += 4800; // ~100 packets * 48 bytes per 5s interval
+  return {
+    intervalStartUtc: '2026-05-15T00:00:00.000Z',
+    intervalEndUtc: '2026-05-15T00:00:05.000Z',
+    audio: {
+      outbound: {
+        audioLevelAvg: 0.5,
+        localTrack: {
+          id: 'track-id',
+          enabled: true,
+          muted: false,
+        },
+      },
+      inbound: {
+        audioLevelAvg: inboundAudioLevelAvg,
+        bytesReceived: _inboundBytesCounter,
+      },
+    },
+  };
+};
 
 describe('CallReportCollector intermediate reports', () => {
   it('allows socket-close intermediate reports with logs but no stats', () => {
@@ -529,6 +562,105 @@ describe('CallReportCollector local audio diagnostics', () => {
     collector._checkQualityWarnings(statsEntry, null);
 
     expect(onWarning).not.toHaveBeenCalled();
+  });
+});
+
+describe('CallReportCollector LOW_INBOUND_AUDIO warning', () => {
+  beforeEach(() => {
+    _inboundBytesCounter = 1000;
+  });
+
+  it('emits low inbound audio warning after consecutive inbound audio breaches', () => {
+    const collector = createCollector();
+    const onWarning = jest.fn();
+    collector.onWarning = onWarning;
+
+    collector._checkQualityWarnings(createInboundStatsEntry(0), null);
+    collector._checkQualityWarnings(createInboundStatsEntry(0), null);
+    expect(onWarning).not.toHaveBeenCalled();
+
+    collector._checkQualityWarnings(createInboundStatsEntry(0), null);
+
+    expect(onWarning).toHaveBeenCalledTimes(1);
+    expect(onWarning).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: LOW_INBOUND_AUDIO,
+        name: 'LOW_INBOUND_AUDIO',
+      })
+    );
+  });
+
+  it('does not emit low inbound audio warning when inbound audio is healthy', () => {
+    const collector = createCollector();
+    const onWarning = jest.fn();
+    collector.onWarning = onWarning;
+
+    for (let i = 0; i < 5; i += 1) {
+      collector._checkQualityWarnings(createInboundStatsEntry(0.5), null);
+    }
+
+    expect(onWarning).not.toHaveBeenCalled();
+  });
+
+  it('does not emit low inbound audio warning on brief silence (fewer than 3 breaches)', () => {
+    const collector = createCollector();
+    const onWarning = jest.fn();
+    collector.onWarning = onWarning;
+
+    collector._checkQualityWarnings(createInboundStatsEntry(0), null);
+    collector._checkQualityWarnings(createInboundStatsEntry(0), null);
+    // Recovery before the 3rd breach
+    collector._checkQualityWarnings(createInboundStatsEntry(0.5), null);
+    collector._checkQualityWarnings(createInboundStatsEntry(0), null);
+    collector._checkQualityWarnings(createInboundStatsEntry(0), null);
+
+    expect(onWarning).not.toHaveBeenCalled();
+  });
+
+  it('resets breach counter when inbound audio level is unavailable', () => {
+    const collector = createCollector();
+    const onWarning = jest.fn();
+    collector.onWarning = onWarning;
+
+    // Two low breaches (not enough to fire)
+    collector._checkQualityWarnings(createInboundStatsEntry(0), null);
+    collector._checkQualityWarnings(createInboundStatsEntry(0), null);
+
+    // Interval with no inbound audioLevelAvg — should reset breach counter
+    const noInboundEntry = createStatsEntry(0.5);
+    collector._checkQualityWarnings(noInboundEntry, null);
+
+    // Two more low breaches should NOT fire (counter was reset)
+    collector._checkQualityWarnings(createInboundStatsEntry(0), null);
+    collector._checkQualityWarnings(createInboundStatsEntry(0), null);
+
+    expect(onWarning).not.toHaveBeenCalled();
+
+    // Third breach after reset DOES fire
+    collector._checkQualityWarnings(createInboundStatsEntry(0), null);
+    expect(onWarning).toHaveBeenCalledTimes(1);
+  });
+
+  it('emits low inbound audio when comfort-noise scenario: RTP bytes flow but audioLevelAvg is near-zero', () => {
+    const collector = createCollector();
+    const onWarning = jest.fn();
+    collector.onWarning = onWarning;
+
+    // Simulate comfort-noise: bytesReceived increasing (RTP flowing)
+    // but audioLevelAvg near-zero (silence/comfort-noise content).
+    // createInboundStatsEntry auto-increments bytesReceived so
+    // LOW_BYTES_RECEIVED won't fire — only LOW_INBOUND_AUDIO should.
+    collector._checkQualityWarnings(createInboundStatsEntry(0.0001), null);
+    collector._checkQualityWarnings(createInboundStatsEntry(0.0001), null);
+    collector._checkQualityWarnings(createInboundStatsEntry(0.0001), null);
+
+    expect(onWarning).toHaveBeenCalledTimes(1);
+    expect(onWarning).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: LOW_INBOUND_AUDIO,
+        name: 'LOW_INBOUND_AUDIO',
+      })
+    );
   });
 });
 

--- a/packages/js/src/Modules/Verto/util/constants/errorCodes.ts
+++ b/packages/js/src/Modules/Verto/util/constants/errorCodes.ts
@@ -56,6 +56,7 @@ export const TELNYX_WARNING_CODES = {
   HIGH_PACKET_LOSS: 31003,
   LOW_MOS: 31004,
   LOW_LOCAL_AUDIO: 31005,
+  LOW_INBOUND_AUDIO: 31006,
 
   // ── Connection / data-flow warnings (320xx) ─────────────────────────
   LOW_BYTES_RECEIVED: 32001,
@@ -119,6 +120,7 @@ export const {
   HIGH_PACKET_LOSS,
   LOW_MOS,
   LOW_LOCAL_AUDIO,
+  LOW_INBOUND_AUDIO,
   LOW_BYTES_RECEIVED,
   LOW_BYTES_SENT,
   ICE_CONNECTIVITY_LOST,

--- a/packages/js/src/Modules/Verto/util/constants/warnings.ts
+++ b/packages/js/src/Modules/Verto/util/constants/warnings.ts
@@ -121,6 +121,24 @@ export const SDK_WARNINGS = {
       'Verify the microphone is not muted at the operating system or hardware level',
     ],
   },
+  31006: {
+    name: 'LOW_INBOUND_AUDIO',
+    message: 'Low inbound audio detected',
+    description:
+      'Inbound (remote) audio level stayed below the acceptable threshold for multiple consecutive stats intervals while RTP packets continued to flow. This may indicate the remote party is sending silence or comfort-noise (e.g. one-way audio caused by a media bridge issue), as opposed to LOW_BYTES_RECEIVED which fires when no bytes arrive at all.',
+    causes: [
+      'Remote party microphone is muted or capturing very low audio',
+      'Media bridge or PBX is injecting comfort-noise/silence instead of forwarding real audio',
+      'One-way audio where RTP flows but content is silent (server-side media issue)',
+      'Remote party is on hold or not speaking',
+    ],
+    solutions: [
+      'Verify the remote party is not muted and is actively speaking',
+      'Check the media bridge / PBX for comfort-noise injection or transcoding issues',
+      'Inspect PCAP RTP payload uniqueness to distinguish real audio from comfort-noise',
+      'If the issue persists, report the call for server-side media investigation',
+    ],
+  },
 
   // ── Connection / data-flow warnings (320xx) ─────────────────────────
   32001: {
@@ -403,7 +421,6 @@ export const SDK_WARNINGS = {
       'If a call should be active, start a new call manually',
     ],
   },
-
 } as const;
 
 export type SdkWarningCode = keyof typeof SDK_WARNINGS;

--- a/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
+++ b/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
@@ -30,6 +30,7 @@ import {
   HIGH_PACKET_LOSS,
   LOW_MOS,
   LOW_LOCAL_AUDIO,
+  LOW_INBOUND_AUDIO,
   LOW_BYTES_RECEIVED,
   LOW_BYTES_SENT,
   ICE_CANDIDATE_PAIR_CHANGED,
@@ -414,6 +415,14 @@ export class CallReportCollector {
   // agent/customer pauses.
   private static readonly THRESHOLD_LOCAL_AUDIO_LEVEL = 0.001;
   private static readonly CONFIRMED_LOCAL_AUDIO_SILENCE_MS = 30_000;
+
+  // Inbound (remote) audio level threshold. Same value as local — near-zero
+  // RMS in [0, 1]. The inbound warning uses consecutive breaches rather than
+  // a confirmation window because the remote party's silence/comfort-noise is
+  // the exact condition we want to surface. However, we still require 3
+  // consecutive breaches (CONSECUTIVE_BREACHES_REQUIRED) to avoid firing on
+  // brief natural pauses in conversation.
+  private static readonly THRESHOLD_INBOUND_AUDIO_LEVEL = 0.001;
 
   // Consecutive breach counters (per warning code)
   private _breachCounters: Record<number, number> = {};
@@ -1285,6 +1294,14 @@ export class CallReportCollector {
     // on normal 5-10s pauses; require a long continuous silence window instead.
     this._trackLowLocalAudio(statsEntry);
 
+    // Inbound (remote) audio warning — checks audioLevelAvg of received
+    // audio. Unlike LOW_BYTES_RECEIVED (which fires when NO bytes arrive),
+    // this catches the case where RTP flows but carries silence or
+    // comfort-noise (e.g. one-way audio from a media bridge issue). Requires
+    // CONSECUTIVE_BREACHES_REQUIRED intervals below threshold to avoid
+    // firing on natural conversation pauses.
+    this._trackLowInboundAudio(statsEntry);
+
     // MOS warning — simplified E-model
     if (
       rtt !== undefined &&
@@ -1379,6 +1396,37 @@ export class CallReportCollector {
     return Number.isFinite(duration) && duration > 0
       ? duration
       : this.options.interval;
+  }
+
+  /**
+   * Track low inbound (remote) audio level.
+   *
+   * Unlike LOW_LOCAL_AUDIO which uses a confirmation window to avoid false
+   * positives during natural local pauses, the inbound check uses the
+   * standard consecutive-breach mechanism (3 intervals below threshold).
+   * This is because sustained near-zero inbound audio while RTP flows is
+   * the exact one-way-audio condition we want to surface — it indicates the
+   * remote party or media bridge is sending silence/comfort-noise rather
+   * than real speech.
+   *
+   * Only fires when audioLevelAvg data is available (not undefined). If the
+   * inbound audio level is unavailable for a given interval (e.g. first
+   * sample, missing totalAudioEnergy), the breach counter is reset to avoid
+   * false positives from data gaps.
+   */
+  private _trackLowInboundAudio(statsEntry: IStatsInterval): void {
+    const inbound = statsEntry.audio?.inbound;
+    const audioLevel = inbound?.audioLevelAvg;
+
+    // No inbound audio data for this interval — reset to avoid false positives
+    if (audioLevel === undefined) {
+      this._trackBreach(LOW_INBOUND_AUDIO, false);
+      return;
+    }
+
+    const isLow =
+      audioLevel <= CallReportCollector.THRESHOLD_INBOUND_AUDIO_LEVEL;
+    this._trackBreach(LOW_INBOUND_AUDIO, isLow);
   }
 
   /**


### PR DESCRIPTION
## Summary

The SDK had **no warning for one-way audio where RTP flows but carries silence/comfort-noise** instead of real speech. This is the exact signature of one-way audio caused by a media bridge issue (e.g. FreeSWITCH comfort-noise injection).

### The gap

| Warning | What it checks | Would fire for comfort-noise? |
|---|---|---|
| `LOW_LOCAL_AUDIO` (31005) | **Outbound** (local mic) audioLevelAvg | ❌ No — mic was fine |
| `LOW_BYTES_RECEIVED` (32001) | bytesReceived delta = 0 (no bytes at all) | ❌ No — comfort-noise frames are still bytes |
| `LOW_MOS` (31004) | Computed from RTT/jitter/loss only | ❌ No — transport was healthy |
| **`LOW_INBOUND_AUDIO` (31006)** ← **new** | **Inbound** audioLevelAvg ≤ 0.001 for 3 intervals | ✅ **Yes** |

### Production evidence (call `f0963de0`)

Call `f0963de0-6f43-11f1-b737-02420aef8fa0` (user `ee6f7f8e-4fca-42b3-a5d6-c0b232009907`) had 3+ minutes of one-way audio where:
- FreeSWITCH (`tel-nj1-prox-prod-762` / `50.114.146.95`) injected comfort-noise toward the browser
- RTP flowed at 50pps with 0% loss — transport was "healthy"
- Inbound `audioLevelAvg` was 0.0000–0.0002 for 73.6% of the call
- **No SDK warning was emitted** — the gap was invisible to all existing checks
- `CallLowAudioRateHigh` server-side alert also didn't fire (spikes inflated the mean)

PCAP analysis confirmed: `50.114.146.95→10.239.129.81` (FS→canary) carried comfort-noise (69.7% payload uniqueness, 1926× repeated frames), while `10.239.129.81→50.114.146.95` (canary→FS) carried real varied audio (95.1% uniqueness).

### Implementation

- **`errorCodes.ts`**: Add `LOW_INBOUND_AUDIO: 31006`
- **`warnings.ts`**: Add warning definition with causes/solutions referencing comfort-noise injection and PCAP payload uniqueness analysis
- **`CallReportCollector.ts`**: Add `_trackLowInboundAudio()` method that checks `statsEntry.audio.inbound.audioLevelAvg` against `THRESHOLD_INBOUND_AUDIO_LEVEL` (0.001) using the existing `_trackBreach()` consecutive-breach mechanism (3 intervals). Wired into `_checkQualityWarnings()`.
- **Tests**: 5 test cases covering: consecutive breach firing, healthy audio no-fire, brief silence no-fire, breach counter reset on missing data, and comfort-noise scenario (RTP bytes flowing but audioLevelAvg near-zero)

### Design decisions

- Uses the same `THRESHOLD_INBOUND_AUDIO_LEVEL = 0.001` and `CONSECUTIVE_BREACHES_REQUIRED = 3` as other quality warnings — fires after ~15s (3 × 5s intervals)
- Does NOT trigger `reportNoRtp` in `BaseCall.ts` — RTP IS flowing, the media path isn't broken, only the audio content is silent. `reportNoRtp` is reserved for `LOW_BYTES_RECEIVED`/`LOW_BYTES_SENT` where the media path is genuinely broken.
- Resets breach counter when `audioLevelAvg` is `undefined` (data gap) to avoid false positives
