### PR TITLE
feat(js): flush call report on beforeunload (keepalive)

### DIFF
--- a/packages/js/src/Modules/Verto/index.ts
+++ b/packages/js/src/Modules/Verto/index.ts
@@ -114,36 +114,48 @@ export default class Verto extends BrowserSession {
       }
     });
 
-    // Re-stamp the reconnect session-id freshness at the last moment the page
-    // is reliably observable: the visibilitychange transition to `hidden`.
-    //
-    // The sessid the SDK sends on the next login is only accepted for reattach
-    // while the persisted session-id is fresh (< RECONNECT_SESSION_ID_MAX_AGE_MS,
-    // 90s), and that timestamp is otherwise only written at login/socket-close.
-    // A leg connected longer than 90s (e.g. a conference host waiting for
-    // participants) would therefore reload with a stale sessid and fail to
-    // reattach. Per MDN guidance, `visibilitychange` → `hidden` is the last
-    // event that fires reliably before a tab is backgrounded, discarded, or
-    // closed — including on mobile, where `beforeunload`/`pagehide` are not
-    // dependable — so it is the correct place to persist this state. The write
-    // is synchronous (sessionStorage), so it completes even as the page goes
-    // away, unlike async work such as a call-report POST.
-    //
-    // Only relevant when calls are meant to survive unload
-    // (hangupOnBeforeUnload === false) and there is an active call to reattach.
+    // Single `visibilitychange` → `hidden` handler for two recovery paths,
+    // both gated on hangupOnBeforeUnload === false (calls meant to survive
+    // unload) and an active call:
+    //   1. Re-stamp the reconnect session-id freshness. The sessid sent on the
+    //      next login is only accepted for reattach while the persisted
+    //      session-id is fresh (< RECONNECT_SESSION_ID_MAX_AGE_MS, 90s), and
+    //      that timestamp is otherwise only written at login/socket-close — so
+    //      a leg connected longer than 90s (e.g. a conference host waiting for
+    //      participants) would reload with a stale sessid. Synchronous
+    //      sessionStorage write.
+    //   2. Flush an intermediate call report with keepalive. A call kept alive
+    //      across unload never hangs up, so no final report is posted for a
+    //      call the user reloads/closes on — its report would otherwise be
+    //      lost. keepalive lets the POST outlive the page tear-down (a plain
+    //      async POST would be cut off).
+    // `visibilitychange` → `hidden` is the last event reliably observable on
+    // desktop and mobile (per MDN), where `beforeunload`/`pagehide` are not
+    // dependable. Complements the persist + retry-on-reconnect path that
+    // covers socket-1001 network losses.
     document.addEventListener('visibilitychange', () => {
       if (document.visibilityState !== 'hidden') return;
-      if (
-        options.hangupOnBeforeUnload !== false ||
-        !this.sessionid ||
-        !this.hasActiveCall()
-      ) {
+      if (options.hangupOnBeforeUnload !== false || !this.hasActiveCall()) {
         return;
       }
-      logger.debug(
-        'visibilitychange → hidden: re-stamping reconnect session-id freshness.'
-      );
-      setReconnectSessionId(this.sessionid);
+      // 1. Reconnect session-id freshness (needs a sessionid).
+      if (this.sessionid) {
+        logger.debug(
+          'visibilitychange → hidden: re-stamping reconnect session-id freshness.'
+        );
+        setReconnectSessionId(this.sessionid);
+      }
+      // 2. Flush call reports. Redundant flushes are cheap —
+      // CallReportCollector.flush() returns null when nothing new has buffered.
+      Object.keys(this.calls || {}).forEach((callId) => {
+        const call = this.calls[callId];
+        if (call?.flushIntermediateCallReport) {
+          logger.debug(
+            `visibilitychange → hidden: flushing call report for ${callId}.`
+          );
+          call.flushIntermediateCallReport({ type: 'page-hidden' });
+        }
+      });
     });
   }
 

