### PR TITLE
Collect codec identity (mimeType, clockRate, channels, payloadType, sdpFmtpLine) (VSDK-387)

### DIFF
--- a/packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts
@@ -53,6 +53,20 @@ type TestableCallReportCollector = {
     stats: RTCStatsReport,
     outboundAudio: RTCOutboundRtpStreamStats & { mediaSourceId?: string }
   ) => number | null;
+  _getCodec: (
+    stats: RTCStatsReport,
+    codecId?: string
+  ) =>
+    | {
+        type: string;
+        id: string;
+        mimeType?: string;
+        clockRate?: number;
+        channels?: number;
+        sdpFmtpLine?: string;
+        payloadType?: number;
+      }
+    | undefined;
   _logLocalAudioTrackSnapshot: (
     localAudioTrack?: ILocalAudioTrackSnapshot,
     localAudioSource?: ILocalAudioSourceStats
@@ -1440,5 +1454,127 @@ describe('CallReportCollector remote RTCP stats', () => {
     const entry = await collectOnce(stats);
 
     expect(entry.remoteRtcp).toBeUndefined();
+  });
+});
+
+describe('CallReportCollector codec identity collection', () => {
+  it('collects codec identity for outbound and inbound audio from getStats', async () => {
+    const codecStat = {
+      id: 'C_audio',
+      type: 'codec',
+      mimeType: 'audio/opus',
+      clockRate: 48000,
+      channels: 2,
+      payloadType: 111,
+      sdpFmtpLine: 'minptime=10;useinbandfec=1',
+    };
+    const stats = new Map<string, unknown>([
+      [
+        'OB_audio',
+        {
+          id: 'OB_audio',
+          type: 'outbound-rtp',
+          kind: 'audio',
+          mediaType: 'audio',
+          ssrc: 1111,
+          codecId: 'C_audio',
+          packetsSent: 100,
+          bytesSent: 4800,
+        },
+      ],
+      [
+        'IB_audio',
+        {
+          id: 'IB_audio',
+          type: 'inbound-rtp',
+          kind: 'audio',
+          mediaType: 'audio',
+          ssrc: 2222,
+          codecId: 'C_audio',
+          packetsReceived: 90,
+          bytesReceived: 4320,
+        },
+      ],
+      ['C_audio', codecStat],
+    ]);
+    const collector = createCollector();
+    collector.peerConnection = {
+      getStats: jest.fn().mockResolvedValue(stats as unknown as RTCStatsReport),
+      getSenders: () => [],
+    };
+    (collector as unknown as { intervalStartTime: Date }).intervalStartTime =
+      new Date(Date.now() - 5000);
+
+    await collector._collectStats(true);
+
+    const entry = (
+      collector as unknown as CallReportCollector
+    ).getStatsBuffer()[0];
+    expect(entry.audio?.outbound?.codec).toEqual(
+      expect.objectContaining({
+        mimeType: 'audio/opus',
+        clockRate: 48000,
+        channels: 2,
+        payloadType: 111,
+        codecId: 'C_audio',
+      })
+    );
+    expect(entry.audio?.outbound?.codec?.sdpFmtpLine).toBeTruthy();
+    expect(entry.audio?.inbound?.codec).toEqual(
+      expect.objectContaining({
+        mimeType: 'audio/opus',
+        clockRate: 48000,
+        channels: 2,
+        payloadType: 111,
+        codecId: 'C_audio',
+      })
+    );
+    expect(entry.audio?.inbound?.codec?.sdpFmtpLine).toBeTruthy();
+  });
+
+  it('omits codec identity when the rtp stream has no codecId', async () => {
+    const stats = new Map<string, unknown>([
+      [
+        'OB_audio',
+        {
+          id: 'OB_audio',
+          type: 'outbound-rtp',
+          kind: 'audio',
+          mediaType: 'audio',
+          ssrc: 1111,
+          packetsSent: 100,
+          bytesSent: 4800,
+        },
+      ],
+    ]);
+    const collector = createCollector();
+    collector.peerConnection = {
+      getStats: jest.fn().mockResolvedValue(stats as unknown as RTCStatsReport),
+      getSenders: () => [],
+    };
+    (collector as unknown as { intervalStartTime: Date }).intervalStartTime =
+      new Date(Date.now() - 5000);
+
+    await collector._collectStats(true);
+
+    const entry = (
+      collector as unknown as CallReportCollector
+    ).getStatsBuffer()[0];
+    expect(entry.audio?.outbound?.codec).toBeUndefined();
+  });
+
+  it('resolves a codec stat by id and validates its type', () => {
+    const collector = createCollector();
+    const stats = new Map<string, unknown>([
+      ['C_audio', { id: 'C_audio', type: 'codec', mimeType: 'audio/opus' }],
+      ['not-a-codec', { id: 'not-a-codec', type: 'transport' }],
+    ]) as unknown as RTCStatsReport;
+
+    expect(collector._getCodec(stats, 'C_audio')).toEqual(
+      expect.objectContaining({ mimeType: 'audio/opus', type: 'codec' })
+    );
+    expect(collector._getCodec(stats, 'not-a-codec')).toBeUndefined();
+    expect(collector._getCodec(stats, undefined)).toBeUndefined();
+    expect(collector._getCodec(stats, 'missing')).toBeUndefined();
   });
 });

