### PR TITLE
Collect remote RTCP stats (remote-inbound-rtp, remote-outbound-rtp) (VSDK-387)

### DIFF
--- a/packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts
@@ -1291,3 +1291,154 @@ describe('CallReportCollector additional inbound RTP fields (VSDK-387)', () => {
     expect(inbound).not.toHaveProperty('totalSamplesDuration');
   });
 });
+
+describe('CallReportCollector remote RTCP stats', () => {
+  // Helper: wire up a collector with the given RTCStatsReport and run one
+  // final (isFinal=true) collection so a single stats entry lands in the
+  // buffer regardless of how short the interval is.
+  const collectOnce = async (
+    stats: RTCStatsReport
+  ): Promise<IStatsInterval> => {
+    const collector = createCollector();
+    collector.peerConnection = {
+      getStats: jest.fn().mockResolvedValue(stats),
+      getSenders: () => [],
+    };
+    (collector as unknown as { intervalStartTime: Date }).intervalStartTime =
+      new Date(Date.now() - 5000);
+
+    await collector._collectStats(true);
+
+    const buffer = (collector as unknown as CallReportCollector).getStatsBuffer();
+    expect(buffer).toHaveLength(1);
+    return buffer[0];
+  };
+
+  it('parses remote-inbound-rtp and remote-outbound-rtp audio stats into remoteRtcp', async () => {
+    const stats = new Map<string, unknown>([
+      [
+        'OB_audio',
+        {
+          id: 'OB_audio',
+          type: 'outbound-rtp',
+          kind: 'audio',
+          mediaType: 'audio',
+          packetsSent: 1000,
+          bytesSent: 48000,
+        },
+      ],
+      [
+        'RIB_audio',
+        {
+          id: 'RIB_audio',
+          type: 'remote-inbound-rtp',
+          kind: 'audio',
+          // NOTE: no mediaType field on remote RTCP reports.
+          jitter: 0.02, // seconds -> ~20ms
+          packetsLost: 3,
+          packetsReceived: 997,
+          fractionLost: 0.01,
+          roundTripTime: 0.15, // seconds — media-path RTT
+          totalRoundTripTime: 1.5,
+          roundTripTimeMeasurements: 10,
+          nackCount: 2,
+          reportsReceived: 10,
+          packetsDiscarded: 1,
+          localId: 'OB_audio',
+        },
+      ],
+      [
+        'ROB_audio',
+        {
+          id: 'ROB_audio',
+          type: 'remote-outbound-rtp',
+          kind: 'audio',
+          packetsSent: 500,
+          bytesSent: 24000,
+          reportsCount: 10,
+          roundTripTime: 0.12,
+          totalPacketSendDelay: 1.2,
+          localId: 'IB_audio',
+          remoteId: 'RIB_audio',
+        },
+      ],
+    ]) as unknown as RTCStatsReport;
+
+    const entry = await collectOnce(stats);
+
+    // remote-inbound-rtp -> remoteRtcp.inbound (outbound quality as seen by
+    // the remote peer). jitter converted to ms; roundTripTimeAvg derived
+    // from totalRoundTripTime / roundTripTimeMeasurements.
+    expect(entry.remoteRtcp?.inbound).toEqual(
+      expect.objectContaining({
+        packetsLost: 3,
+        packetsReceived: 997,
+        fractionLost: 0.01,
+        roundTripTime: 0.15,
+        totalRoundTripTime: 1.5,
+        roundTripTimeMeasurements: 10,
+        nackCount: 2,
+        reportsReceived: 10,
+        packetsDiscarded: 1,
+      })
+    );
+    expect(entry.remoteRtcp?.inbound?.jitter).toBeCloseTo(20, 5);
+    expect(entry.remoteRtcp?.inbound?.roundTripTimeAvg).toBeCloseTo(0.15, 5);
+
+    // remote-outbound-rtp -> remoteRtcp.outbound (remote Sender Report).
+    expect(entry.remoteRtcp?.outbound).toEqual(
+      expect.objectContaining({
+        packetsSent: 500,
+        bytesSent: 24000,
+        reportsCount: 10,
+      })
+    );
+  });
+
+  it('omits roundTripTimeAvg when roundTripTimeMeasurements is missing or zero', async () => {
+    const stats = new Map<string, unknown>([
+      [
+        'RIB_audio',
+        {
+          id: 'RIB_audio',
+          type: 'remote-inbound-rtp',
+          kind: 'audio',
+          jitter: 0.03,
+          roundTripTime: 0.2,
+          totalRoundTripTime: 0.6,
+          // roundTripTimeMeasurements intentionally absent.
+        },
+      ],
+    ]) as unknown as RTCStatsReport;
+
+    const entry = await collectOnce(stats);
+
+    expect(entry.remoteRtcp?.inbound).toBeDefined();
+    expect(entry.remoteRtcp?.inbound?.roundTripTimeAvg).toBeUndefined();
+    // Other passthrough fields are still captured.
+    expect(entry.remoteRtcp?.inbound?.roundTripTime).toBe(0.2);
+    expect(entry.remoteRtcp?.inbound?.totalRoundTripTime).toBe(0.6);
+    // No remote-outbound-rtp in this report -> outbound block absent.
+    expect(entry.remoteRtcp?.outbound).toBeUndefined();
+  });
+
+  it('does not set remoteRtcp when no remote RTCP reports are present', async () => {
+    const stats = new Map<string, unknown>([
+      [
+        'OB_audio',
+        {
+          id: 'OB_audio',
+          type: 'outbound-rtp',
+          kind: 'audio',
+          mediaType: 'audio',
+          packetsSent: 1,
+          bytesSent: 48,
+        },
+      ],
+    ]) as unknown as RTCStatsReport;
+
+    const entry = await collectOnce(stats);
+
+    expect(entry.remoteRtcp).toBeUndefined();
+  });
+});