--- a/packages/js/src/Modules/Verto/index.ts
+++ b/packages/js/src/Modules/Verto/index.ts
@@ -59,6 +59,26 @@ export default class Verto extends BrowserSession {
         return;
       }
 
+      // hangupOnBeforeUnload === false: calls are kept alive across unload, so
+      // they never hang up and no final call report is ever posted for a call
+      // the user reloads/closes on — its report would otherwise be lost. Flush
+      // an intermediate call report for each active call and send it with
+      // keepalive (threaded via the `page-unload` flush reason) so the POST is
+      // allowed to outlive the document tear-down; a plain async POST would be
+      // cut off. Done here, before the recovery-marker logic below, so it still
+      // runs even when there is no sessionid to persist. Redundant flushes are
+      // cheap — CallReportCollector.flush() returns null when nothing new has
+      // buffered since the last flush.
+      if (this.calls) {
+        Object.keys(this.calls).forEach((callId) => {
+          const call = this.calls[callId];
+          if (call?.flushIntermediateCallReport) {
+            logger.debug(`beforeunload: flushing call report for ${callId}.`);
+            call.flushIntermediateCallReport({ type: 'page-unload' });
+          }
+        });
+      }
+
       // hangupOnBeforeUnload === false: the SDK does NOT hang up active calls
       // before unload, so the server may still know about them. After a page
       // reload the SDK starts with a fresh in-memory cache and may not detect
@@ -114,48 +134,36 @@ export default class Verto extends BrowserSession {
       }
     });
 
-    // Single `visibilitychange` → `hidden` handler for two recovery paths,
-    // both gated on hangupOnBeforeUnload === false (calls meant to survive
-    // unload) and an active call:
-    //   1. Re-stamp the reconnect session-id freshness. The sessid sent on the
-    //      next login is only accepted for reattach while the persisted
-    //      session-id is fresh (< RECONNECT_SESSION_ID_MAX_AGE_MS, 90s), and
-    //      that timestamp is otherwise only written at login/socket-close — so
-    //      a leg connected longer than 90s (e.g. a conference host waiting for
-    //      participants) would reload with a stale sessid. Synchronous
-    //      sessionStorage write.
-    //   2. Flush an intermediate call report with keepalive. A call kept alive
-    //      across unload never hangs up, so no final report is posted for a
-    //      call the user reloads/closes on — its report would otherwise be
-    //      lost. keepalive lets the POST outlive the page tear-down (a plain
-    //      async POST would be cut off).
-    // `visibilitychange` → `hidden` is the last event reliably observable on
-    // desktop and mobile (per MDN), where `beforeunload`/`pagehide` are not
-    // dependable. Complements the persist + retry-on-reconnect path that
-    // covers socket-1001 network losses.
+    // Re-stamp the reconnect session-id freshness at the last moment the page
+    // is reliably observable: the visibilitychange transition to `hidden`.
+    //
+    // The sessid the SDK sends on the next login is only accepted for reattach
+    // while the persisted session-id is fresh (< RECONNECT_SESSION_ID_MAX_AGE_MS,
+    // 90s), and that timestamp is otherwise only written at login/socket-close.
+    // A leg connected longer than 90s (e.g. a conference host waiting for
+    // participants) would therefore reload with a stale sessid and fail to
+    // reattach. Per MDN guidance, `visibilitychange` → `hidden` is the last
+    // event that fires reliably before a tab is backgrounded, discarded, or
+    // closed — including on mobile, where `beforeunload`/`pagehide` are not
+    // dependable — so it is the correct place to persist this state. The write
+    // is synchronous (sessionStorage), so it completes even as the page goes
+    // away, unlike async work such as a call-report POST.
+    //
+    // Only relevant when calls are meant to survive unload
+    // (hangupOnBeforeUnload === false) and there is an active call to reattach.
     document.addEventListener('visibilitychange', () => {
       if (document.visibilityState !== 'hidden') return;
-      if (options.hangupOnBeforeUnload !== false || !this.hasActiveCall()) {
+      if (
+        options.hangupOnBeforeUnload !== false ||
+        !this.sessionid ||
+        !this.hasActiveCall()
+      ) {
         return;
       }
-      // 1. Reconnect session-id freshness (needs a sessionid).
-      if (this.sessionid) {
-        logger.debug(
-          'visibilitychange → hidden: re-stamping reconnect session-id freshness.'
-        );
-        setReconnectSessionId(this.sessionid);
-      }
-      // 2. Flush call reports. Redundant flushes are cheap —
-      // CallReportCollector.flush() returns null when nothing new has buffered.
-      Object.keys(this.calls || {}).forEach((callId) => {
-        const call = this.calls[callId];
-        if (call?.flushIntermediateCallReport) {
-          logger.debug(
-            `visibilitychange → hidden: flushing call report for ${callId}.`
-          );
-          call.flushIntermediateCallReport({ type: 'page-hidden' });
-        }
-      });
+      logger.debug(
+        'visibilitychange → hidden: re-stamping reconnect session-id freshness.'
+      );
+      setReconnectSessionId(this.sessionid);
     });
   }
 