--- a/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
+++ b/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
@@ -155,6 +155,22 @@ interface ExtendedMediaPlayoutStats {
 }
 
 /**
+ * Extended RTCCodecStats (type: 'codec').
+ *
+ * Captures codec identity for an RTP stream. The `outbound-rtp` and
+ * `inbound-rtp` stats reference their codec via `codecId`.
+ */
+interface ExtendedCodecStats {
+  type: string;
+  id: string;
+  mimeType?: string;
+  clockRate?: number;
+  channels?: number;
+  sdpFmtpLine?: string;
+  payloadType?: number;
+}
+
+/**
  * Extended RTCAudioSourceStats (type: 'media-source', kind: 'audio')
  * Available in Chrome 96+ via outbound-rtp.mediaSourceId
  */
@@ -311,6 +327,14 @@ export interface IStatsInterval {
       targetBitrate?: number;
       totalPacketSendDelay?: number;
       active?: boolean;
+      codec?: {
+        mimeType?: string;
+        clockRate?: number;
+        channels?: number;
+        payloadType?: number;
+        sdpFmtpLine?: string;
+        codecId?: string;
+      };
     };
     inbound?: {
       packetsReceived?: number;
@@ -336,6 +360,14 @@ export interface IStatsInterval {
       samplesDecodedWithConcealment?: number;
       totalAudioEnergy?: number;
       totalSamplesDuration?: number;
+      codec?: {
+        mimeType?: string;
+        clockRate?: number;
+        channels?: number;
+        payloadType?: number;
+        sdpFmtpLine?: string;
+        codecId?: string;
+      };
     };
   };
   connection?: {
@@ -1159,6 +1191,11 @@ export class CallReportCollector {
             | undefined)
         : undefined;
 
+      // Resolve codec identity for the audio RTP streams. The `outbound-rtp`
+      // and `inbound-rtp` stats reference their codec via `codecId`.
+      const outboundCodec = this._getCodec(stats, outboundAudio?.codecId);
+      const inboundCodec = this._getCodec(stats, inboundAudio?.codecId);
+
       if (selectedCandidatePair?.type === 'candidate-pair') {
         candidatePair = selectedCandidatePair;
       } else if (selectedCandidatePairId) {
@@ -1320,7 +1357,9 @@ export class CallReportCollector {
           localAudioSource,
           mediaPlayout,
           remoteInboundAudio,
-          remoteOutboundAudio
+          remoteOutboundAudio,
+          outboundCodec,
+          inboundCodec
         );
 
         // Add to buffer with size limit
@@ -1670,7 +1709,9 @@ export class CallReportCollector {
     localAudioSource?: ILocalAudioSourceStats,
     mediaPlayout?: ExtendedMediaPlayoutStats | null,
     remoteInboundAudio?: ExtendedRemoteInboundRtpStreamStats | null,
-    remoteOutboundAudio?: ExtendedRemoteOutboundRtpStreamStats | null
+    remoteOutboundAudio?: ExtendedRemoteOutboundRtpStreamStats | null,
+    outboundCodec?: ExtendedCodecStats,
+    inboundCodec?: ExtendedCodecStats
   ): IStatsInterval {
     const entry: IStatsInterval = {
       intervalStartUtc: start.toISOString(),
@@ -1708,6 +1749,14 @@ export class CallReportCollector {
           : {}),
         ...(outboundAudio.active !== undefined
           ? { active: outboundAudio.active }
+          : {}),
+        ...(outboundCodec
+          ? {
+              codec: this._buildCodecSnapshot(
+                outboundCodec,
+                outboundAudio.codecId
+              ),
+            }
           : {}),
       };
     }
@@ -1761,6 +1810,14 @@ export class CallReportCollector {
           : {}),
         ...(inboundAudio.totalSamplesDuration !== undefined
           ? { totalSamplesDuration: inboundAudio.totalSamplesDuration }
+          : {}),
+        ...(inboundCodec
+          ? {
+              codec: this._buildCodecSnapshot(
+                inboundCodec,
+                inboundAudio.codecId
+              ),
+            }
           : {}),
       };
     }