--- a/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
+++ b/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
@@ -99,6 +99,48 @@ interface ExtendedOutboundRtpStreamStats extends RTCOutboundRtpStreamStats {
 }
 
 /**
+ * Extended remote-inbound-rtp stats — the remote peer's inbound-rtp as
+ * reported via RTCP Receiver Report. Reflects OUR outbound stream quality
+ * (loss/jitter/RTT as observed by the remote side).
+ */
+interface ExtendedRemoteInboundRtpStreamStats {
+  type: string;
+  id: string;
+  kind?: string;
+  jitter?: number; // seconds
+  packetsLost?: number;
+  packetsReceived?: number;
+  fractionLost?: number;
+  /** seconds — media-path RTT */
+  roundTripTime?: number;
+  totalRoundTripTime?: number;
+  roundTripTimeMeasurements?: number;
+  nackCount?: number;
+  reportsReceived?: number;
+  packetsDiscarded?: number;
+  /** links to our outbound-rtp stat id */
+  localId?: string;
+}
+
+/**
+ * Extended remote-outbound-rtp stats — the remote peer's outbound-rtp as
+ * reported via RTCP Sender Report.
+ */
+interface ExtendedRemoteOutboundRtpStreamStats {
+  type: string;
+  id: string;
+  kind?: string;
+  localId?: string;
+  remoteId?: string;
+  packetsSent?: number;
+  bytesSent?: number;
+  reportsCount?: number;
+  /** seconds */
+  roundTripTime?: number;
+  totalPacketSendDelay?: number;
+}
+
+/**
  * Extended media-playout stats (type: 'media-playout', audio).
  * Reports playout delay and synthesized-sample indicators.
  */