--- a/packages/js/src/Modules/Verto/tests/Verto.test.ts
+++ b/packages/js/src/Modules/Verto/tests/Verto.test.ts
@@ -430,6 +430,116 @@ describe('Verto', () => {
     });
   });
 
+  describe('visibilitychange call-report flush', () => {
+    const setVisibility = (state: 'visible' | 'hidden') => {
+      Object.defineProperty(document, 'visibilityState', {
+        value: state,
+        configurable: true,
+      });
+    };
+
+    const buildWithVisHandler = (props: Partial<IVertoOptions>) => {
+      const spy = jest.spyOn(document, 'addEventListener');
+      spy.mockClear();
+      const instance = _buildInstance({
+        host: 'example.telnyx.com',
+        login: 'login',
+        password: 'password',
+        ...props,
+      } as IVertoOptions);
+      const handler = spy.mock.calls.find(
+        ([eventName]) => eventName === 'visibilitychange'
+      )?.[1] as EventListener;
+      return { instance, handler, restore: () => spy.mockRestore() };
+    };
+
+    afterEach(() => {
+      delete (document as unknown as { visibilityState?: string })
+        .visibilityState;
+    });
+
+    it('flushes a page-hidden report for active calls when hidden (hangupOnBeforeUnload=false)', () => {
+      const { instance, handler, restore } = buildWithVisHandler({
+        hangupOnBeforeUnload: false,
+      });
+      expect(handler).toBeDefined();
+
+      const flush = jest.fn();
+      instance.hasActiveCall = jest.fn(() => true);
+      instance.calls = {
+        'call-1': {
+          id: 'call-1',
+          flushIntermediateCallReport: flush,
+        } as unknown as IWebRTCCall,
+      };
+
+      setVisibility('hidden');
+      handler(new Event('visibilitychange'));
+
+      expect(flush).toHaveBeenCalledTimes(1);
+      expect(flush).toHaveBeenCalledWith({ type: 'page-hidden' });
+      restore();
+    });
+
+    it('does not flush while the page is still visible', () => {
+      const { instance, handler, restore } = buildWithVisHandler({
+        hangupOnBeforeUnload: false,
+      });
+      const flush = jest.fn();
+      instance.hasActiveCall = jest.fn(() => true);
+      instance.calls = {
+        'call-1': {
+          id: 'call-1',
+          flushIntermediateCallReport: flush,
+        } as unknown as IWebRTCCall,
+      };
+
+      setVisibility('visible');
+      handler(new Event('visibilitychange'));
+
+      expect(flush).not.toHaveBeenCalled();
+      restore();
+    });
+
+    it('does not flush when hangupOnBeforeUnload is not false (call is hung up on unload instead)', () => {
+      const { instance, handler, restore } = buildWithVisHandler({});
+      const flush = jest.fn();
+      instance.hasActiveCall = jest.fn(() => true);
+      instance.calls = {
+        'call-1': {
+          id: 'call-1',
+          flushIntermediateCallReport: flush,
+        } as unknown as IWebRTCCall,
+      };
+
+      setVisibility('hidden');
+      handler(new Event('visibilitychange'));
+
+      expect(flush).not.toHaveBeenCalled();
+      restore();
+    });
+
+    it('does not flush when there is no active call', () => {
+      const { instance, handler, restore } = buildWithVisHandler({
+        hangupOnBeforeUnload: false,
+      });
+      const flush = jest.fn();
+      instance.hasActiveCall = jest.fn(() => false);
+      instance.calls = {
+        'call-1': {
+          id: 'call-1',
+          flushIntermediateCallReport: flush,
+        } as unknown as IWebRTCCall,
+      };
+
+      setVisibility('hidden');
+      handler(new Event('visibilitychange'));
+
+      expect(flush).not.toHaveBeenCalled();
+      restore();
+    });
+  });
+
   describe('reconnect login', () => {
     it('should include the persisted sessid whenever a stored voice_sdk_id marks the login as a reconnect', async () => {
       setReconnectToken('voice-sdk-id');

--- a/packages/js/src/Modules/Verto/tests/Verto.test.ts
+++ b/packages/js/src/Modules/Verto/tests/Verto.test.ts
@@ -430,16 +430,9 @@ describe('Verto', () => {
     });
   });
 
-  describe('visibilitychange call-report flush', () => {
-    const setVisibility = (state: 'visible' | 'hidden') => {
-      Object.defineProperty(document, 'visibilityState', {
-        value: state,
-        configurable: true,
-      });
-    };
-
-    const buildWithVisHandler = (props: Partial<IVertoOptions>) => {
-      const spy = jest.spyOn(document, 'addEventListener');
+  describe('beforeunload call-report flush', () => {
+    const buildWithUnloadHandler = (props: Partial<IVertoOptions>) => {
+      const spy = jest.spyOn(window, 'addEventListener');
       spy.mockClear();
       const instance = _buildInstance({
         host: 'example.telnyx.com',
@@ -448,24 +441,18 @@ describe('Verto', () => {
         ...props,
       } as IVertoOptions);
       const handler = spy.mock.calls.find(
-        ([eventName]) => eventName === 'visibilitychange'
+        ([eventName]) => eventName === 'beforeunload'
       )?.[1] as EventListener;
       return { instance, handler, restore: () => spy.mockRestore() };
     };
 
-    afterEach(() => {
-      delete (document as unknown as { visibilityState?: string })
-        .visibilityState;
-    });
-
-    it('flushes a page-hidden report for active calls when hidden (hangupOnBeforeUnload=false)', () => {
-      const { instance, handler, restore } = buildWithVisHandler({
+    it('flushes a page-unload report for each active call on unload (hangupOnBeforeUnload=false)', () => {
+      const { instance, handler, restore } = buildWithUnloadHandler({
         hangupOnBeforeUnload: false,
       });
       expect(handler).toBeDefined();
 
       const flush = jest.fn();
-      instance.hasActiveCall = jest.fn(() => true);
       instance.calls = {
         'call-1': {
           id: 'call-1',
@@ -473,69 +460,39 @@ describe('Verto', () => {
         } as unknown as IWebRTCCall,
       };
 
-      setVisibility('hidden');
-      handler(new Event('visibilitychange'));
+      handler(new Event('beforeunload'));
 
       expect(flush).toHaveBeenCalledTimes(1);
-      expect(flush).toHaveBeenCalledWith({ type: 'page-hidden' });
-      restore();
-    });
-
-    it('does not flush while the page is still visible', () => {
-      const { instance, handler, restore } = buildWithVisHandler({
-        hangupOnBeforeUnload: false,
-      });
-      const flush = jest.fn();
-      instance.hasActiveCall = jest.fn(() => true);
-      instance.calls = {
-        'call-1': {
-          id: 'call-1',
-          flushIntermediateCallReport: flush,
-        } as unknown as IWebRTCCall,
-      };
-
-      setVisibility('visible');
-      handler(new Event('visibilitychange'));
-
-      expect(flush).not.toHaveBeenCalled();
+      expect(flush).toHaveBeenCalledWith({ type: 'page-unload' });
       restore();
     });
 
     it('does not flush when hangupOnBeforeUnload is not false (call is hung up on unload instead)', () => {
-      const { instance, handler, restore } = buildWithVisHandler({});
+      const { instance, handler, restore } = buildWithUnloadHandler({});
       const flush = jest.fn();
-      instance.hasActiveCall = jest.fn(() => true);
+      const hangup = jest.fn();
       instance.calls = {
         'call-1': {
           id: 'call-1',
+          hangup,
           flushIntermediateCallReport: flush,
         } as unknown as IWebRTCCall,
       };
 
-      setVisibility('hidden');
-      handler(new Event('visibilitychange'));
+      handler(new Event('beforeunload'));
 
       expect(flush).not.toHaveBeenCalled();
+      expect(hangup).toHaveBeenCalled();
       restore();
     });
 
-    it('does not flush when there is no active call', () => {
-      const { instance, handler, restore } = buildWithVisHandler({
+    it('does not throw when there are no active calls to flush', () => {
+      const { instance, handler, restore } = buildWithUnloadHandler({
         hangupOnBeforeUnload: false,
       });
-      const flush = jest.fn();
-      instance.hasActiveCall = jest.fn(() => false);
-      instance.calls = {
-        'call-1': {
-          id: 'call-1',
-          flushIntermediateCallReport: flush,
-        } as unknown as IWebRTCCall,
-      };
+      instance.calls = {};
 
-      setVisibility('hidden');
-      handler(new Event('visibilitychange'));
-
-      expect(flush).not.toHaveBeenCalled();
+      expect(() => handler(new Event('beforeunload'))).not.toThrow();
       restore();
     });
   });

--- a/packages/js/src/Modules/Verto/tests/webrtc/Call.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/Call.test.ts
@@ -352,7 +352,8 @@ describe('Call', () => {
         payload,
         'call-report-id',
         'wss://rtc.telnyx.com',
-        'owning-session-voice-sdk-id'
+        'owning-session-voice-sdk-id',
+        false // forceKeepalive — normal (non-page-hidden) intermediate flush
       );
       expect(trackSpy).toHaveBeenCalledTimes(1);
       expect(trackSpy.mock.calls[0][0]).toHaveProperty(
@@ -785,8 +786,10 @@ describe('Call', () => {
 
       // The debug log for "answering inbound call while N other active call(s) exist"
       // should NOT fire when the only active call is the one being answered.
-      const multiCallLog = debugSpy.mock.calls.find(
-        (args: string[]) => /answer\(\): answering inbound call while \d+ other active call/.test(args[0])
+      const multiCallLog = debugSpy.mock.calls.find((args: string[]) =>
+        /answer\(\): answering inbound call while \d+ other active call/.test(
+          args[0]
+        )
       );
       expect(multiCallLog).toBeUndefined();
 
@@ -809,8 +812,10 @@ describe('Call', () => {
       await answerCall.answer();
 
       // The debug log should fire because at least one other active call exists.
-      const multiCallLog = debugSpy.mock.calls.find(
-        (args: string[]) => /answer\(\): answering inbound call while \d+ other active call/.test(args[0])
+      const multiCallLog = debugSpy.mock.calls.find((args: string[]) =>
+        /answer\(\): answering inbound call while \d+ other active call/.test(
+          args[0]
+        )
       );
       expect(multiCallLog).toBeDefined();
       // The log should NOT count the call being answered itself

--- a/packages/js/src/Modules/Verto/tests/webrtc/Call.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/Call.test.ts
@@ -353,7 +353,7 @@ describe('Call', () => {
         'call-report-id',
         'wss://rtc.telnyx.com',
         'owning-session-voice-sdk-id',
-        false // forceKeepalive — normal (non-page-hidden) intermediate flush
+        false // forceKeepalive — normal (non-page-unload) intermediate flush
       );
       expect(trackSpy).toHaveBeenCalledTimes(1);
       expect(trackSpy.mock.calls[0][0]).toHaveProperty(

--- a/packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts
@@ -17,7 +17,11 @@ type SendPayload = (
   payload: unknown,
   callReportId: string,
   host: string,
-  voiceSdkId?: string
+  voiceSdkId?: string,
+  // 5th/6th positional args differ between the public `sendPayload`
+  // (forceKeepalive) and private `_sendPayload` (isFinalReport, forceKeepalive).
+  isFinalReportOrForceKeepalive?: boolean,
+  forceKeepalive?: boolean
 ) => Promise<void>;
 
 type TestableCallReportCollector = {
@@ -1101,6 +1105,26 @@ describe('CallReportCollector call report uploads', () => {
 
     expect(fetchMock.mock.calls[0][1]).not.toHaveProperty('keepalive');
   });
+
+  it('uses keepalive for an intermediate report when forceKeepalive is set (page-hidden flush)', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 202,
+      text: () => Promise.resolve(''),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const collector = createCollector();
+    await collector.sendPayload(
+      { ...payload, segment: 0 },
+      'call-report-id',
+      'wss://rtc.telnyx.com',
+      'voice-sdk-id',
+      true // forceKeepalive
+    );
+
+    expect(fetchMock.mock.calls[0][1]).toHaveProperty('keepalive', true);
+  });
 });
 
 describe('CallReportCollector media-playout stats', () => {
@@ -1323,7 +1347,9 @@ describe('CallReportCollector remote RTCP stats', () => {
 
     await collector._collectStats(true);
 
-    const buffer = (collector as unknown as CallReportCollector).getStatsBuffer();
+    const buffer = (
+      collector as unknown as CallReportCollector
+    ).getStatsBuffer();
     expect(buffer).toHaveLength(1);
     return buffer[0];
   };

--- a/packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts
@@ -1106,7 +1106,7 @@ describe('CallReportCollector call report uploads', () => {
     expect(fetchMock.mock.calls[0][1]).not.toHaveProperty('keepalive');
   });
 
-  it('uses keepalive for an intermediate report when forceKeepalive is set (page-hidden flush)', async () => {
+  it('uses keepalive for an intermediate report when forceKeepalive is set (page-unload flush)', async () => {
     const fetchMock = jest.fn().mockResolvedValue({
       ok: true,
       status: 202,

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -2746,10 +2746,20 @@ export default abstract class BaseCall implements IWebRTCCall {
 
     const callReportVoiceSdkId = this._getCallReportVoiceSdkId();
 
+    // A page-hidden flush fires as the document is being torn down, so the
+    // POST must be allowed to outlive the page — send it with keepalive.
+    const forceKeepalive = flushReason.type === 'page-hidden';
+
     // Fire-and-forget — don't block the stats collection interval,
     // but track the upload so disconnect() can drain in-flight reports.
     const upload = this._callReportCollector
-      .sendPayload(payload, callReportId, host, callReportVoiceSdkId)
+      .sendPayload(
+        payload,
+        callReportId,
+        host,
+        callReportVoiceSdkId,
+        forceKeepalive
+      )
       .catch((error) => {
         logger.error('Failed to post intermediate call report segment', {
           error,

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -2746,9 +2746,9 @@ export default abstract class BaseCall implements IWebRTCCall {
 
     const callReportVoiceSdkId = this._getCallReportVoiceSdkId();
 
-    // A page-hidden flush fires as the document is being torn down, so the
+    // A page-unload flush fires as the document is being torn down, so the
     // POST must be allowed to outlive the page — send it with keepalive.
-    const forceKeepalive = flushReason.type === 'page-hidden';
+    const forceKeepalive = flushReason.type === 'page-unload';
 
     // Fire-and-forget — don't block the stats collection interval,
     // but track the upload so disconnect() can drain in-flight reports.

--- a/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
+++ b/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
@@ -506,7 +506,12 @@ export type SanitizedClientOption =
   | { [key: string]: SanitizedClientOption };
 
 export interface ICallReportFlushReason {
-  type: 'buffer-limit' | 'manual' | 'socket-close' | 'socket-error';
+  type:
+    | 'buffer-limit'
+    | 'manual'
+    | 'socket-close'
+    | 'socket-error'
+    | 'page-hidden';
   socketClose?: {
     code?: number;
     codeName?: string;
@@ -856,9 +861,20 @@ export class CallReportCollector {
     payload: ICallReportPayload,
     callReportId: string,
     host: string,
-    voiceSdkId?: string
+    voiceSdkId?: string,
+    // Force `keepalive: true` even though this is not the final report. Used
+    // for page-hidden flushes, where the request must be allowed to outlive
+    // the document being torn down.
+    forceKeepalive: boolean = false
   ): Promise<void> {
-    await this._sendPayload(payload, callReportId, host, voiceSdkId, false);
+    await this._sendPayload(
+      payload,
+      callReportId,
+      host,
+      voiceSdkId,
+      false,
+      forceKeepalive
+    );
   }
 
   /**
@@ -873,7 +889,8 @@ export class CallReportCollector {
     callReportId: string,
     host: string,
     voiceSdkId?: string,
-    isFinalReport: boolean = true
+    isFinalReport: boolean = true,
+    forceKeepalive: boolean = false
   ): Promise<void> {
     const wsUrl = new URL(host);
     const endpoint = `${wsUrl.protocol.replace(/^ws/, 'http')}//${wsUrl.host}/call_report`;
@@ -901,7 +918,7 @@ export class CallReportCollector {
 
     const body = JSON.stringify(payload);
     const useKeepalive =
-      isFinalReport &&
+      (isFinalReport || forceKeepalive) &&
       body.length <= CallReportCollector.KEEPALIVE_BODY_LIMIT_BYTES;
 
     let lastError: unknown;
@@ -1341,7 +1358,7 @@ export class CallReportCollector {
       // short calls (shorter than the collection interval) still produce
       // at least one stats entry in the buffer.
       const intervalDuration = now.getTime() - this.intervalStartTime.getTime();
-    const currentInterval = this._collectionIntervalFor();
+      const currentInterval = this._collectionIntervalFor();
       if (isFinal || intervalDuration >= currentInterval) {
         // Create stats entry for this interval
         const statsEntry = this._createStatsEntry(
@@ -1797,7 +1814,9 @@ export class CallReportCollector {
           ? { totalSamplesDecoded: inboundAudio.totalSamplesDecoded }
           : {}),
         ...(inboundAudio.samplesDecodedWithSilence !== undefined
-          ? { samplesDecodedWithSilence: inboundAudio.samplesDecodedWithSilence }
+          ? {
+              samplesDecodedWithSilence: inboundAudio.samplesDecodedWithSilence,
+            }
           : {}),
         ...(inboundAudio.samplesDecodedWithConcealment !== undefined
           ? {

--- a/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
+++ b/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
@@ -511,7 +511,7 @@ export interface ICallReportFlushReason {
     | 'manual'
     | 'socket-close'
     | 'socket-error'
-    | 'page-hidden';
+    | 'page-unload';
   socketClose?: {
     code?: number;
     codeName?: string;
@@ -863,7 +863,7 @@ export class CallReportCollector {
     host: string,
     voiceSdkId?: string,
     // Force `keepalive: true` even though this is not the final report. Used
-    // for page-hidden flushes, where the request must be allowed to outlive
+    // for page-unload flushes, where the request must be allowed to outlive
     // the document being torn down.
     forceKeepalive: boolean = false
   ): Promise<void> {


### PR DESCRIPTION
## Problem

Call reports can be lost when the page goes away mid-call:

- When calls are kept alive across unload (`hangupOnBeforeUnload === false`), the call **never hangs up**, so `_postCallReport()` (the final report) is never triggered for a call the user reloads/closes on — its report is simply lost.
- A plain async `fetch` started in an unload handler is **cut off** as the document tears down (requests are document-bound; without `keepalive` the browser aborts them on unload). So "just fire-and-forget a POST on unload" doesn't reliably work.

Existing coverage:
- `main` already sends the **final** report with `keepalive: true`, but only when the call actually ends (BYE/disconnect).
- **#714** persists failed reports to `sessionStorage` and retries them on the next reconnect — this rescues reports lost to a **socket-1001 network drop**, but nothing captures a report at the **unload** moment for a still-active call.

## Fix

On **`beforeunload`**, when calls are being kept alive (`hangupOnBeforeUnload === false`), flush an intermediate call report for each active call and send it with **`keepalive: true`** so the POST is allowed to outlive the page tear-down.

This reuses the SDK's **existing `beforeunload` handler** — the same one that already, in its `hangupOnBeforeUnload === false` branch, persists the active-calls recovery marker. The flush is added at the **top of that branch**, before the recovery-marker logic, so it runs even when there is no `sessionid` to persist.

### Changes
- **`CallReportCollector.ts`** — add `'page-unload'` to `ICallReportFlushReason`; thread an optional `forceKeepalive` through `sendPayload()` → `_sendPayload()` so `useKeepalive = (isFinalReport || forceKeepalive) && body ≤ 60 KiB`.
- **`BaseCall.ts`** — `_flushIntermediateReport` sends with `forceKeepalive = flushReason.type === 'page-unload'`.
- **`Verto` (`index.ts`)** — in the existing `beforeunload` handler's `hangupOnBeforeUnload === false` branch, flush `{ type: 'page-unload' }` for each active call. No bespoke dedup — a redundant flush is already a no-op because `CallReportCollector.flush()` returns `null` when nothing new has buffered since the last flush.

### Relationship to #717
The reconnect session-id re-stamp added in #717 stays on its own **`visibilitychange` → `hidden`** listener (a synchronous `sessionStorage` write, which is reliable even where `beforeunload` is not). This PR does **not** move that; it only adds the call-report flush, on `beforeunload`.

### Relationship to #714
Complementary, not overlapping: this captures a **snapshot at the unload moment** (keepalive send); #714 **persists + retries** reports that failed to POST while the network was down. Together they cover both the page-going-away and the network-going-away cases.

## Tests
- `CallReportCollector`: keepalive is used for an intermediate report when `forceKeepalive` is set.
- `Verto`: flushes `page-unload` for each active call on `beforeunload` (`hangupOnBeforeUnload=false`); does not flush when `hangupOnBeforeUnload` is not `false` (calls are hung up instead); does not throw when there are no active calls.
- Full `Verto` + `CallReportCollector` + `Call` suites green (**148 tests**), `tsc --noEmit` clean.

## Notes
- Uses `fetch(keepalive)` rather than `navigator.sendBeacon` because the report requires custom headers (`x-call-report-id`, `x-call-id`, `x-voice-sdk-id`) that `sendBeacon` cannot set; keepalive fetch is the modern equivalent and already the SDK's final-report primitive. `keepalive` has a 64 KB body cap (guarded by `KEEPALIVE_BODY_LIMIT_BYTES`); oversized reports fall back to a normal fetch and are covered by #714's persist/retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)