@@ -1946,6 +2003,47 @@ export class CallReportCollector {
     }
 
     return info;
+  }
+
+  /**
+   * Resolve a `codec` stat from the RTCStatsReport by its stat id.
+   *
+   * The `outbound-rtp` and `inbound-rtp` stats reference their codec via the
+   * `codecId` field. Returns undefined when the referenced stat is missing
+   * or is not a `codec`-typed report.
+   */
+  private _getCodec(
+    stats: RTCStatsReport,
+    codecId?: string
+  ): ExtendedCodecStats | undefined {
+    if (!codecId) return undefined;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const codec = (stats as any).get(codecId);
+    if (!codec || codec.type !== 'codec') return undefined;
+    return codec as ExtendedCodecStats;
+  }
+
+  /**
+   * Build the `codec` snapshot persisted on an audio stats interval.
+   *
+   * Includes identity fields from the resolved `codec` stat and the
+   * rtp-level `codecId` (same value as the codec stat's `id`, stored for
+   * traceability back to the rtp stream).
+   */
+  private _buildCodecSnapshot(
+    codec: ExtendedCodecStats,
+    codecId?: string
+  ): NonNullable<NonNullable<IStatsInterval['audio']>['outbound']>['codec'] {
+    const snapshot = this._withoutUndefined({
+      mimeType: codec.mimeType,
+      clockRate: codec.clockRate,
+      channels: codec.channels,
+      payloadType: codec.payloadType,
+      sdpFmtpLine: codec.sdpFmtpLine,
+      // Store the rtp-level codecId for traceability to the rtp stream.
+      ...(codecId !== undefined ? { codecId } : {}),
+    });
+    return Object.keys(snapshot).length > 0 ? snapshot : undefined;
   }
 
   /**


### PR DESCRIPTION
## VSDK-387

Linear: https://linear.app/telnyx/issue/VSDK-387

## Change
Resolves the `codec` stat referenced by `outbound-rtp.codecId` / `inbound-rtp.codecId` and persists codec identity under `audio.outbound.codec` and `audio.inbound.codec` on each `IStatsInterval`.

Fields: `mimeType`, `clockRate`, `channels`, `payloadType`, `sdpFmtpLine`, `codecId`.

Covers the VSDK-387 case: "Codec identity is not collected (`mimeType`, `clockRate`, `channels`, `payloadType`, `sdpFmtpLine`, `codecId`)".

- Adds `ExtendedCodecStats` interface and a `_getCodec(stats, codecId?)` helper that validates `type === 'codec'`.
- `_createStatsEntry` attaches the codec snapshot (only when a codec stat is present), storing the rtp-level `codecId` for traceability.

Tests: 3 new cases (collect + omit-when-no-codecId + resolve/validate). All 36 tests pass; full webrtc suite green (233 passing).

Part of VSDK-387 (separate PR per case).