@@ -316,6 +358,40 @@ export interface IStatsInterval {
     synthesizedDuration?: number;
     totalPlayoutDelay?: number;
     totalSampleCount?: number;
+  };
+  /**
+   * Remote RTCP stats parsed from `remote-inbound-rtp` (RTCP Receiver Report
+   * describing OUR outbound stream) and `remote-outbound-rtp` (RTCP Sender
+   * Report from the remote peer).
+   */
+  remoteRtcp?: {
+    // remote-inbound-rtp: RTCP Receiver Report for OUR outbound stream.
+    inbound?: {
+      packetsReceived?: number;
+      packetsLost?: number;
+      fractionLost?: number;
+      /** ms (converted from seconds x1000 for consistency with jitterAvg) */
+      jitter?: number;
+      /** seconds — media-path RTT */
+      roundTripTime?: number;
+      /** seconds */
+      totalRoundTripTime?: number;
+      roundTripTimeMeasurements?: number;
+      /** Cumulative media-path RTT average = totalRoundTripTime / roundTripTimeMeasurements (seconds). */
+      roundTripTimeAvg?: number;
+      nackCount?: number;
+      reportsReceived?: number;
+      packetsDiscarded?: number;
+    };
+    // remote-outbound-rtp: RTCP Sender Report from the remote peer.
+    outbound?: {
+      packetsSent?: number;
+      bytesSent?: number;
+      reportsCount?: number;
+      /** seconds */
+      roundTripTime?: number;
+      totalPacketSendDelay?: number;
+    };
   };
 }
 
