### PR TITLE
fix(js): re-stamp reconnect session-id on visibilitychange → hidden

### DIFF
--- a/packages/js/src/Modules/Verto/index.ts
+++ b/packages/js/src/Modules/Verto/index.ts
@@ -18,6 +18,7 @@ import {
   clearReconnectToken,
   clearActiveCallsRecoveryMarker,
   setActiveCallsRecoveryMarker,
+  setReconnectSessionId,
 } from './util/reconnect';
 import { INVALID_CALL_PARAMETERS } from './util/constants/errorCodes';
 
@@ -111,6 +112,38 @@ export default class Verto extends BrowserSession {
           )}]): ${err instanceof Error ? err.message : String(err)}`
         );
       }
+    });
+
+    // Re-stamp the reconnect session-id freshness at the last moment the page
+    // is reliably observable: the visibilitychange transition to `hidden`.
+    //
+    // The sessid the SDK sends on the next login is only accepted for reattach
+    // while the persisted session-id is fresh (< RECONNECT_SESSION_ID_MAX_AGE_MS,
+    // 90s), and that timestamp is otherwise only written at login/socket-close.
+    // A leg connected longer than 90s (e.g. a conference host waiting for
+    // participants) would therefore reload with a stale sessid and fail to
+    // reattach. Per MDN guidance, `visibilitychange` → `hidden` is the last
+    // event that fires reliably before a tab is backgrounded, discarded, or
+    // closed — including on mobile, where `beforeunload`/`pagehide` are not
+    // dependable — so it is the correct place to persist this state. The write
+    // is synchronous (sessionStorage), so it completes even as the page goes
+    // away, unlike async work such as a call-report POST.
+    //
+    // Only relevant when calls are meant to survive unload
+    // (hangupOnBeforeUnload === false) and there is an active call to reattach.
+    document.addEventListener('visibilitychange', () => {
+      if (document.visibilityState !== 'hidden') return;
+      if (
+        options.hangupOnBeforeUnload !== false ||
+        !this.sessionid ||
+        !this.hasActiveCall()
+      ) {
+        return;
+      }
+      logger.debug(
+        'visibilitychange → hidden: re-stamping reconnect session-id freshness.'
+      );
+      setReconnectSessionId(this.sessionid);
     });
   }
 

--- a/packages/js/src/Modules/Verto/tests/Verto.test.ts
+++ b/packages/js/src/Modules/Verto/tests/Verto.test.ts
@@ -177,7 +177,7 @@ describe('Verto', () => {
       telnyxRTC.sessionid = 'session-abc';
       const hangup = jest.fn();
       telnyxRTC.calls = {
-        'call-1': ({
+        'call-1': {
           id: 'call-1',
           hangup,
           state: 'active',
@@ -187,8 +187,8 @@ describe('Verto', () => {
           options: {
             customHeaders: [{ name: 'X-Test', value: '1' }],
           },
-        } as unknown) as IWebRTCCall,
-        'call-2': ({
+        } as unknown as IWebRTCCall,
+        'call-2': {
           id: 'call-2',
           hangup,
           state: 'active',
@@ -196,7 +196,7 @@ describe('Verto', () => {
           session: {}, // not persisted — narrow projection drops it
           peer: {}, // not persisted — narrow projection drops it
           options: {},
-        } as unknown) as IWebRTCCall,
+        } as unknown as IWebRTCCall,
       };
 
       const beforeUnloadHandler = addEventListenerSpy.mock.calls.find(
@@ -253,7 +253,9 @@ describe('Verto', () => {
 
       // Pre-seed a stale marker from a previous page.
       setActiveCallsRecoveryMarker(
-        [{ id: 'stale-call', state: 'active', options: {} }] as unknown as IStoredActiveCall[],
+        [
+          { id: 'stale-call', state: 'active', options: {} },
+        ] as unknown as IStoredActiveCall[],
         'old-session'
       );
       const seeded = getActiveCallsRecoveryMarker();
@@ -262,7 +264,9 @@ describe('Verto', () => {
 
       // Re-seed since getActiveCallsRecoveryMarker clears on read.
       setActiveCallsRecoveryMarker(
-        [{ id: 'stale-call', state: 'active', options: {} }] as unknown as IStoredActiveCall[],
+        [
+          { id: 'stale-call', state: 'active', options: {} },
+        ] as unknown as IStoredActiveCall[],
         'old-session'
       );
 
@@ -301,12 +305,12 @@ describe('Verto', () => {
       });
       telnyxRTC.sessionid = 'session-default';
       telnyxRTC.calls = {
-        'call-x': ({
+        'call-x': {
           id: 'call-x',
           hangup: jest.fn(),
           state: 'active',
           options: {},
-        } as unknown) as IWebRTCCall,
+        } as unknown as IWebRTCCall,
       };
 
       const beforeUnloadHandler = addEventListenerSpy.mock.calls.find(
@@ -320,6 +324,109 @@ describe('Verto', () => {
       addEventListenerSpy.mockRestore();
       clearReconnectToken();
       clearActiveCallsRecoveryMarker();
+    });
+  });
+
+  describe('visibilitychange session-id re-stamp', () => {
+    const STORED_AT_KEY = 'telnyx-voice-sdk-session-id-stored-at';
+
+    const setVisibility = (state: 'visible' | 'hidden') => {
+      Object.defineProperty(document, 'visibilityState', {
+        value: state,
+        configurable: true,
+      });
+    };
+
+    // Build an instance and return its registered visibilitychange handler.
+    const buildWithVisHandler = (
+      props: Partial<IVertoOptions>
+    ): { instance: Verto; handler: EventListener; restore: () => void } => {
+      const spy = jest.spyOn(document, 'addEventListener');
+      spy.mockClear();
+      const instance = _buildInstance({
+        host: 'example.telnyx.com',
+        login: 'login',
+        password: 'password',
+        ...props,
+      } as IVertoOptions);
+      const handler = spy.mock.calls.find(
+        ([eventName]) => eventName === 'visibilitychange'
+      )?.[1] as EventListener;
+      return { instance, handler, restore: () => spy.mockRestore() };
+    };
+
+    afterEach(() => {
+      // Restore jsdom's default visibility and clear storage between tests.
+      delete (document as unknown as { visibilityState?: string })
+        .visibilityState;
+      clearReconnectToken();
+    });
+
+    it('re-stamps freshness when the page is hidden with an active call (hangupOnBeforeUnload=false)', () => {
+      const { instance, handler, restore } = buildWithVisHandler({
+        hangupOnBeforeUnload: false,
+      });
+      expect(handler).toBeDefined();
+
+      instance.sessionid = 'session-abc';
+      instance.hasActiveCall = jest.fn(() => true);
+      const oldStoredAt = Date.now() - 80 * 1000;
+      setReconnectSessionId('session-abc', oldStoredAt);
+
+      setVisibility('hidden');
+      handler(new Event('visibilitychange'));
+
+      expect(Number(sessionStorage.getItem(STORED_AT_KEY))).toBeGreaterThan(
+        oldStoredAt
+      );
+      expect(getReconnectSessionId()).toBe('session-abc');
+      restore();
+    });
+
+    it('does not re-stamp while the page is still visible', () => {
+      const { instance, handler, restore } = buildWithVisHandler({
+        hangupOnBeforeUnload: false,
+      });
+      instance.sessionid = 'session-abc';
+      instance.hasActiveCall = jest.fn(() => true);
+      const oldStoredAt = Date.now() - 80 * 1000;
+      setReconnectSessionId('session-abc', oldStoredAt);
+
+      setVisibility('visible');
+      handler(new Event('visibilitychange'));
+
+      expect(Number(sessionStorage.getItem(STORED_AT_KEY))).toBe(oldStoredAt);
+      restore();
+    });
+
+    it('does not re-stamp when there is no active call', () => {
+      const { instance, handler, restore } = buildWithVisHandler({
+        hangupOnBeforeUnload: false,
+      });
+      instance.sessionid = 'session-abc';
+      instance.hasActiveCall = jest.fn(() => false);
+      const oldStoredAt = Date.now() - 80 * 1000;
+      setReconnectSessionId('session-abc', oldStoredAt);
+
+      setVisibility('hidden');
+      handler(new Event('visibilitychange'));
+
+      expect(Number(sessionStorage.getItem(STORED_AT_KEY))).toBe(oldStoredAt);
+      restore();
+    });
+
+    it('does not re-stamp when hangupOnBeforeUnload is not false', () => {
+      const { instance, handler, restore } = buildWithVisHandler({});
+      instance.sessionid = 'session-abc';
+      instance.hasActiveCall = jest.fn(() => true);
+      const oldStoredAt = Date.now() - 80 * 1000;
+      setReconnectSessionId('session-abc', oldStoredAt);
+
+      setVisibility('hidden');
+      handler(new Event('visibilitychange'));
+
+      expect(Number(sessionStorage.getItem(STORED_AT_KEY))).toBe(oldStoredAt);
+      restore();
     });
   });
 


### PR DESCRIPTION
## Problem

The reconnect `sessid` the SDK sends on login is what lets the server reattach a call that survived a page reload. It's only sent while the persisted session-id is **fresh**:

- `RECONNECT_SESSION_ID_MAX_AGE_MS = 90 * 1000` (`util/reconnect.ts`)
- `getReconnectSessionId()` deletes the keys and returns `null` once `now - storedAt > 90s`
- login uses it at `BaseSession._login` (`reconnectSessionId` → `Login.sessid`)

But `storedAt` is written **only** at login and on socket-close — **never while the connection is healthy and open**. So any leg connected/idle longer than 90s logs in with an **empty `sessid`** after a reload; the server returns an empty `reattached_sessions` and the SDK emits `SESSION_NOT_REATTACHED`.

This hits the **longest-lived leg first** — e.g. a **conference host** that creates the conference and then waits past 90s for participants can never be reattached, while a just-joined leg (still inside its 90s window) reattaches fine.

## Fix — re-stamp on `visibilitychange` → `hidden`

Re-stamp the freshness timestamp when the page transitions to `hidden`. Per [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilitychange_event), *"Transitioning to `hidden` is the last event that's reliably observable by the page"* — it fires on tab switch, minimize, navigation, close, and (critically) when a mobile browser is backgrounded and the tab is later discarded, where `beforeunload`/`pagehide` are **not** dependable.

- The write is **synchronous** (`sessionStorage`), so it completes even as the page goes away — unlike async work such as a call-report POST.
- Gated on `hangupOnBeforeUnload === false` (calls are meant to survive unload) and `hasActiveCall()` (something to reattach).
- Registered alongside the existing `beforeunload` handler in the `Verto` constructor; the pre-existing beforeunload hangup/recovery-marker logic is untouched.

## Tests

`describe('visibilitychange session-id re-stamp')` in `Verto.test.ts`:
- re-stamps when hidden with an active call (`hangupOnBeforeUnload=false`)
- does **not** re-stamp while still visible
- does **not** re-stamp when there's no active call
- does **not** re-stamp when `hangupOnBeforeUnload` is not `false`

Full `Verto` suite green (**537 tests**), `tsc --noEmit` clean.

## Notes

- Scoped intentionally to the session-id freshness re-stamp. The **active-calls recovery marker** is still written on `beforeunload` only; moving that to `visibilitychange` for the same mobile-reliability reasons is a reasonable follow-up but out of scope here.
- This decouples the freshness window from "recently disconnected": for an open, foregrounded call the timestamp is refreshed each time the page is hidden. Happy to re-justify the 90s bound if the team prefers a different semantic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
