### PR TITLE
Collect media-playout stats (playout delay, synthesized samples) (VSDK-387)

### DIFF
--- a/packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts
@@ -999,3 +999,86 @@ describe('CallReportCollector call report uploads', () => {
     expect(fetchMock.mock.calls[0][1]).not.toHaveProperty('keepalive');
   });
 });
+
+describe('CallReportCollector media-playout stats', () => {
+  it('collects playout delay and synthesized sample indicators from media-playout stats', async () => {
+    const stats = new Map<string, unknown>([
+      [
+        'outbound_audio',
+        {
+          id: 'outbound_audio',
+          type: 'outbound-rtp',
+          kind: 'audio',
+          mediaType: 'audio',
+          packetsSent: 100,
+          bytesSent: 4800,
+        },
+      ],
+      [
+        'MP_audio',
+        {
+          id: 'MP_audio',
+          type: 'media-playout',
+          kind: 'audio',
+          synthesizedSamples: 1500,
+          synthesizedDuration: 0.03,
+          totalPlayoutDelay: 0.12,
+          totalSampleCount: 48000,
+        },
+      ],
+    ]);
+    const collector = createCollector();
+    collector.peerConnection = {
+      getStats: jest.fn().mockResolvedValue(stats as unknown as RTCStatsReport),
+      getSenders: () => [],
+    };
+    (collector as unknown as { intervalStartTime: Date }).intervalStartTime =
+      new Date(Date.now() - 5000);
+
+    await collector._collectStats(true);
+
+    expect(
+      (collector as unknown as CallReportCollector).getStatsBuffer()[0]
+    ).toEqual(
+      expect.objectContaining({
+        mediaPlayout: {
+          synthesizedSamples: 1500,
+          synthesizedDuration: 0.03,
+          totalPlayoutDelay: 0.12,
+          totalSampleCount: 48000,
+        },
+      })
+    );
+  });
+
+  it('omits mediaPlayout when no media-playout stat is present', async () => {
+    const stats = new Map<string, unknown>([
+      [
+        'outbound_audio',
+        {
+          id: 'outbound_audio',
+          type: 'outbound-rtp',
+          kind: 'audio',
+          mediaType: 'audio',
+          packetsSent: 100,
+          bytesSent: 4800,
+        },
+      ],
+    ]);
+    const collector = createCollector();
+    collector.peerConnection = {
+      getStats: jest.fn().mockResolvedValue(stats as unknown as RTCStatsReport),
+      getSenders: () => [],
+    };
+    (collector as unknown as { intervalStartTime: Date }).intervalStartTime =
+      new Date(Date.now() - 5000);
+
+    await collector._collectStats(true);
+
+    const entry = (
+      collector as unknown as CallReportCollector
+    ).getStatsBuffer()[0];
+    expect(entry).toBeDefined();
+    expect(entry.mediaPlayout).toBeUndefined();
+  });
+});

--- a/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
+++ b/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
@@ -65,6 +65,20 @@ interface ExtendedOutboundRtpStreamStats extends RTCOutboundRtpStreamStats {
 }
 
 /**
+ * Extended media-playout stats (type: 'media-playout', audio).
+ * Reports playout delay and synthesized-sample indicators.
+ */
+interface ExtendedMediaPlayoutStats {
+  type: string;
+  id: string;
+  kind?: string;
+  synthesizedSamples?: number;
+  synthesizedDuration?: number;
+  totalPlayoutDelay?: number;
+  totalSampleCount?: number;
+}
+
+/**
  * Extended RTCAudioSourceStats (type: 'media-source', kind: 'audio')
  * Available in Chrome 96+ via outbound-rtp.mediaSourceId
  */
@@ -241,6 +255,16 @@ export interface IStatsInterval {
   };
   ice?: IICECandidatePair;
   transport?: ITransportStats;
+  /**
+   * Audio playout stats from the `media-playout` RTCStatsType.
+   * Reports playout delay and synthesized-sample indicators.
+   */
+  mediaPlayout?: {
+    synthesizedSamples?: number;
+    synthesizedDuration?: number;
+    totalPlayoutDelay?: number;
+    totalSampleCount?: number;
+  };
 }
 
 export interface ICallSummary {
@@ -948,6 +972,7 @@ export class CallReportCollector {
       // Process stats reports
       let outboundAudio: ExtendedOutboundRtpStreamStats | null = null;
       let inboundAudio: ExtendedInboundRtpStreamStats | null = null;
+      let mediaPlayout: ExtendedMediaPlayoutStats | null = null;
       let candidatePair: ExtendedCandidatePairStats | null = null;
       const candidatePairs: ExtendedCandidatePairStats[] = [];
       let transportStats: ExtendedTransportStats | null = null;
@@ -962,6 +987,11 @@ export class CallReportCollector {
           case 'inbound-rtp':
             if (report.kind === 'audio' && report.mediaType === 'audio') {
               inboundAudio = report as ExtendedInboundRtpStreamStats;
+            }
+            break;
+          case 'media-playout':
+            if (report.kind === 'audio') {
+              mediaPlayout = report as ExtendedMediaPlayoutStats;
             }
             break;
           case 'candidate-pair':
@@ -1147,7 +1177,8 @@ export class CallReportCollector {
           remoteCandidate,
           transportStats,
           localAudioTrack,
-          localAudioSource
+          localAudioSource,
+          mediaPlayout
         );
 
         // Add to buffer with size limit
@@ -1494,7 +1525,8 @@ export class CallReportCollector {
     remoteCandidate?: ICECandidateInfo,
     transportStats?: ExtendedTransportStats | null,
     localAudioTrack?: ILocalAudioTrackSnapshot,
-    localAudioSource?: ILocalAudioSourceStats
+    localAudioSource?: ILocalAudioSourceStats,
+    mediaPlayout?: ExtendedMediaPlayoutStats | null
   ): IStatsInterval {
     const entry: IStatsInterval = {
       intervalStartUtc: start.toISOString(),
@@ -1587,6 +1619,16 @@ export class CallReportCollector {
           ? { selectedCandidatePairId: transportStats.selectedCandidatePairId }
           : {}),
       };
+    }
+
+    // Media-playout stats (audio playout delay + synthesized samples)
+    if (mediaPlayout) {
+      entry.mediaPlayout = this._withoutUndefined({
+        synthesizedSamples: mediaPlayout.synthesizedSamples,
+        synthesizedDuration: mediaPlayout.synthesizedDuration,
+        totalPlayoutDelay: mediaPlayout.totalPlayoutDelay,
+        totalSampleCount: mediaPlayout.totalSampleCount,
+      });
     }
 
     return entry;


### PR DESCRIPTION
## VSDK-387

Linear: https://linear.app/telnyx/issue/VSDK-387

## Change
Parses the `media-playout` audio stat in `CallReportCollector._collectStats` and persists it under a new top-level `mediaPlayout` field on each `IStatsInterval`:

- `synthesizedSamples`, `synthesizedDuration` (synthesized sample indicators)
- `totalPlayoutDelay`, `totalSampleCount` (playout delay)

Covers the VSDK-387 case: "`media-playout` stats are not collected, including playout delay and synthesized sample indicators."

Part of VSDK-387 (separate PR per case).