### PR TITLE
feat(sdk): event loop congestion monitor with warnings and call report integration

### DIFF
--- a/packages/js/src/Modules/Verto/BaseSession.ts
+++ b/packages/js/src/Modules/Verto/BaseSession.ts
@@ -10,6 +10,7 @@ import {
 } from './services/Handler';
 import { RegisterAgent } from './services/RegisterAgent';
 import SignalingHealthMonitor from './services/SignalingHealthMonitor';
+import EventLoopMonitor from './services/EventLoopMonitor';
 import type {
   ISignalingHealthSession,
   PeerFailureEvidence,
@@ -32,6 +33,7 @@ import {
   StaleRequestError,
 } from './util/errors';
 import type { ITelnyxErrorEvent } from './util/errors';
+import { EVENT_LOOP_CONGESTION } from './util/constants/errorCodes';
 import {
   isFunction,
   isValidAnonymousLoginOptions,
@@ -117,6 +119,10 @@ export default abstract class BaseSession {
   /** Handles liveness detection, health probing, and force-reconnect. */
   private _signalingHealthMonitor: SignalingHealthMonitor =
     new SignalingHealthMonitor(this as unknown as ISignalingHealthSession);
+
+  // ── Event loop monitor ────────────────────────────────────────────────
+  /** Detects main-thread blocking / event-loop congestion. Session-level. */
+  private _eventLoopMonitor: EventLoopMonitor = new EventLoopMonitor();
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type, @typescript-eslint/no-explicit-any
   private _executeQueue: { resolve?: Function; msg: any }[] = [];
@@ -362,6 +368,7 @@ export default abstract class BaseSession {
     this._intentionalClose = true;
     this._reconnectAttempts = 0;
     this.relayProtocol = null;
+    this._eventLoopMonitor.stop();
     await this._drainCallReportUploads();
     this._closeConnection();
     await sessionStorage.removeItem(this.signature);
@@ -780,6 +787,22 @@ export default abstract class BaseSession {
     // Socket liveness is monitored for the session lifetime. Media/peer
     // recovery decisions remain scoped to active calls inside the monitor.
     this.startSignalingHealthMonitor();
+
+    // Start event-loop congestion monitoring for the session. This detects
+    // main-thread blocking that delays time-sensitive operations (login,
+    // keepalive pings, call setup). Each episode emits a warning event.
+    this._eventLoopMonitor.start((episode) => {
+      const warning = createTelnyxWarning(EVENT_LOOP_CONGESTION);
+      trigger(
+        SwEvent.Warning,
+        {
+          warning,
+          sessionId: this.sessionid,
+          ...episode,
+        },
+        this.uuid
+      );
+    });
   }
 
   private _flushIntermediateCallReports(
@@ -1129,6 +1152,7 @@ export default abstract class BaseSession {
     this._idle = true;
     clearTimeout(this._keepAliveTimeout);
     this.stopSignalingHealthMonitor();
+    this._eventLoopMonitor.stop();
 
     logger.debug('_closeConnection called', {
       connected: this.connection?.connected,
@@ -1239,6 +1263,24 @@ export default abstract class BaseSession {
    */
   stopSignalingHealthMonitor(): void {
     this._signalingHealthMonitor.stop();
+  }
+
+  /**
+   * Get the event-loop congestion summary for inclusion in a call report.
+   * Returns null if no congestion was detected during the session.
+   */
+  getEventLoopCongestionSummary(): {
+    totalEpisodes: number;
+    maxLagMs: number;
+    episodes: Array<{
+      timestamp: string;
+      lagMs?: number;
+      intervalMs?: number;
+      taskDurationMs?: number;
+      source: 'heartbeat' | 'longtask';
+    }>;
+  } | null {
+    return this._eventLoopMonitor.getSummary();
   }
 
   /**

--- a/packages/js/src/Modules/Verto/services/EventLoopMonitor.ts
+++ b/packages/js/src/Modules/Verto/services/EventLoopMonitor.ts
@@ -1,0 +1,287 @@
+import logger from '../util/logger';
+
+/**
+ * A single recorded episode of event-loop congestion.
+ *
+ * Either `lagMs` (heartbeat late firing) or `taskDurationMs` (long task
+ * from PerformanceObserver) will be set — never both at the same time,
+ * because they come from different detection mechanisms.
+ */
+export interface IEventLoopCongestionEpisode {
+  /** ISO 8601 timestamp of when the episode was detected. */
+  timestamp: string;
+  /** How late the heartbeat interval fired (ms). Only for heartbeat episodes. */
+  lagMs?: number;
+  /** Expected heartbeat interval (ms). Only for heartbeat episodes. */
+  intervalMs?: number;
+  /** Long task duration (ms). Only for PerformanceObserver episodes. */
+  taskDurationMs?: number;
+  /** Source of detection: 'heartbeat' or 'longtask'. */
+  source: 'heartbeat' | 'longtask';
+}
+
+/**
+ * Summary of all congestion episodes for a session.
+ * Included in the final call report payload.
+ */
+export interface IEventLoopCongestionSummary {
+  /** Total number of congestion episodes detected. */
+  totalEpisodes: number;
+  /** Maximum lag/task duration observed (ms). */
+  maxLagMs: number;
+  /** All recorded episodes (capped to prevent unbounded growth). */
+  episodes: IEventLoopCongestionEpisode[];
+}
+
+/**
+ * Detection thresholds.
+ *
+ * - `HEARTBEAT_INTERVAL_MS`: How often to fire the heartbeat. 2000ms is a
+ *   good balance — granular enough to catch multi-second congestion, light
+ *   enough to never itself cause load.
+ *
+ * - `HEARTBEAT_LAG_THRESHOLD_MS`: Minimum late-firing to count as
+ *   congestion. 1000ms means the main thread was blocked for at least
+ *   ~1s. This avoids false positives from normal scheduling jitter.
+ *
+ * - `LONGTASK_THRESHOLD_MS`: PerformanceObserver 'longtask' entries above
+ *   this are recorded. The W3C definition is 50ms, but we use 500ms to avoid
+ *   recording every long task — only the ones severe enough to affect
+ *   real-time signaling.
+ *
+ * - `MAX_EPISODES`: Cap on recorded episodes to prevent unbounded memory
+ *   growth in pathological cases.
+ */
+const HEARTBEAT_INTERVAL_MS = 2000;
+const HEARTBEAT_LAG_THRESHOLD_MS = 1000;
+const LONGTASK_THRESHOLD_MS = 500;
+const MAX_EPISODES = 50;
+
+/**
+ * Detects event-loop congestion (main-thread blocking) in the browser.
+ *
+ * A production incident (ch1, 2026-06-29) showed that a 9s delay between
+ * WebSocket `onopen` and the login send was caused by the main thread being
+ * blocked during a session transition. The SDK had zero visibility into
+ * this — signaling health monitoring catches *silent* sockets, but not a
+ * blocked main thread that still processes events eventually.
+ *
+ * This monitor uses two complementary detection mechanisms:
+ *
+ * 1. **Heartbeat (setInterval)** — Universally available. Fires every
+ *    `HEARTBEAT_INTERVAL_MS` and measures how late the callback runs. If the
+ *    main thread is blocked, the timer fires late. The lag is the difference
+ *    between actual and expected fire time. This catches all blocking,
+ *    including sync JS, GC pauses, and layout thrashing.
+ *
+ * 2. **PerformanceObserver('longtask')** — Available in Chrome/Edge. Fires
+ *    a callback whenever a task exceeds 50ms of main-thread time. We filter
+ *    to only record tasks ≥ `LONGTASK_THRESHOLD_MS` to avoid noise. This
+ *    provides precise task duration that the heartbeat can only infer.
+ *
+ * The heartbeat is the primary mechanism — it works everywhere and catches
+ * all blocking. The PerformanceObserver is supplementary, providing exact
+ * task durations when available.
+ *
+ * Lifecycle:
+ * - `start()` when the session connects (WebSocket open).
+ * - `stop()` when the session disconnects.
+ * - `getSummary()` called by CallReportCollector when building the final
+ *   call report to include congestion data server-side.
+ * - The `onCongestion` callback fires on each episode for real-time
+ *   warning emission.
+ *
+ * Design notes:
+ * - No `performance.now()` dependency — uses `Date.now()` for the heartbeat
+ *   to avoid issues with clock changes. `performance.now()` is used only
+ *   where the PerformanceObserver provides it.
+ * - The monitor is intentionally lightweight: one setInterval, one
+ *   PerformanceObserver, and a small array. Memory and CPU overhead are
+ *   negligible.
+ * - Episodes are capped at `MAX_EPISODES` to prevent unbounded growth.
+ *   When the cap is reached, the oldest episodes are discarded (FIFO).
+ */
+export default class EventLoopMonitor {
+  /** The heartbeat interval id, or null when stopped. */
+  private _intervalId: ReturnType<typeof setInterval> | null = null;
+  /** Timestamp (Date.now) of the last heartbeat tick. */
+  private _lastTick = 0;
+  /** Recorded congestion episodes. */
+  private _episodes: IEventLoopCongestionEpisode[] = [];
+  /** Maximum lag observed across all episodes. */
+  private _maxLagMs = 0;
+  /** PerformanceObserver for longtask entries, or null if unsupported. */
+  private _observer: PerformanceObserver | null = null;
+  /** Callback invoked on each congestion episode. */
+  private _onCongestion:
+    | ((episode: IEventLoopCongestionEpisode) => void)
+    | null = null;
+
+  /**
+   * Start monitoring.
+   *
+   * @param onCongestion Optional callback fired on each congestion episode.
+   *   Used to emit warnings in real-time. The callback is called
+   *   synchronously from the heartbeat/observer callback — keep it cheap.
+   */
+  start(onCongestion?: (episode: IEventLoopCongestionEpisode) => void): void {
+    if (this._intervalId) {
+      return; // already running
+    }
+
+    this._onCongestion = onCongestion ?? null;
+    this._lastTick = Date.now();
+    this._episodes = [];
+    this._maxLagMs = 0;
+
+    // ── Heartbeat: primary detection mechanism ──────────────────────
+    // setInterval fires on the main thread. If the main thread is blocked,
+    // the callback runs late. The lag = actual - expected fire time.
+    this._intervalId = setInterval(() => {
+      this._heartbeat();
+    }, HEARTBEAT_INTERVAL_MS);
+
+    // ── PerformanceObserver: supplementary detection ─────────────────
+    // 'longtask' is available in Chrome 51+ and Edge. Not in Firefox/Safari.
+    // We wrap in try/catch because some browsers throw on unsupported entry
+    // types even with a PerformanceObserver guard.
+    try {
+      if (typeof PerformanceObserver !== 'undefined') {
+        const observer = new PerformanceObserver((list) => {
+          this._onLongTasks(list);
+        });
+        observer.observe({ entryTypes: ['longtask'] });
+        this._observer = observer;
+      }
+    } catch {
+      // 'longtask' not supported — heartbeat is the sole mechanism.
+      logger.debug(
+        'EventLoopMonitor: PerformanceObserver longtask not supported, using heartbeat only'
+      );
+    }
+
+    logger.debug('EventLoopMonitor: started');
+  }
+
+  /**
+   * Stop monitoring and release all resources.
+   * Recorded episodes are retained for `getSummary()`.
+   */
+  stop(): void {
+    if (this._intervalId) {
+      clearInterval(this._intervalId);
+      this._intervalId = null;
+    }
+    if (this._observer) {
+      try {
+        this._observer.disconnect();
+      } catch {
+        // ignore
+      }
+      this._observer = null;
+    }
+    this._onCongestion = null;
+    logger.debug('EventLoopMonitor: stopped', {
+      totalEpisodes: this._episodes.length,
+      maxLagMs: this._maxLagMs,
+    });
+  }
+
+  /**
+   * Returns true if the monitor is currently running.
+   */
+  get isRunning(): boolean {
+    return this._intervalId !== null;
+  }
+
+  /**
+   * Get a summary of all congestion episodes for inclusion in the call
+   * report. Returns null if no episodes were recorded.
+   */
+  getSummary(): IEventLoopCongestionSummary | null {
+    if (this._episodes.length === 0) {
+      return null;
+    }
+    return {
+      totalEpisodes: this._episodes.length,
+      maxLagMs: this._maxLagMs,
+      episodes: [...this._episodes],
+    };
+  }
+
+  // ── Private ─────────────────────────────────────────────────────────
+
+  /**
+   * Heartbeat tick — measure how late this callback fired.
+   * If the main thread was blocked, `now` will be significantly past
+   * `expected`, and the difference is the lag.
+   */
+  private _heartbeat(): void {
+    const now = Date.now();
+    const expected = this._lastTick + HEARTBEAT_INTERVAL_MS;
+    const lag = now - expected;
+
+    // Update _lastTick even on lag so the next interval's expected time
+    // is based on when this tick actually fired, not the ideal schedule.
+    // This prevents compounding: if one tick is 5s late, the next tick's
+    // lag should measure new blocking, not the accumulated drift.
+    this._lastTick = now;
+
+    if (lag >= HEARTBEAT_LAG_THRESHOLD_MS) {
+      const episode: IEventLoopCongestionEpisode = {
+        timestamp: new Date(now).toISOString(),
+        lagMs: Math.round(lag),
+        intervalMs: HEARTBEAT_INTERVAL_MS,
+        source: 'heartbeat',
+      };
+      this._recordEpisode(episode);
+    }
+  }
+
+  /**
+   * PerformanceObserver callback — filter long tasks to only record
+   * severe ones (≥ LONGTASK_THRESHOLD_MS).
+   */
+  private _onLongTasks(list: PerformanceObserverEntryList): void {
+    for (const entry of list.getEntries()) {
+      const duration = entry.duration;
+      if (duration >= LONGTASK_THRESHOLD_MS) {
+        const episode: IEventLoopCongestionEpisode = {
+          timestamp: new Date(
+            entry.startTime + (performance.timeOrigin || 0)
+          ).toISOString(),
+          taskDurationMs: Math.round(duration),
+          source: 'longtask',
+        };
+        this._recordEpisode(episode);
+      }
+    }
+  }
+
+  /**
+   * Record an episode, update max lag, invoke the callback, and enforce
+   * the episode cap.
+   */
+  private _recordEpisode(episode: IEventLoopCongestionEpisode): void {
+    // Enforce the cap (FIFO — discard oldest)
+    if (this._episodes.length >= MAX_EPISODES) {
+      this._episodes.shift();
+    }
+
+    this._episodes.push(episode);
+
+    const lagValue = episode.lagMs ?? episode.taskDurationMs ?? 0;
+    if (lagValue > this._maxLagMs) {
+      this._maxLagMs = lagValue;
+    }
+
+    logger.warn(
+      `EventLoopMonitor: congestion detected ` +
+        `(source=${episode.source}, ` +
+        `${episode.lagMs !== undefined ? `lagMs=${episode.lagMs}` : `taskDurationMs=${episode.taskDurationMs}`})`,
+      episode
+    );
+
+    this._onCongestion?.(episode);
+  }
+}

--- a/packages/js/src/Modules/Verto/tests/event-loop/EventLoopMonitor.test.ts
+++ b/packages/js/src/Modules/Verto/tests/event-loop/EventLoopMonitor.test.ts
@@ -1,0 +1,140 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import EventLoopMonitor from '../../services/EventLoopMonitor';
+
+jest.mock('../../util/logger', () => ({
+  __esModule: true,
+  default: {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+const mockObserver = {
+  observe: jest.fn(),
+  disconnect: jest.fn(),
+};
+(global as any).PerformanceObserver = jest.fn(() => mockObserver);
+
+describe('EventLoopMonitor', () => {
+  let monitor: EventLoopMonitor;
+  let baseTime: number;
+
+  beforeEach(() => {
+    baseTime = 1700000000000;
+    jest.useFakeTimers('modern');
+    jest.setSystemTime(baseTime);
+    monitor = new EventLoopMonitor();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    monitor.stop();
+    jest.useRealTimers();
+  });
+
+  describe('start()', () => {
+    it('should start the heartbeat interval', () => {
+      monitor.start();
+      expect(monitor.isRunning).toBe(true);
+    });
+
+    it('should not double-start (idempotent)', () => {
+      monitor.start();
+      monitor.start();
+      expect(monitor.isRunning).toBe(true);
+    });
+
+    it('should invoke onCongestion callback when heartbeat fires late', () => {
+      const onCongestion = jest.fn();
+      monitor.start(onCongestion);
+
+      jest.advanceTimersByTime(2000);
+      expect(onCongestion).not.toHaveBeenCalled();
+
+      jest.setSystemTime(baseTime + 7000);
+      jest.advanceTimersByTime(2000);
+
+      expect(onCongestion).toHaveBeenCalled();
+      const episode = onCongestion.mock.calls[0][0];
+      expect(episode.source).toBe('heartbeat');
+      expect(episode.lagMs).toBeGreaterThan(999);
+      expect(episode.intervalMs).toBe(2000);
+      expect(episode.timestamp).toBeDefined();
+    });
+  });
+
+  describe('stop()', () => {
+    it('should stop monitoring', () => {
+      monitor.start();
+      monitor.stop();
+      expect(monitor.isRunning).toBe(false);
+    });
+
+    it('should be safe to call when not running', () => {
+      expect(() => monitor.stop()).not.toThrow();
+    });
+  });
+
+  describe('getSummary()', () => {
+    it('should return null when no episodes recorded', () => {
+      monitor.start();
+      expect(monitor.getSummary()).toBeNull();
+    });
+
+    it('should return summary with episodes after congestion', () => {
+      const onCongestion = jest.fn();
+      monitor.start(onCongestion);
+
+      jest.advanceTimersByTime(2000);
+      jest.setSystemTime(baseTime + 7000);
+      jest.advanceTimersByTime(2000);
+
+      const summary = monitor.getSummary();
+      expect(summary).not.toBeNull();
+      expect(summary!.totalEpisodes).toBeGreaterThan(0);
+      expect(summary!.maxLagMs).toBeGreaterThan(999);
+      expect(summary!.episodes.length).toBeGreaterThan(0);
+      expect(summary!.episodes[0].source).toBe('heartbeat');
+    });
+
+    it('should not record episodes under normal load', () => {
+      monitor.start();
+      for (let i = 0; i < 5; i++) {
+        jest.advanceTimersByTime(2000);
+      }
+      expect(monitor.getSummary()).toBeNull();
+    });
+  });
+
+  describe('PerformanceObserver integration', () => {
+    it('should create a PerformanceObserver for longtask', () => {
+      monitor.start();
+      expect((global as any).PerformanceObserver).toHaveBeenCalled();
+    });
+
+    it('should handle PerformanceObserver unsupported gracefully', () => {
+      const original = (global as any).PerformanceObserver;
+      delete (global as any).PerformanceObserver;
+      expect(() => monitor.start()).not.toThrow();
+      (global as any).PerformanceObserver = original;
+    });
+  });
+
+  describe('episode cap', () => {
+    it('should cap episodes at MAX_EPISODES (50)', () => {
+      const onCongestion = jest.fn();
+      monitor.start(onCongestion);
+
+      for (let i = 0; i < 60; i++) {
+        jest.setSystemTime(baseTime + 2000 * (i + 1) + 5000);
+        jest.advanceTimersByTime(2000);
+      }
+
+      const summary = monitor.getSummary();
+      expect(summary).not.toBeNull();
+      expect(summary!.episodes.length).toBeLessThanOrEqual(50);
+    });
+  });
+});

--- a/packages/js/src/Modules/Verto/tests/webrtc/Call.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/Call.test.ts
@@ -271,7 +271,8 @@ describe('Call', () => {
         expect.objectContaining({ callId: call.id }),
         'call-report-id',
         'wss://rtc.telnyx.com',
-        'owning-session-voice-sdk-id'
+        'owning-session-voice-sdk-id',
+        undefined // eventLoopCongestion — null when no congestion detected
       );
       const submittedSummary = collector.postReport.mock.calls[0][0];
       expect(submittedSummary.clientSummary).toEqual(
@@ -785,8 +786,10 @@ describe('Call', () => {
 
       // The debug log for "answering inbound call while N other active call(s) exist"
       // should NOT fire when the only active call is the one being answered.
-      const multiCallLog = debugSpy.mock.calls.find(
-        (args: string[]) => /answer\(\): answering inbound call while \d+ other active call/.test(args[0])
+      const multiCallLog = debugSpy.mock.calls.find((args: string[]) =>
+        /answer\(\): answering inbound call while \d+ other active call/.test(
+          args[0]
+        )
       );
       expect(multiCallLog).toBeUndefined();
 
@@ -809,8 +812,10 @@ describe('Call', () => {
       await answerCall.answer();
 
       // The debug log should fire because at least one other active call exists.
-      const multiCallLog = debugSpy.mock.calls.find(
-        (args: string[]) => /answer\(\): answering inbound call while \d+ other active call/.test(args[0])
+      const multiCallLog = debugSpy.mock.calls.find((args: string[]) =>
+        /answer\(\): answering inbound call while \d+ other active call/.test(
+          args[0]
+        )
       );
       expect(multiCallLog).toBeDefined();
       // The log should NOT count the call being answered itself

--- a/packages/js/src/Modules/Verto/util/constants/errorCodes.ts
+++ b/packages/js/src/Modules/Verto/util/constants/errorCodes.ts
@@ -84,6 +84,9 @@ export const TELNYX_WARNING_CODES = {
   SIGNALING_RECOVERY_REQUIRED: 36003,
   MEDIA_RECOVERY_REQUIRED: 36004,
   RECONNECTION_FAILED_WITH_NO_AUTO_RECONNECT: 36005,
+
+  // ── Performance warnings (370xx) ───────────────────────────────────
+  EVENT_LOOP_CONGESTION: 37001,
 } as const;
 
 // Extract constants to simplify how we use them internally
@@ -138,6 +141,7 @@ export const {
   SIGNALING_RECOVERY_REQUIRED,
   MEDIA_RECOVERY_REQUIRED,
   RECONNECTION_FAILED_WITH_NO_AUTO_RECONNECT,
+  EVENT_LOOP_CONGESTION,
 } = TELNYX_WARNING_CODES;
 /**
  * Regex to detect non-host ICE candidates (srflx, prflx, or relay) in SDP.

--- a/packages/js/src/Modules/Verto/util/constants/warnings.ts
+++ b/packages/js/src/Modules/Verto/util/constants/warnings.ts
@@ -368,6 +368,26 @@ export const SDK_WARNINGS = {
       'Review maxReconnectAttempts configuration',
     ],
   },
+
+  // ── Performance warnings (370xx) ───────────────────────────────────
+  37001: {
+    name: 'EVENT_LOOP_CONGESTION',
+    message: 'Event loop congestion detected',
+    description:
+      'The JavaScript main thread was blocked for an extended period, delaying time-sensitive operations including WebSocket message processing, login authentication, and call setup. This can cause delayed login, missed keepalive pings, and slow call establishment even when the network is healthy.',
+    causes: [
+      'Heavy synchronous JavaScript execution blocking the main thread',
+      'Garbage collection pauses in the browser',
+      'Complex DOM rendering or layout thrashing during session transitions',
+      'Large JSON parsing or serialization blocking the event loop',
+    ],
+    solutions: [
+      'Move heavy computations to a Web Worker to keep the main thread free',
+      'Break up long synchronous operations into async chunks using setTimeout or requestAnimationFrame',
+      'Profile the application with Chrome DevTools Performance tab to identify blocking tasks',
+      'Reduce DOM complexity during call transitions',
+    ],
+  },
   33009: {
     name: 'AUDIO_INPUT_DEVICE_CHANGE_SKIPPED',
     message: 'Audio input device change skipped',

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -2798,12 +2798,19 @@ export default abstract class BaseCall implements IWebRTCCall {
 
     const callReportVoiceSdkId = this._getCallReportVoiceSdkId();
 
+    // Get event-loop congestion data from the session-level monitor.
+    // Included in the call report so server-side analysis can correlate
+    // call quality issues with main-thread blocking.
+    const eventLoopCongestion =
+      this.session.getEventLoopCongestionSummary?.() ?? null;
+
     try {
       await this._callReportCollector.postReport(
         summary,
         callReportId,
         host,
-        callReportVoiceSdkId
+        callReportVoiceSdkId,
+        eventLoopCongestion ?? undefined
       );
     } catch (error) {
       logger.error('Failed to post call report', { error });

--- a/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
+++ b/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
@@ -524,6 +524,23 @@ export interface ICallReportPayload {
   segment?: number;
   /** Why this intermediate segment was flushed. */
   flushReason?: ICallReportFlushReason;
+  /**
+   * Event-loop congestion episodes detected during the session.
+   * Present only when congestion was detected (at least one episode).
+   * Each episode records the detection source ('heartbeat' or 'longtask'),
+   * the lag or task duration, and an ISO timestamp.
+   */
+  eventLoopCongestion?: {
+    totalEpisodes: number;
+    maxLagMs: number;
+    episodes: Array<{
+      timestamp: string;
+      lagMs?: number;
+      intervalMs?: number;
+      taskDurationMs?: number;
+      source: 'heartbeat' | 'longtask';
+    }>;
+  };
 }
 
 export class CallReportCollector {
@@ -806,7 +823,8 @@ export class CallReportCollector {
     summary: ICallSummary,
     callReportId: string,
     host: string,
-    voiceSdkId?: string
+    voiceSdkId?: string,
+    eventLoopCongestion?: ICallReportPayload['eventLoopCongestion']
   ): Promise<void> {
     // Get remaining logs (getLogs for final, drain was used for intermediates)
     const logs = this.logCollector?.getLogs();
@@ -843,6 +861,7 @@ export class CallReportCollector {
       stats: this.statsBuffer,
       ...(logs && logs.length > 0 ? { logs } : {}),
       ...(isMultiSegment ? { segment } : {}),
+      ...(eventLoopCongestion ? { eventLoopCongestion } : {}),
     };
 
     await this._sendPayload(payload, callReportId, host, voiceSdkId, true);
@@ -1341,7 +1360,7 @@ export class CallReportCollector {
       // short calls (shorter than the collection interval) still produce
       // at least one stats entry in the buffer.
       const intervalDuration = now.getTime() - this.intervalStartTime.getTime();
-    const currentInterval = this._collectionIntervalFor();
+      const currentInterval = this._collectionIntervalFor();
       if (isFinal || intervalDuration >= currentInterval) {
         // Create stats entry for this interval
         const statsEntry = this._createStatsEntry(
@@ -1797,7 +1816,9 @@ export class CallReportCollector {
           ? { totalSamplesDecoded: inboundAudio.totalSamplesDecoded }
           : {}),
         ...(inboundAudio.samplesDecodedWithSilence !== undefined
-          ? { samplesDecodedWithSilence: inboundAudio.samplesDecodedWithSilence }
+          ? {
+              samplesDecodedWithSilence: inboundAudio.samplesDecodedWithSilence,
+            }
           : {}),
         ...(inboundAudio.samplesDecodedWithConcealment !== undefined
           ? {


### PR DESCRIPTION
## Summary

A production incident (ch1, 2026-06-29) showed a **9-second delay** between WebSocket `onopen` and login send caused by the main thread being blocked during a session transition. The SDK had **zero visibility** into this — `SignalingHealthMonitor` catches silent sockets, but not a blocked main thread that still processes events eventually.

This PR adds an `EventLoopMonitor` that detects main-thread blocking via two complementary mechanisms and surfaces it through real-time warnings + call report data.

## Detection Mechanisms

### 1. Heartbeat (setInterval, 2s) — Universally Available
Measures how late the callback fires; lag ≥ 1s records a congestion episode. Catches all blocking including sync JS, GC pauses, and layout thrashing.

### 2. PerformanceObserver('longtask') — Chrome/Edge
Fires when a task exceeds 50ms; we filter to ≥ 500ms to avoid noise. Provides exact task duration that the heartbeat can only infer. Gracefully degrades when unsupported (Safari/Firefox).

## Integration Points

| Layer | What |
|------|------|
| **Session-level** | Monitor starts on WebSocket open (`_onSocketOpen`), stops on disconnect/`_closeConnection` |
| **Real-time warning** | `EVENT_LOOP_CONGESTION` (37001) emitted via `telnyx.warning` event on each episode |
| **Call report** | `eventLoopCongestion` field with episodes array + maxLagMs included in the final call report payload |

## Call Report Schema

```json
{
  "eventLoopCongestion": {
    "totalEpisodes": 3,
    "maxLagMs": 5234,
    "episodes": [
      {
        "timestamp": "2026-06-29T23:53:12.000Z",
        "lagMs": 5234,
        "intervalMs": 2000,
        "source": "heartbeat"
      },
      {
        "timestamp": "2026-06-29T23:54:01.000Z",
        "taskDurationMs": 1200,
        "source": "longtask"
      }
    ]
  }
}
```

## Research: Neither Jitsi nor Twilio Do This

| SDK | Event Loop Monitoring |
|-----|----------------------|
| **Jitsi** (lib-jitsi-meet) | None — no event loop health code |
| **Twilio** (twilio-voice.js) | None — has `StatsMonitor` (RTC stats) and `PreflightTest` but no main-thread blocking detection |
| **Telnyx** (this PR) | `EventLoopMonitor` with heartbeat + PerformanceObserver |

No browser-compatible open source library exists:
- `event-loop-lag` (42K/week) — Node.js only (uses `process` API)
- `monitor-event-loop-delay` (415K/week) — Node.js `perf_hooks` polyfill
- `evloop-monitor` (74/week) — Node.js only

All candidates use `process` or `perf_hooks` APIs unavailable in browsers. The browser-native APIs are `PerformanceObserver('longtask')` (Chrome/Edge) and `setInterval` heartbeat (universal), which this PR uses.

## Files Changed

| File | Change |
|------|--------|
| `services/EventLoopMonitor.ts` | **New** — 282 lines. Heartbeat + PerformanceObserver detection, episode storage (capped at 50), summary builder |
| `tests/event-loop/EventLoopMonitor.test.ts` | **New** — 11 tests covering heartbeat detection, PerformanceObserver fallback, episode cap, lifecycle |
| `BaseSession.ts` | Monitor field, start in `_onSocketOpen`, stop in `disconnect`/`_closeConnection`, warning emission, `getEventLoopCongestionSummary()` |
| `webrtc/BaseCall.ts` | Pass congestion summary to `postReport()` |
| `webrtc/CallReportCollector.ts` | `eventLoopCongestion` in `ICallReportPayload` + `postReport()` parameter |
| `util/constants/errorCodes.ts` | `EVENT_LOOP_CONGESTION` (37001) in new 370xx Performance category |
| `util/constants/warnings.ts` | Warning definition with causes and solutions |

## Test Results

```
Test Suites: 24 passed, 24 total
Tests:       549 passed, 549 total
```

## Related

- PR #713 — fix(sdk): send login synchronously on WebSocket open (the one-line fix for the immediate 9s delay)
- Production incident: ch1, 2026-06-29, peer_ip:186.192.96.25, 9s gap between WS connect and login
