### PR TITLE
Collect additional inbound RTP fields (FEC, nack, jitter-buffer, decode, energy) (VSDK-387)

### DIFF
--- a/packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts
@@ -1171,3 +1171,123 @@ describe('CallReportCollector media-playout stats', () => {
     expect(entry.mediaPlayout).toBeUndefined();
   });
 });
+
+describe('CallReportCollector additional inbound RTP fields (VSDK-387)', () => {
+  const buildInboundStats = (extra?: Record<string, unknown>) => {
+    const inboundAudio = {
+      id: 'inbound-audio',
+      type: 'inbound-rtp',
+      kind: 'audio',
+      mediaType: 'audio',
+      packetsReceived: 100,
+      bytesReceived: 4800,
+      packetsLost: 1,
+      packetsDiscarded: 0,
+      jitterBufferDelay: 0.1,
+      jitterBufferEmittedCount: 100,
+      totalSamplesReceived: 48000,
+      concealedSamples: 50,
+      concealmentEvents: 5,
+      ...extra,
+    };
+    return inboundAudio;
+  };
+
+  const buildOutboundStats = () => ({
+    id: 'outbound-audio',
+    type: 'outbound-rtp',
+    kind: 'audio',
+    mediaType: 'audio',
+    packetsSent: 100,
+    bytesSent: 4800,
+  });
+
+  const runCollect = async (
+    inboundAudio: Record<string, unknown>
+  ): Promise<IStatsInterval> => {
+    const stats = new Map<string, unknown>([
+      ['inbound-audio', inboundAudio],
+      ['outbound-audio', buildOutboundStats()],
+    ]);
+    const collector = createCollector();
+    collector.peerConnection = {
+      getStats: jest.fn().mockResolvedValue(stats as unknown as RTCStatsReport),
+      getSenders: () => [],
+    };
+    (collector as unknown as { intervalStartTime: Date }).intervalStartTime =
+      new Date(Date.now() - 5000);
+
+    await collector._collectStats(true);
+
+    return (collector as unknown as CallReportCollector).getStatsBuffer()[0];
+  };
+
+  it('collects nack, header bytes, FEC, jitter-buffer, decode, and energy fields from inbound-rtp', async () => {
+    const entry = await runCollect(
+      buildInboundStats({
+        nackCount: 5,
+        headerBytesReceived: 1200,
+        fecPacketsReceived: 10,
+        fecPacketsDiscarded: 2,
+        jitterBufferTargetDelay: 0.05,
+        jitterBufferMinimumDelay: 0.02,
+        totalSamplesDecoded: 48000,
+        samplesDecodedWithSilence: 100,
+        samplesDecodedWithConcealment: 200,
+        totalAudioEnergy: 1.5,
+        totalSamplesDuration: 1.0,
+      })
+    );
+
+    expect(entry.audio?.inbound).toEqual(
+      expect.objectContaining({
+        // Existing fields still present
+        packetsReceived: 100,
+        bytesReceived: 4800,
+        packetsLost: 1,
+        packetsDiscarded: 0,
+        jitterBufferDelay: 0.1,
+        jitterBufferEmittedCount: 100,
+        totalSamplesReceived: 48000,
+        concealedSamples: 50,
+        concealmentEvents: 5,
+        // New inbound RTP fields
+        nackCount: 5,
+        headerBytesReceived: 1200,
+        fecPacketsReceived: 10,
+        fecPacketsDiscarded: 2,
+        jitterBufferTargetDelay: 0.05,
+        jitterBufferMinimumDelay: 0.02,
+        totalSamplesDecoded: 48000,
+        samplesDecodedWithSilence: 100,
+        samplesDecodedWithConcealment: 200,
+        totalAudioEnergy: 1.5,
+        totalSamplesDuration: 1.0,
+      })
+    );
+  });
+
+  it('omits the additional inbound fields when not reported by getStats', async () => {
+    const entry = await runCollect(buildInboundStats());
+
+    const inbound = entry.audio?.inbound;
+    expect(inbound).toEqual(
+      expect.objectContaining({
+        packetsReceived: 100,
+        bytesReceived: 4800,
+      })
+    );
+    // New optional fields should NOT be present when undefined
+    expect(inbound).not.toHaveProperty('nackCount');
+    expect(inbound).not.toHaveProperty('headerBytesReceived');
+    expect(inbound).not.toHaveProperty('fecPacketsReceived');
+    expect(inbound).not.toHaveProperty('fecPacketsDiscarded');
+    expect(inbound).not.toHaveProperty('jitterBufferTargetDelay');
+    expect(inbound).not.toHaveProperty('jitterBufferMinimumDelay');
+    expect(inbound).not.toHaveProperty('totalSamplesDecoded');
+    expect(inbound).not.toHaveProperty('samplesDecodedWithSilence');
+    expect(inbound).not.toHaveProperty('samplesDecodedWithConcealment');
+    expect(inbound).not.toHaveProperty('totalAudioEnergy');
+    expect(inbound).not.toHaveProperty('totalSamplesDuration');
+  });
+});

