### PR TITLE
Collect call report stats every second for full call duration (VSDK-387)

### DIFF
--- a/packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts
@@ -670,7 +670,7 @@ describe('CallReportCollector cadence', () => {
     jest.useRealTimers();
   });
 
-  it('defaults to 1 second intervals during the first 10 seconds, then the default interval', () => {
+  it('collects every second for the full call duration', () => {
     const collector = new CallReportCollector({
       enabled: true,
       interval: 5000,
@@ -682,12 +682,9 @@ describe('CallReportCollector cadence', () => {
     const callStart = testable.callStartTime.getTime();
 
     expect(testable._collectionIntervalFor(new Date(callStart))).toEqual(1000);
-    expect(testable._collectionIntervalFor(new Date(callStart + 9000))).toEqual(
-      1000
-    );
     expect(
-      testable._collectionIntervalFor(new Date(callStart + 10000))
-    ).toEqual(5000);
+      testable._collectionIntervalFor(new Date(callStart + 60000))
+    ).toEqual(1000);
   });
 
   it('does not slow down collection if the configured default interval is shorter than the initial cadence', () => {

--- a/packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts
@@ -676,15 +676,10 @@ describe('CallReportCollector cadence', () => {
       interval: 5000,
     });
     const testable = collector as unknown as {
-      callStartTime: Date;
-      _collectionIntervalFor: (intervalStartTime: Date) => number;
+      _collectionIntervalFor: () => number;
     };
-    const callStart = testable.callStartTime.getTime();
 
-    expect(testable._collectionIntervalFor(new Date(callStart))).toEqual(1000);
-    expect(
-      testable._collectionIntervalFor(new Date(callStart + 60000))
-    ).toEqual(1000);
+    expect(testable._collectionIntervalFor()).toEqual(1000);
   });
 
   it('does not slow down collection if the configured default interval is shorter than the initial cadence', () => {
@@ -693,13 +688,10 @@ describe('CallReportCollector cadence', () => {
       interval: 500,
     });
     const testable = collector as unknown as {
-      callStartTime: Date;
-      _collectionIntervalFor: (intervalStartTime: Date) => number;
+      _collectionIntervalFor: () => number;
     };
 
-    expect(testable._collectionIntervalFor(testable.callStartTime)).toEqual(
-      500
-    );
+    expect(testable._collectionIntervalFor()).toEqual(500);
   });
 
   it('collects a final stats interval for calls shorter than the current cadence interval', async () => {

--- a/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
+++ b/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
@@ -892,7 +892,7 @@ export class CallReportCollector {
       return;
     }
 
-    const interval = this._collectionIntervalFor(this.intervalStartTime);
+    const interval = this._collectionIntervalFor();
     this.intervalId = setTimeout(() => {
       this.intervalId = null;
       this._collectStats().finally(() => {
@@ -903,13 +903,10 @@ export class CallReportCollector {
     }, interval);
   }
 
-  private _collectionIntervalFor(intervalStartTime: Date): number {
+  private _collectionIntervalFor(): number {
     const defaultInterval = this._positiveInterval(this.options.interval, 5000);
 
     // Stats are collected every second for the full call duration.
-    // intervalStartTime is retained in the signature for callers but no
-    // longer affects the cadence — the interval is now constant.
-    void intervalStartTime;
     return Math.min(
       CallReportCollector.INITIAL_COLLECTION_INTERVAL_MS,
       defaultInterval
@@ -1127,9 +1124,7 @@ export class CallReportCollector {
       // short calls (shorter than the collection interval) still produce
       // at least one stats entry in the buffer.
       const intervalDuration = now.getTime() - this.intervalStartTime.getTime();
-      const currentInterval = this._collectionIntervalFor(
-        this.intervalStartTime
-      );
+    const currentInterval = this._collectionIntervalFor();
       if (isFinal || intervalDuration >= currentInterval) {
         // Create stats entry for this interval
         const statsEntry = this._createStatsEntry(

--- a/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
+++ b/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
@@ -5,7 +5,7 @@
  * at the end of the call for quality analysis and debugging.
  *
  * Stats Collection Strategy (based on Twilio/Jitsi best practices):
- * - Collects stats every second for the first 10 seconds, then at a regular interval (default 5 seconds)
+ * - Collects stats every second for the full call duration
  * - Stores cumulative values (packets, bytes) from WebRTC API
  * - Calculates averages for variable metrics (audio level, jitter, RTT)
  * - Uses in-memory buffer with size limits for long calls
@@ -384,7 +384,6 @@ export class CallReportCollector {
   private previousCandidatePairSnapshot: IICECandidatePair | null = null;
 
   private static readonly INITIAL_COLLECTION_INTERVAL_MS = 1000;
-  private static readonly INITIAL_COLLECTION_DURATION_MS = 10000;
 
   // Maximum buffer size to prevent memory issues on long calls
   private readonly MAX_BUFFER_SIZE = 360; // 30 minutes at 5-second intervals, plus denser startup samples
@@ -504,7 +503,6 @@ export class CallReportCollector {
     logger.info('CallReportCollector: Starting stats collection', {
       interval: this.options.interval,
       initialInterval: CallReportCollector.INITIAL_COLLECTION_INTERVAL_MS,
-      initialDuration: CallReportCollector.INITIAL_COLLECTION_DURATION_MS,
       logCollectorActive: this.logCollector?.isActive() ?? false,
     });
 
@@ -908,17 +906,14 @@ export class CallReportCollector {
   private _collectionIntervalFor(intervalStartTime: Date): number {
     const defaultInterval = this._positiveInterval(this.options.interval, 5000);
 
-    if (
-      intervalStartTime.getTime() - this.callStartTime.getTime() <
-      CallReportCollector.INITIAL_COLLECTION_DURATION_MS
-    ) {
-      return Math.min(
-        CallReportCollector.INITIAL_COLLECTION_INTERVAL_MS,
-        defaultInterval
-      );
-    }
-
-    return defaultInterval;
+    // Stats are collected every second for the full call duration.
+    // intervalStartTime is retained in the signature for callers but no
+    // longer affects the cadence — the interval is now constant.
+    void intervalStartTime;
+    return Math.min(
+      CallReportCollector.INITIAL_COLLECTION_INTERVAL_MS,
+      defaultInterval
+    );
   }
 
   private _positiveInterval(


### PR DESCRIPTION
## VSDK-387

Linear: https://linear.app/telnyx/issue/VSDK-387

## Change
Removes the two-phase stats collection cadence (1s for first 10s, then 5s) so that `CallReportCollector` now collects metrics every 1 second for the **entire call duration**. This is the interval-collection case from VSDK-387.

- `_collectionIntervalFor` now always returns `min(1000, configuredInterval)` regardless of elapsed call time.
- Removed the unused `INITIAL_COLLECTION_DURATION_MS` two-phase constant.

Part of VSDK-387 (separate PR per case). This PR covers ONLY the collection-interval change; other metric-expansion cases are separate PRs.