@@ -1017,6 +1093,13 @@ export class CallReportCollector {
       let outboundAudio: ExtendedOutboundRtpStreamStats | null = null;
       let inboundAudio: ExtendedInboundRtpStreamStats | null = null;
       let mediaPlayout: ExtendedMediaPlayoutStats | null = null;
+      // remote-inbound-rtp / remote-outbound-rtp are RTCP reports from the
+      // remote peer describing OUR outbound (and the remote's outbound)
+      // streams. They may not carry a mediaType field, so we gate on
+      // report.kind === 'audio' only.
+      let remoteInboundAudio: ExtendedRemoteInboundRtpStreamStats | null = null;
+      let remoteOutboundAudio: ExtendedRemoteOutboundRtpStreamStats | null =
+        null;
       let candidatePair: ExtendedCandidatePairStats | null = null;
       const candidatePairs: ExtendedCandidatePairStats[] = [];
       let transportStats: ExtendedTransportStats | null = null;
@@ -1036,6 +1119,21 @@ export class CallReportCollector {
           case 'media-playout':
             if (report.kind === 'audio') {
               mediaPlayout = report as ExtendedMediaPlayoutStats;
+            }
+            break;
+          case 'remote-inbound-rtp':
+            // RTCP Receiver Report for OUR outbound stream. Note: this report
+            // type does NOT include a mediaType field, so gate on kind only.
+            if (report.kind === 'audio') {
+              remoteInboundAudio =
+                report as ExtendedRemoteInboundRtpStreamStats;
+            }
+            break;
+          case 'remote-outbound-rtp':
+            // RTCP Sender Report from the remote peer. Same mediaType caveat.
+            if (report.kind === 'audio') {
+              remoteOutboundAudio =
+                report as ExtendedRemoteOutboundRtpStreamStats;
             }
             break;
           case 'candidate-pair':
@@ -1220,7 +1318,9 @@ export class CallReportCollector {
           transportStats,
           localAudioTrack,
           localAudioSource,
-          mediaPlayout
+          mediaPlayout,
+          remoteInboundAudio,
+          remoteOutboundAudio
         );
 
         // Add to buffer with size limit
@@ -1568,7 +1668,9 @@ export class CallReportCollector {
     transportStats?: ExtendedTransportStats | null,
     localAudioTrack?: ILocalAudioTrackSnapshot,
     localAudioSource?: ILocalAudioSourceStats,
-    mediaPlayout?: ExtendedMediaPlayoutStats | null
+    mediaPlayout?: ExtendedMediaPlayoutStats | null,
+    remoteInboundAudio?: ExtendedRemoteInboundRtpStreamStats | null,
+    remoteOutboundAudio?: ExtendedRemoteOutboundRtpStreamStats | null
   ): IStatsInterval {
     const entry: IStatsInterval = {
       intervalStartUtc: start.toISOString(),
@@ -1728,6 +1830,63 @@ export class CallReportCollector {
         totalPlayoutDelay: mediaPlayout.totalPlayoutDelay,
         totalSampleCount: mediaPlayout.totalSampleCount,
       });
+    }
+
+    // Remote RTCP stats — gives us the remote's view of OUR outbound stream
+    // (loss/jitter/RTT from remote-inbound-rtp) and the remote's outbound
+    // counters (remote-outbound-rtp). Only set when at least one side has data.
+    if (remoteInboundAudio || remoteOutboundAudio) {
+      const remoteRtcp: IStatsInterval['remoteRtcp'] = {};
+
+      if (remoteInboundAudio) {
+        // Jitter from remote-inbound-rtp is in seconds — convert to ms to
+        // match jitterAvg semantics elsewhere in the report.
+        const jitterMs =
+          remoteInboundAudio.jitter !== undefined
+            ? remoteInboundAudio.jitter * 1000
+            : undefined;
+
+        // Cumulative media-path RTT average = totalRoundTripTime /
+        // roundTripTimeMeasurements (both in seconds). Only compute when both
+        // are present and measurements > 0 to avoid NaN/Infinity.
+        let roundTripTimeAvg: number | undefined;
+        if (
+          typeof remoteInboundAudio.totalRoundTripTime === 'number' &&
+          typeof remoteInboundAudio.roundTripTimeMeasurements === 'number' &&
+          remoteInboundAudio.roundTripTimeMeasurements > 0
+        ) {
+          roundTripTimeAvg =
+            remoteInboundAudio.totalRoundTripTime /
+            remoteInboundAudio.roundTripTimeMeasurements;
+        }
+
+        remoteRtcp.inbound = this._withoutUndefined({
+          packetsReceived: remoteInboundAudio.packetsReceived,
+          packetsLost: remoteInboundAudio.packetsLost,
+          fractionLost: remoteInboundAudio.fractionLost,
+          jitter: jitterMs,
+          roundTripTime: remoteInboundAudio.roundTripTime,
+          totalRoundTripTime: remoteInboundAudio.totalRoundTripTime,
+          roundTripTimeMeasurements:
+            remoteInboundAudio.roundTripTimeMeasurements,
+          roundTripTimeAvg,
+          nackCount: remoteInboundAudio.nackCount,
+          reportsReceived: remoteInboundAudio.reportsReceived,
+          packetsDiscarded: remoteInboundAudio.packetsDiscarded,
+        });
+      }
+
+      if (remoteOutboundAudio) {
+        remoteRtcp.outbound = this._withoutUndefined({
+          packetsSent: remoteOutboundAudio.packetsSent,
+          bytesSent: remoteOutboundAudio.bytesSent,
+          reportsCount: remoteOutboundAudio.reportsCount,
+          roundTripTime: remoteOutboundAudio.roundTripTime,
+          totalPacketSendDelay: remoteOutboundAudio.totalPacketSendDelay,
+        });
+      }
+
+      entry.remoteRtcp = remoteRtcp;
     }
 
     return entry;


### PR DESCRIPTION
## VSDK-387

Linear: https://linear.app/telnyx/issue/VSDK-387

## Change
Parses `remote-inbound-rtp` and `remote-outbound-rtp` audio stats in `CallReportCollector._collectStats` and persists them under a new `remoteRtcp` field on each `IStatsInterval`.

Covers the VSDK-387 cases:
- Remote RTCP stats are not parsed (remote-inbound-rtp, remote-outbound-rtp)
- Persisted reports have no outbound loss or outbound jitter visibility (now exposed via remote-inbound-rtp `fractionLost`/`packetsLost`/`jitter`)
- Media-path cumulative RTT averaging (`remote-inbound-rtp.totalRoundTripTime` / `roundTripTimeMeasurements` → `roundTripTimeAvg`)

New `IStatsInterval.remoteRtcp` shape:
- `remoteRtcp.inbound` → remote-inbound-rtp (outbound quality as seen by remote): `fractionLost`, `jitter` (ms), `roundTripTime`, `totalRoundTripTime`, `roundTripTimeMeasurements`, `roundTripTimeAvg`, `nackCount`, `reportsReceived`, `packetsDiscarded`
- `remoteRtcp.outbound` → remote-outbound-rtp (remote Sender Report): `packetsSent`, `bytesSent`, `reportsCount`, `roundTripTime`, `totalPacketSendDelay`

Tests: 3 new cases (parse + roundTripTimeAvg edge cases + absence when no RTCP reports). All 36 tests pass.

Part of VSDK-387 (separate PR per case). This PR covers ONLY remote RTCP; interval, codec, inbound-extra, outbound-extra, and playout cases are separate PRs.