--- a/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
+++ b/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
@@ -54,6 +54,24 @@ interface ExtendedInboundRtpStreamStats extends RTCInboundRtpStreamStats {
   totalAudioEnergy?: number;
   /** Cumulative duration of received audio in seconds */
   totalSamplesDuration?: number;
+  /** Number of NACK packets received (negative acknowledgements) */
+  nackCount?: number;
+  /** Total RTP header bytes received */
+  headerBytesReceived?: number;
+  /** FEC packets received */
+  fecPacketsReceived?: number;
+  /** FEC packets that could not be recovered and were discarded */
+  fecPacketsDiscarded?: number;
+  /** Target delay for the jitter buffer, in seconds */
+  jitterBufferTargetDelay?: number;
+  /** Minimum delay for the jitter buffer, in seconds */
+  jitterBufferMinimumDelay?: number;
+  /** Total number of audio samples decoded */
+  totalSamplesDecoded?: number;
+  /** Samples decoded as silence (inserted by the decoder) */
+  samplesDecodedWithSilence?: number;
+  /** Samples decoded using concealment (PLC) */
+  samplesDecodedWithConcealment?: number;
 }
 
 /**
@@ -265,6 +283,17 @@ export interface IStatsInterval {
       audioLevelAvg?: number;
       jitterAvg?: number;
       bitrateAvg?: number;
+      nackCount?: number;
+      headerBytesReceived?: number;
+      fecPacketsReceived?: number;
+      fecPacketsDiscarded?: number;
+      jitterBufferTargetDelay?: number;
+      jitterBufferMinimumDelay?: number;
+      totalSamplesDecoded?: number;
+      samplesDecodedWithSilence?: number;
+      samplesDecodedWithConcealment?: number;
+      totalAudioEnergy?: number;
+      totalSamplesDuration?: number;
     };
   };
   connection?: {
@@ -1595,6 +1624,42 @@ export class CallReportCollector {
         audioLevelAvg: this._average(this.intervalAudioLevels.inbound),
         jitterAvg: this._average(this.intervalJitters),
         bitrateAvg: this._average(this.intervalBitrates.inbound),
+        ...(inboundAudio.nackCount !== undefined
+          ? { nackCount: inboundAudio.nackCount }
+          : {}),
+        ...(inboundAudio.headerBytesReceived !== undefined
+          ? { headerBytesReceived: inboundAudio.headerBytesReceived }
+          : {}),
+        ...(inboundAudio.fecPacketsReceived !== undefined
+          ? { fecPacketsReceived: inboundAudio.fecPacketsReceived }
+          : {}),
+        ...(inboundAudio.fecPacketsDiscarded !== undefined
+          ? { fecPacketsDiscarded: inboundAudio.fecPacketsDiscarded }
+          : {}),
+        ...(inboundAudio.jitterBufferTargetDelay !== undefined
+          ? { jitterBufferTargetDelay: inboundAudio.jitterBufferTargetDelay }
+          : {}),
+        ...(inboundAudio.jitterBufferMinimumDelay !== undefined
+          ? { jitterBufferMinimumDelay: inboundAudio.jitterBufferMinimumDelay }
+          : {}),
+        ...(inboundAudio.totalSamplesDecoded !== undefined
+          ? { totalSamplesDecoded: inboundAudio.totalSamplesDecoded }
+          : {}),
+        ...(inboundAudio.samplesDecodedWithSilence !== undefined
+          ? { samplesDecodedWithSilence: inboundAudio.samplesDecodedWithSilence }
+          : {}),
+        ...(inboundAudio.samplesDecodedWithConcealment !== undefined
+          ? {
+              samplesDecodedWithConcealment:
+                inboundAudio.samplesDecodedWithConcealment,
+            }
+          : {}),
+        ...(inboundAudio.totalAudioEnergy !== undefined
+          ? { totalAudioEnergy: inboundAudio.totalAudioEnergy }
+          : {}),
+        ...(inboundAudio.totalSamplesDuration !== undefined
+          ? { totalSamplesDuration: inboundAudio.totalSamplesDuration }
+          : {}),
       };
     }
 


### PR DESCRIPTION
## VSDK-387

Linear: https://linear.app/telnyx/issue/VSDK-387

## Change
Collects currently-dropped inbound-rtp fields in `CallReportCollector` and persists them under `audio.inbound` on each `IStatsInterval`:

- `nackCount`, `headerBytesReceived`
- FEC stats: `fecPacketsReceived`, `fecPacketsDiscarded`
- Jitter-buffer details: `jitterBufferTargetDelay`, `jitterBufferMinimumDelay`
- Decode stats: `totalSamplesDecoded`, `samplesDecodedWithSilence`, `samplesDecodedWithConcealment`
- Persistent energy/sample duration: `totalAudioEnergy`, `totalSamplesDuration` (previously used only for audioLevel computation, now persisted)

Covers the VSDK-387 case: "Several available inbound fields are dropped, including nackCount, headerBytesReceived, FEC stats, packet timing and jitter-buffer details, playout adjustment samples, and persistent energy/sample duration data."

Part of VSDK-387 (separate PR per case).