### PR TITLE
fix(sdk): send login synchronously on WebSocket open to avoid event loop congestion

### DIFF
--- a/packages/js/src/Modules/Verto/index.ts
+++ b/packages/js/src/Modules/Verto/index.ts
@@ -183,8 +183,21 @@ export default class Verto extends BrowserSession {
   }
 
   protected async _onSocketOpen() {
-    // Let BaseSession resume signaling health monitor for active calls
-    await super._onSocketOpen();
+    // Start the signaling health monitor synchronously — do NOT await.
+    //
+    // super._onSocketOpen() only calls startSignalingHealthMonitor() which
+    // is fully synchronous (sets fields + setInterval). Awaiting it wraps
+    // the call in a resolved Promise and creates a microtask yield between
+    // the WebSocket onopen event and the login send. During event loop
+    // congestion (session transitions, heavy GC, main-thread blocking),
+    // this yield delays authentication by seconds — observed 9s in
+    // production (ch1, 2026-06-29) where the old session's main thread was
+    // blocked for ~32s during a reconnection transition.
+    //
+    // By calling super._onSocketOpen() without await, the login message
+    // is sent synchronously in the same call stack as the onopen handler,
+    // before any microtask or macrotask can intercept.
+    void super._onSocketOpen();
 
     if (isValidLoginOptions(this.options)) {
       return this.handleLoginOnSocketOpen();


### PR DESCRIPTION
## Summary

Fixes a multi-second delay between WebSocket `onopen` and login message send caused by an unnecessary `await` on a synchronous method.

## Problem

The Verto subclass `_onSocketOpen()` awaited `super._onSocketOpen()` which only calls `startSignalingHealthMonitor()` — a fully synchronous method (sets fields + `setInterval`). The `await` wrapped the call in a resolved Promise, creating a **microtask yield** between the WebSocket `onopen` event and the login message send.

During event loop congestion (session transitions, heavy GC, main-thread blocking), this yield delayed authentication by **seconds**. Observed **9s delay** in production (ch1, 2026-06-29) where the old session's main thread was blocked for ~32s during a reconnection transition, delaying both the old session's pings and the new session's login send.

## Fix

Call `super._onSocketOpen()` without `await` (using `void` operator). The login message is now sent synchronously in the same call stack as the `onopen` handler, before any microtask or macrotask can intercept.

### Why this is safe

- `super._onSocketOpen()` → `startSignalingHealthMonitor()` → `SignalingHealthMonitor.start()` — all synchronous
- No async operations, no network calls, no promises that could reject
- The `void` operator explicitly marks the Promise as intentionally not awaited
- Execution order is preserved: health monitor starts → login is sent (same synchronous call stack)

## Investigation Evidence

- **ch1** runs older VSP (pre-PreRouting) that creates upstream proactively in `websocket_init`, exposing the client-side `onopen`→login gap
- **nj1** runs newer VSP with PreRouting, masking the gap (upstream created after login, so gap is always ~1ms)
- 4 sessions from same client IP: 3 normal (0–177ms gap), 1 problematic (9.034s gap on ch1 during session transition)
- DNS is **not** the cause (CoreDNS P99 sub-ms at all sites, zero errors)
- VSP instance metrics healthy (BEAM run queue 0–2, no failures)

## Test Results

All 533 tests pass across 22 test suites.
