### PR TITLE
Collect additional outbound RTP fields (retransmission, nack, targetBitrate, totalPacketSendDelay, active) (VSDK-387)

### DIFF
--- a/packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts
@@ -826,6 +826,106 @@ describe('CallReportCollector cadence', () => {
   });
 });
 
+describe('CallReportCollector outbound RTP fields', () => {
+  it('collects additional outbound-rtp fields (retransmission, headers, nack, targetBitrate, totalPacketSendDelay, active)', async () => {
+    const outboundRtp = {
+      id: 'outbound-audio',
+      type: 'outbound-rtp',
+      kind: 'audio',
+      mediaType: 'audio',
+      ssrc: 1234,
+      timestamp: Date.now(),
+      packetsSent: 100,
+      bytesSent: 4800,
+      retransmittedPacketsSent: 3,
+      retransmittedBytesSent: 144,
+      headerBytesSent: 800,
+      nackCount: 1,
+      targetBitrate: 32000,
+      totalPacketSendDelay: 0.5,
+      active: true,
+    };
+    const stats = new Map<string, unknown>([['outbound-audio', outboundRtp]]);
+    const collector = createCollector();
+    collector.peerConnection = {
+      getStats: jest.fn().mockResolvedValue(stats as unknown as RTCStatsReport),
+      getSenders: () => [],
+    };
+    (collector as unknown as { intervalStartTime: Date }).intervalStartTime =
+      new Date(Date.now() - 5000);
+
+    await collector._collectStats(true);
+
+    const outbound = (
+      collector as unknown as CallReportCollector
+    ).getStatsBuffer()[0].audio?.outbound;
+
+    // New fields are collected with their expected values.
+    expect(outbound).toEqual(
+      expect.objectContaining({
+        retransmittedPacketsSent: 3,
+        retransmittedBytesSent: 144,
+        headerBytesSent: 800,
+        nackCount: 1,
+        targetBitrate: 32000,
+        totalPacketSendDelay: 0.5,
+        active: true,
+      })
+    );
+
+    // Existing fields are still present.
+    expect(outbound).toEqual(
+      expect.objectContaining({
+        packetsSent: 100,
+        bytesSent: 4800,
+      })
+    );
+    expect(outbound).toHaveProperty('audioLevelAvg');
+    expect(outbound).toHaveProperty('bitrateAvg');
+  });
+
+  it('does not set the new outbound-rtp fields when the report omits them', async () => {
+    const outboundRtp = {
+      id: 'outbound-audio',
+      type: 'outbound-rtp',
+      kind: 'audio',
+      mediaType: 'audio',
+      ssrc: 1234,
+      timestamp: Date.now(),
+      packetsSent: 50,
+      bytesSent: 2400,
+    };
+    const stats = new Map<string, unknown>([['outbound-audio', outboundRtp]]);
+    const collector = createCollector();
+    collector.peerConnection = {
+      getStats: jest.fn().mockResolvedValue(stats as unknown as RTCStatsReport),
+      getSenders: () => [],
+    };
+    (collector as unknown as { intervalStartTime: Date }).intervalStartTime =
+      new Date(Date.now() - 5000);
+
+    await collector._collectStats(true);
+
+    const outbound = (
+      collector as unknown as CallReportCollector
+    ).getStatsBuffer()[0].audio?.outbound;
+
+    expect(outbound).toEqual(
+      expect.objectContaining({
+        packetsSent: 50,
+        bytesSent: 2400,
+      })
+    );
+    expect(outbound).not.toHaveProperty('retransmittedPacketsSent');
+    expect(outbound).not.toHaveProperty('retransmittedBytesSent');
+    expect(outbound).not.toHaveProperty('headerBytesSent');
+    expect(outbound).not.toHaveProperty('nackCount');
+    expect(outbound).not.toHaveProperty('targetBitrate');
+    expect(outbound).not.toHaveProperty('totalPacketSendDelay');
+    expect(outbound).not.toHaveProperty('active');
+  });
+});
+
 describe('CallReportCollector intermediate flushes', () => {
   it('requests time-based intermediate flushes while a call is active', async () => {
     const collector = new CallReportCollector({

--- a/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
+++ b/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
@@ -58,10 +58,26 @@ interface ExtendedInboundRtpStreamStats extends RTCInboundRtpStreamStats {
 
 /**
  * Extended RTCOutboundRtpStreamStats
+ *
+ * `nackCount` is already declared on the base lib.dom type, so it is not
+ * re-declared here. The remaining outbound-rtp fields below are produced by
+ * Chromium but are not yet in the bundled TypeScript lib definitions.
  */
 interface ExtendedOutboundRtpStreamStats extends RTCOutboundRtpStreamStats {
   trackId?: string;
   mediaSourceId?: string;
+  /** Packets retransmitted to recover from loss (cumulative). */
+  retransmittedPacketsSent?: number;
+  /** Bytes retransmitted to recover from loss (cumulative). */
+  retransmittedBytesSent?: number;
+  /** RTP/RTCP header bytes sent (cumulative). */
+  headerBytesSent?: number;
+  /** Target bitrate the encoder is aiming for, in bits per second. */
+  targetBitrate?: number;
+  /** Cumulative time packets spent buffered before being sent, in seconds. */
+  totalPacketSendDelay?: number;
+  /** Whether the sender is currently active. */
+  active?: boolean;
 }
 
 /**
@@ -214,6 +230,13 @@ export interface IStatsInterval {
       bitrateAvg?: number;
       localTrack?: ILocalAudioTrackSnapshot;
       mediaSource?: ILocalAudioSourceStats;
+      retransmittedPacketsSent?: number;
+      retransmittedBytesSent?: number;
+      headerBytesSent?: number;
+      nackCount?: number;
+      targetBitrate?: number;
+      totalPacketSendDelay?: number;
+      active?: boolean;
     };
     inbound?: {
       packetsReceived?: number;
@@ -1512,6 +1535,27 @@ export class CallReportCollector {
         bitrateAvg: this._average(this.intervalBitrates.outbound),
         ...(localAudioTrack ? { localTrack: localAudioTrack } : {}),
         ...(localAudioSource ? { mediaSource: localAudioSource } : {}),
+        ...(outboundAudio.retransmittedPacketsSent !== undefined
+          ? { retransmittedPacketsSent: outboundAudio.retransmittedPacketsSent }
+          : {}),
+        ...(outboundAudio.retransmittedBytesSent !== undefined
+          ? { retransmittedBytesSent: outboundAudio.retransmittedBytesSent }
+          : {}),
+        ...(outboundAudio.headerBytesSent !== undefined
+          ? { headerBytesSent: outboundAudio.headerBytesSent }
+          : {}),
+        ...(outboundAudio.nackCount !== undefined
+          ? { nackCount: outboundAudio.nackCount }
+          : {}),
+        ...(outboundAudio.targetBitrate !== undefined
+          ? { targetBitrate: outboundAudio.targetBitrate }
+          : {}),
+        ...(outboundAudio.totalPacketSendDelay !== undefined
+          ? { totalPacketSendDelay: outboundAudio.totalPacketSendDelay }
+          : {}),
+        ...(outboundAudio.active !== undefined
+          ? { active: outboundAudio.active }
+          : {}),
       };
     }
 


### PR DESCRIPTION
## VSDK-387

Linear: https://linear.app/telnyx/issue/VSDK-387

## Change
Collects currently-dropped outbound-rtp fields in `CallReportCollector` and persists them under `audio.outbound` on each `IStatsInterval`:

- Retransmission: `retransmittedPacketsSent`, `retransmittedBytesSent`
- Headers: `headerBytesSent`
- `nackCount`
- `targetBitrate`
- `totalPacketSendDelay`
- `active`

Covers the VSDK-387 case: "Several available outbound fields are dropped, including retransmission, headers, nackCount, targetBitrate, totalPacketSendDelay, active, and media-source capture quality indicators."

Part of VSDK-387 (separate PR per case).