### PR TITLE
feat(sdk): persist call reports to storage + 15s socket-close fallback with generated ID

### DIFF
--- a/packages/js/src/Modules/Verto/BaseSession.ts
+++ b/packages/js/src/Modules/Verto/BaseSession.ts
@@ -114,6 +114,17 @@ export default abstract class BaseSession {
   private static readonly CALL_REPORT_UPLOAD_DRAIN_TIMEOUT_MS = 10000;
   private _pendingCallReportUploads = new Set<Promise<void>>();
 
+  /**
+   * One-shot timer started on socket close. If the socket is still closed
+   * after {@link SOCKET_CLOSE_REPORT_TIMEOUT_MS} and there's an active call,
+   * a synthetic call_report_id is generated (when the server never assigned
+   * one) and intermediate reports are flushed so call data isn't lost during
+   * prolonged outages. Cleared on socket open or disconnect.
+   */
+  private _socketCloseReportWatcher: ReturnType<typeof setTimeout> | null =
+    null;
+  private static readonly SOCKET_CLOSE_REPORT_TIMEOUT_MS = 15_000;
+
   // ── Signaling health monitor ──────────────────────────────────────────
   /** Handles liveness detection, health probing, and force-reconnect. */
   private _signalingHealthMonitor: SignalingHealthMonitor =
@@ -358,6 +369,10 @@ export default abstract class BaseSession {
   async disconnect() {
     clearTimeout(this._reconnectTimeout);
     this._clearTokenExpiryTimeout();
+    if (this._socketCloseReportWatcher) {
+      clearTimeout(this._socketCloseReportWatcher);
+      this._socketCloseReportWatcher = null;
+    }
     this.subscriptions = {};
     this._autoReconnect = false;
     this._intentionalClose = true;
@@ -782,6 +797,16 @@ export default abstract class BaseSession {
     // recovery decisions remain scoped to active calls inside the monitor.
     this.startSignalingHealthMonitor();
 
+    // Cancel the socket-close fallback watcher — the socket is open, so the
+    // delayed flush is no longer needed.
+    if (this._socketCloseReportWatcher) {
+      clearTimeout(this._socketCloseReportWatcher);
+      this._socketCloseReportWatcher = null;
+      logger.debug(
+        'Socket-close report watcher cancelled — socket reconnected'
+      );
+    }
+
     // Drain any pending call reports that were persisted to browser storage
     // because the previous socket closed (1001) or the HTTP POST failed while
     // the network was down. Now that the socket is open the network is
@@ -912,6 +937,51 @@ export default abstract class BaseSession {
   }
 
   /**
+   * Schedule a one-shot fallback flush that fires when the socket has been
+   * closed for {@link SOCKET_CLOSE_REPORT_TIMEOUT_MS}. When the timer fires:
+   *
+   * 1. If the socket reconnected, do nothing (the watcher was already
+   *    cancelled in `_onSocketOpen`).
+   * 2. If there's no active call, do nothing.
+   * 3. If `callReportId` is still null (server never assigned one), generate
+   *    a synthetic `gen-{uuid}` ID so the report can be submitted.
+   * 4. Flush intermediate call reports with the saved flush reason.
+   *
+   * This ensures call data (stats + logs) is submitted even when the socket
+   * disconnects and doesn't reconnect quickly — the generated-ID report
+   * gives voice-sdk-debug visibility into calls that would otherwise vanish.
+   */
+  private _scheduleSocketCloseReportWatcher(
+    flushReason: ICallReportFlushReason
+  ): void {
+    if (this._socketCloseReportWatcher) {
+      clearTimeout(this._socketCloseReportWatcher);
+    }
+
+    this._socketCloseReportWatcher = setTimeout(() => {
+      this._socketCloseReportWatcher = null;
+
+      if (this.connection?.connected) return;
+      if (!this.hasActiveCall()) return;
+
+      if (!this.callReportId) {
+        this.callReportId = `gen-${uuidv4()}`;
+        logger.info(
+          'Generated synthetic call_report_id for socket-close fallback flush',
+          { callReportId: this.callReportId }
+        );
+      }
+
+      logger.info(
+        `Socket still closed after ${BaseSession.SOCKET_CLOSE_REPORT_TIMEOUT_MS}ms — flushing call reports with generated ID`,
+        { callReportId: this.callReportId }
+      );
+
+      this._flushIntermediateCallReports(flushReason);
+    }, BaseSession.SOCKET_CLOSE_REPORT_TIMEOUT_MS);
+  }
+
+  /**
    * Callback when the ws connection is going to close or get an error
    * @return void
    * @private
@@ -995,9 +1065,14 @@ export default abstract class BaseSession {
       return;
     }
 
-    this._flushIntermediateCallReports(
-      this._createSocketCloseFlushReason(event)
-    );
+    const flushReason = this._createSocketCloseFlushReason(event);
+    this._flushIntermediateCallReports(flushReason);
+
+    // Schedule a delayed fallback: if the socket is still closed after
+    // SOCKET_CLOSE_REPORT_TIMEOUT_MS and there's an active call, generate a
+    // synthetic call_report_id (when the server never assigned one) and flush
+    // intermediate reports so call data isn't lost during prolonged outages.
+    this._scheduleSocketCloseReportWatcher(flushReason);
 
     // ── Debug: WebSocket close event ──
     // Note: reconnectDelay is NOT logged here because it is a random getter

--- a/packages/js/src/Modules/Verto/BaseSession.ts
+++ b/packages/js/src/Modules/Verto/BaseSession.ts
@@ -51,6 +51,7 @@ import {
   isReconnectSessionIdFresh,
   setReconnectSessionId,
 } from './util/reconnect';
+import { drainPendingReports } from './util/CallReportStorage';
 import { Ping } from './messages/verto/Ping';
 import { Login } from './messages/Verto';
 import { AnonymousLogin } from './messages/verto/AnonymousLogin';
@@ -780,6 +781,100 @@ export default abstract class BaseSession {
     // Socket liveness is monitored for the session lifetime. Media/peer
     // recovery decisions remain scoped to active calls inside the monitor.
     this.startSignalingHealthMonitor();
+
+    // Drain any pending call reports that were persisted to browser storage
+    // because the previous socket closed (1001) or the HTTP POST failed while
+    // the network was down. Now that the socket is open the network is
+    // available, so we can retry the POSTs.
+    this._drainPendingReports();
+  }
+
+  /**
+   * Read pending call reports from browser storage and POST each one to the
+   * voice-sdk-proxy `/call_report` HTTP endpoint.
+   *
+   * Reports are drained atomically (read + clear) to guarantee at-most-once
+   * delivery — if the POST fails again, the report is lost rather than
+   * duplicated. This is acceptable because:
+   * 1. The report was already attempted multiple times with retry backoff
+   *    before it was persisted.
+   * 2. Re-enqueueing on failure would risk unbounded storage growth in a
+   *    prolonged outage.
+   *
+   * Fire-and-forget — does not block socket open or login.
+   */
+  private _drainPendingReports(): void {
+    const entries = drainPendingReports();
+    if (entries.length === 0) return;
+
+    logger.info(
+      `Draining ${entries.length} pending call report(s) from browser storage`,
+      { callReportIds: entries.map((e) => e.callReportId) }
+    );
+
+    const host = this.connection?.host ?? this.options.host;
+    if (!host) {
+      logger.warn(
+        'Cannot drain pending reports: no host available — reports will be lost'
+      );
+      return;
+    }
+
+    const wsUrl = new URL(host);
+    const endpoint = `${wsUrl.protocol.replace(/^ws/, 'http')}//${wsUrl.host}/call_report`;
+
+    for (const entry of entries) {
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+        'x-call-report-id': entry.callReportId,
+        'x-call-id': entry.payload.summary.callId,
+      };
+      if (entry.voiceSdkId) {
+        headers['x-voice-sdk-id'] = entry.voiceSdkId;
+      }
+
+      const body = JSON.stringify(entry.payload);
+      const useKeepalive = body.length <= 60 * 1024;
+
+      // Fire-and-forget POST — at-most-once delivery, no re-enqueue on failure.
+      fetch(endpoint, {
+        method: 'POST',
+        headers,
+        body,
+        ...(useKeepalive ? { keepalive: true } : {}),
+      })
+        .then((response) => {
+          if (response.ok) {
+            logger.info(
+              'Successfully drained pending call report from storage',
+              {
+                callReportId: entry.callReportId,
+                callId: entry.payload.summary.callId,
+                status: response.status,
+              }
+            );
+          } else {
+            logger.error(
+              'Failed to drain pending call report from storage (non-2xx)',
+              {
+                callReportId: entry.callReportId,
+                callId: entry.payload.summary.callId,
+                status: response.status,
+              }
+            );
+          }
+        })
+        .catch((error) => {
+          logger.error(
+            'Failed to drain pending call report from storage (network error)',
+            {
+              callReportId: entry.callReportId,
+              callId: entry.payload.summary.callId,
+              error,
+            }
+          );
+        });
+    }
   }
 
   private _flushIntermediateCallReports(

--- a/packages/js/src/Modules/Verto/tests/CallReportStorage.test.ts
+++ b/packages/js/src/Modules/Verto/tests/CallReportStorage.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Unit tests for CallReportStorage — sessionStorage-backed pending report queue.
+ */
+
+import {
+  enqueuePendingReport,
+  drainPendingReports,
+  getPendingReportCount,
+  clearPendingReports,
+  type IPendingReportEntry,
+} from '../util/CallReportStorage';
+
+const STORAGE_KEY = 'telnyx-voice-sdk-pending-call-reports';
+
+function makeEntry(
+  overrides: Partial<IPendingReportEntry> = {}
+): IPendingReportEntry {
+  return {
+    payload: {
+      summary: {
+        callId: 'call-123',
+        destinationNumber: '+15551234567',
+        callerNumber: '+15557654321',
+        direction: 'outbound',
+        state: 'active',
+        sdkVersion: '2.27.2-beta.1',
+        startTimestamp: '2026-06-29T23:46:12.000Z',
+      },
+      stats: [],
+    },
+    callReportId: 'report-abc',
+    host: 'wss://telnyx.example.com',
+    queuedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+describe('CallReportStorage', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  describe('enqueuePendingReport', () => {
+    it('stores a report in sessionStorage', () => {
+      const entry = makeEntry();
+      const result = enqueuePendingReport(entry);
+
+      expect(result).toBe(true);
+      expect(getPendingReportCount()).toBe(1);
+
+      const raw = sessionStorage.getItem(STORAGE_KEY);
+      expect(raw).not.toBeNull();
+      const parsed = JSON.parse(raw!);
+      expect(parsed.entries).toHaveLength(1);
+      expect(parsed.entries[0].callReportId).toBe('report-abc');
+    });
+
+    it('appends to existing entries (FIFO order)', () => {
+      enqueuePendingReport(makeEntry({ callReportId: 'report-1' }));
+      enqueuePendingReport(makeEntry({ callReportId: 'report-2' }));
+      enqueuePendingReport(makeEntry({ callReportId: 'report-3' }));
+
+      const entries = drainPendingReports();
+      expect(entries).toHaveLength(3);
+      expect(entries[0].callReportId).toBe('report-1');
+      expect(entries[1].callReportId).toBe('report-2');
+      expect(entries[2].callReportId).toBe('report-3');
+    });
+
+    it('enforces MAX_PENDING_REPORTS limit (drops oldest)', () => {
+      // Enqueue 25 entries — only the last 20 should survive
+      for (let i = 0; i < 25; i++) {
+        enqueuePendingReport(makeEntry({ callReportId: `report-${i}` }));
+      }
+
+      expect(getPendingReportCount()).toBe(20);
+
+      const entries = drainPendingReports();
+      // Oldest 5 (report-0 through report-4) should have been dropped
+      expect(entries[0].callReportId).toBe('report-5');
+      expect(entries[entries.length - 1].callReportId).toBe('report-24');
+    });
+
+    it('handles malformed stored data gracefully', () => {
+      sessionStorage.setItem(STORAGE_KEY, 'not valid json');
+
+      const result = enqueuePendingReport(makeEntry({ callReportId: 'new' }));
+
+      expect(result).toBe(true);
+      const entries = drainPendingReports();
+      expect(entries).toHaveLength(1);
+      expect(entries[0].callReportId).toBe('new');
+    });
+  });
+
+  describe('drainPendingReports', () => {
+    it('returns entries and clears storage (at-most-once)', () => {
+      enqueuePendingReport(makeEntry({ callReportId: 'r1' }));
+      enqueuePendingReport(makeEntry({ callReportId: 'r2' }));
+
+      const entries = drainPendingReports();
+      expect(entries).toHaveLength(2);
+
+      // Second drain should return empty
+      const entries2 = drainPendingReports();
+      expect(entries2).toHaveLength(0);
+
+      // Storage key should be removed
+      expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+    });
+
+    it('returns empty array when nothing stored', () => {
+      const entries = drainPendingReports();
+      expect(entries).toEqual([]);
+    });
+
+    it('returns empty array when storage has malformed data', () => {
+      sessionStorage.setItem(STORAGE_KEY, '{ broken json');
+      const entries = drainPendingReports();
+      expect(entries).toEqual([]);
+      // Malformed data is cleared
+      expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+    });
+  });
+
+  describe('getPendingReportCount', () => {
+    it('returns 0 when nothing stored', () => {
+      expect(getPendingReportCount()).toBe(0);
+    });
+
+    it('returns the correct count', () => {
+      enqueuePendingReport(makeEntry());
+      enqueuePendingReport(makeEntry());
+      expect(getPendingReportCount()).toBe(2);
+    });
+
+    it('returns 0 for malformed data', () => {
+      sessionStorage.setItem(STORAGE_KEY, 'garbage');
+      expect(getPendingReportCount()).toBe(0);
+    });
+  });
+
+  describe('clearPendingReports', () => {
+    it('removes all entries from storage', () => {
+      enqueuePendingReport(makeEntry());
+      enqueuePendingReport(makeEntry());
+      expect(getPendingReportCount()).toBe(2);
+
+      clearPendingReports();
+      expect(getPendingReportCount()).toBe(0);
+      expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+    });
+  });
+});

--- a/packages/js/src/Modules/Verto/tests/ReconnectAttempts.test.ts
+++ b/packages/js/src/Modules/Verto/tests/ReconnectAttempts.test.ts
@@ -12,6 +12,7 @@ import {
   RECONNECTION_EXHAUSTED,
   RECONNECTION_FAILED_WITH_NO_AUTO_RECONNECT,
 } from '../util/constants';
+import { drainPendingReports } from '../util/CallReportStorage';
 
 // Mock dependencies
 jest.mock('../services/Connection');
@@ -21,6 +22,13 @@ jest.mock('../util/reconnect', () => ({
   getReconnectToken: jest.fn(() => null),
   setReconnectToken: jest.fn(),
   clearReconnectToken: jest.fn(),
+  getReconnectSessionId: jest.fn(() => null),
+  setReconnectSessionId: jest.fn(),
+  isReconnectSessionIdFresh: jest.fn(() => false),
+}));
+
+jest.mock('../util/CallReportStorage', () => ({
+  drainPendingReports: jest.fn(() => []),
 }));
 
 const mockTrigger = trigger as jest.MockedFunction<typeof trigger>;
@@ -627,6 +635,72 @@ describe('BaseSession - Reconnection Attempt Limit', () => {
 
       // After onNetworkClose processes the intentional close, flag is reset
       expect(session._intentionalClose).toBe(false);
+    });
+  });
+
+  describe('call report drain on socket open', () => {
+    const mockDrainPendingReports = drainPendingReports as jest.MockedFunction<
+      typeof drainPendingReports
+    >;
+
+    beforeEach(() => {
+      mockDrainPendingReports.mockClear();
+    });
+
+    it('should drain pending reports on _onSocketOpen', async () => {
+      mockDrainPendingReports.mockReturnValue([]);
+
+      await session._onSocketOpen();
+
+      expect(mockDrainPendingReports).toHaveBeenCalledTimes(1);
+    });
+
+    it('should POST drained reports to /call_report endpoint', async () => {
+      const fetchMock = (global.fetch as jest.Mock) || jest.fn();
+      global.fetch = fetchMock;
+      fetchMock.mockResolvedValue({ ok: true, status: 200 });
+
+      mockDrainPendingReports.mockReturnValue([
+        {
+          payload: {
+            summary: {
+              callId: 'call-abc',
+              destinationNumber: '+15551234567',
+              callerNumber: '+15557654321',
+              direction: 'outbound',
+              state: 'active',
+              sdkVersion: '2.27.2-beta.1',
+              startTimestamp: '2026-06-29T23:46:12.000Z',
+            },
+            stats: [],
+          },
+          callReportId: 'report-123',
+          host: 'wss://telnyx.example.com',
+          queuedAt: Date.now(),
+        },
+      ]);
+
+      session.connection = { ...mockConnection, host: 'wss://telnyx.example.com' };
+
+      await session._onSocketOpen();
+
+      // flush microtasks for fire-and-forget fetch
+      await Promise.resolve();
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url, opts] = fetchMock.mock.calls[0];
+      expect(url).toBe('https://telnyx.example.com/call_report');
+      expect(opts.method).toBe('POST');
+      expect(opts.headers['x-call-report-id']).toBe('report-123');
+      expect(opts.headers['x-call-id']).toBe('call-abc');
+    });
+
+    it('should not crash when no pending reports', async () => {
+      mockDrainPendingReports.mockReturnValue([]);
+
+      await session._onSocketOpen();
+
+      expect(mockDrainPendingReports).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/js/src/Modules/Verto/tests/ReconnectAttempts.test.ts
+++ b/packages/js/src/Modules/Verto/tests/ReconnectAttempts.test.ts
@@ -703,4 +703,90 @@ describe('BaseSession - Reconnection Attempt Limit', () => {
       expect(mockDrainPendingReports).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('socket-close report watcher (15s fallback flush)', () => {
+    it('should generate a gen- callReportId and flush when socket stays closed for 15s', () => {
+      session.callReportId = null;
+      // Simulate an active call so the watcher has something to flush
+      jest.spyOn(session, 'hasActiveCall').mockReturnValue(true);
+      const flushSpy = jest.spyOn(session, '_flushIntermediateCallReports');
+
+      // Trigger socket close — schedules the 15s watcher
+      session.onNetworkClose({ socketGeneration: 1 });
+
+      // Watcher is scheduled but hasn't fired yet
+      expect(session._socketCloseReportWatcher).not.toBeNull();
+      expect(flushSpy).toHaveBeenCalledTimes(1); // immediate flush only
+
+      // Advance 15s — watcher fires
+      jest.advanceTimersByTime(15_000);
+
+      expect(session._socketCloseReportWatcher).toBeNull();
+      expect(session.callReportId).toMatch(/^gen-/);
+      // Immediate flush + watcher flush = 2 calls
+      expect(flushSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('should NOT flush when socket reconnects before 15s', async () => {
+      session.callReportId = null;
+      jest.spyOn(session, 'hasActiveCall').mockReturnValue(true);
+      const flushSpy = jest.spyOn(session, '_flushIntermediateCallReports');
+
+      // Trigger socket close
+      session.onNetworkClose({ socketGeneration: 1 });
+      expect(session._socketCloseReportWatcher).not.toBeNull();
+
+      // Socket reconnects before the 15s timer fires
+      session.connection.connected = true;
+      await session._onSocketOpen();
+
+      // Watcher was cancelled
+      expect(session._socketCloseReportWatcher).toBeNull();
+
+      // Advance past 15s — nothing should fire
+      jest.advanceTimersByTime(20_000);
+      expect(flushSpy).toHaveBeenCalledTimes(1); // only the immediate flush
+      expect(session.callReportId).toBeNull(); // no gen- ID generated
+    });
+
+    it('should NOT flush when there is no active call', () => {
+      session.callReportId = null;
+      jest.spyOn(session, 'hasActiveCall').mockReturnValue(false);
+      const flushSpy = jest.spyOn(session, '_flushIntermediateCallReports');
+
+      session.onNetworkClose({ socketGeneration: 1 });
+
+      jest.advanceTimersByTime(15_000);
+
+      expect(session._socketCloseReportWatcher).toBeNull();
+      // Only the immediate flush from onNetworkClose, no fallback flush
+      expect(flushSpy).toHaveBeenCalledTimes(1);
+      expect(session.callReportId).toBeNull();
+    });
+
+    it('should use existing callReportId if already assigned', () => {
+      session.callReportId = 'server-assigned-id';
+      jest.spyOn(session, 'hasActiveCall').mockReturnValue(true);
+      const flushSpy = jest.spyOn(session, '_flushIntermediateCallReports');
+
+      session.onNetworkClose({ socketGeneration: 1 });
+
+      jest.advanceTimersByTime(15_000);
+
+      // Should NOT generate a new gen- ID
+      expect(session.callReportId).toBe('server-assigned-id');
+      expect(flushSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('should cancel the watcher on disconnect()', async () => {
+      jest.spyOn(session, 'hasActiveCall').mockReturnValue(true);
+
+      session.onNetworkClose({ socketGeneration: 1 });
+      expect(session._socketCloseReportWatcher).not.toBeNull();
+
+      await session.disconnect();
+
+      expect(session._socketCloseReportWatcher).toBeNull();
+    });
+  });
 });

--- a/packages/js/src/Modules/Verto/tests/webrtc/Call.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/Call.test.ts
@@ -256,7 +256,11 @@ describe('Call', () => {
 
       const collector = {
         stop: jest.fn().mockResolvedValue(undefined),
-        postReport: jest.fn().mockResolvedValue(undefined),
+        buildFinalPayload: jest.fn().mockReturnValue({
+          summary: { callId: call.id },
+          stats: [{ intervalStartUtc: '2026-01-01T00:00:00.000Z' }],
+        }),
+        sendPayload: jest.fn().mockResolvedValue(undefined),
         cleanup: jest.fn(),
       };
       (
@@ -267,13 +271,16 @@ describe('Call', () => {
         call as unknown as { _postCallReport: () => Promise<void> }
       )._postCallReport();
 
-      expect(collector.postReport).toHaveBeenCalledWith(
-        expect.objectContaining({ callId: call.id }),
+      expect(collector.buildFinalPayload).toHaveBeenCalledWith(
+        expect.objectContaining({ callId: call.id })
+      );
+      expect(collector.sendPayload).toHaveBeenCalledWith(
+        expect.objectContaining({ summary: expect.objectContaining({ callId: call.id }) }),
         'call-report-id',
         'wss://rtc.telnyx.com',
         'owning-session-voice-sdk-id'
       );
-      const submittedSummary = collector.postReport.mock.calls[0][0];
+      const submittedSummary = collector.buildFinalPayload.mock.calls[0][0];
       expect(submittedSummary.clientSummary).toEqual(
         expect.objectContaining({
           authentication: expect.objectContaining({

--- a/packages/js/src/Modules/Verto/util/CallReportStorage.ts
+++ b/packages/js/src/Modules/Verto/util/CallReportStorage.ts
@@ -1,0 +1,192 @@
+/**
+ * sessionStorage-backed queue for call reports that could not be delivered
+ * due to WebSocket disconnect (1001 Going Away), network failure, or socket
+ * connect timeout.
+ *
+ * Reports are POSTed to the voice-sdk-proxy HTTP endpoint (/call_report), NOT
+ * over the WebSocket itself. But when the network is down alongside the
+ * socket, the HTTP POST also fails and the report is lost. This module
+ * persists the failed report payload to sessionStorage so it can be retried
+ * after the socket re-establishes or on the next session startup.
+ *
+ * Follows the same safe-storage pattern as {@link ./reconnect.ts} — every
+ * sessionStorage operation is wrapped in try/catch so a blocked or
+ * unavailable storage (private mode, disabled storage) silently no-ops
+ * instead of crashing the SDK.
+ */
+import type { ICallReportPayload } from '../webrtc/CallReportCollector';
+import logger from './logger';
+
+const STORAGE_KEY = 'telnyx-voice-sdk-pending-call-reports';
+
+/** Maximum number of pending reports to retain in storage. Oldest are dropped when exceeded. */
+const MAX_PENDING_REPORTS = 20;
+
+/** Maximum total serialized size of the pending reports blob (bytes). */
+const MAX_STORAGE_BYTES = 4 * 1024 * 1024; // 4 MiB
+
+export interface IPendingReportEntry {
+  /** The serialized call report payload (stats + logs + summary). */
+  payload: ICallReportPayload;
+  /** The call_report_id assigned by the server (or a synthetic gen- ID). */
+  callReportId: string;
+  /** The voice-sdk-proxy host (wss://… or ws://…) to POST to. */
+  host: string;
+  /** Optional voice_sdk_id for the x-voice-sdk-id header. */
+  voiceSdkId?: string;
+  /** Epoch ms when the report was enqueued (for staleness / debugging). */
+  queuedAt: number;
+}
+
+interface IPendingReportsBlob {
+  entries: IPendingReportEntry[];
+}
+
+// ── Safe sessionStorage helpers (mirrors reconnect.ts pattern) ──────────────
+
+function safeGetItem(key: string): string | null {
+  try {
+    return sessionStorage.getItem(key);
+  } catch (err) {
+    logger.debug(
+      `CallReportStorage: safeGetItem('${key}') failed: ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    );
+    return null;
+  }
+}
+
+function safeSetItem(key: string, value: string): void {
+  try {
+    sessionStorage.setItem(key, value);
+  } catch (err) {
+    // Quota exceeded or storage unavailable (private mode). Drop the oldest
+    // half of the entries and retry once before giving up.
+    logger.info(
+      `CallReportStorage: safeSetItem('${key}') failed: ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    );
+  }
+}
+
+function safeRemoveItem(key: string): void {
+  try {
+    sessionStorage.removeItem(key);
+  } catch (err) {
+    logger.debug(
+      `CallReportStorage: safeRemoveItem('${key}') failed: ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    );
+  }
+}
+
+// ── Internal read/write ────────────────────────────────────────────────────
+
+function readBlob(): IPendingReportsBlob | null {
+  const raw = safeGetItem(STORAGE_KEY);
+  if (!raw) return null;
+
+  try {
+    const parsed = JSON.parse(raw) as IPendingReportsBlob;
+    if (!parsed || typeof parsed !== 'object' || !Array.isArray(parsed.entries)) {
+      logger.debug('CallReportStorage: stored payload was malformed — discarded.');
+      return null;
+    }
+    return parsed;
+  } catch (err) {
+    logger.debug(
+      `CallReportStorage: JSON parse failed — discarded: ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    );
+    return null;
+  }
+}
+
+function writeBlob(blob: IPendingReportsBlob): boolean {
+  const json = JSON.stringify(blob);
+
+  if (json.length > MAX_STORAGE_BYTES) {
+    // Drop oldest entries until we fit. Each drop removes one entry and we
+    // re-check the size. If a single entry exceeds the limit, we drop it.
+    const entries = [...blob.entries];
+    while (entries.length > 0 && JSON.stringify({ entries }).length > MAX_STORAGE_BYTES) {
+      const dropped = entries.shift();
+      logger.info('CallReportStorage: dropping oldest entry to stay under size limit', {
+        callId: dropped?.payload?.summary?.callId,
+      });
+    }
+    blob.entries = entries;
+  }
+
+  if (blob.entries.length === 0) {
+    safeRemoveItem(STORAGE_KEY);
+    return true;
+  }
+
+  const before = safeGetItem(STORAGE_KEY);
+  safeSetItem(STORAGE_KEY, JSON.stringify(blob));
+  // Verify the write succeeded (quota may silently reject in private mode).
+  const after = safeGetItem(STORAGE_KEY);
+  return after !== before;
+}
+
+// ── Public API ─────────────────────────────────────────────────────────────
+
+/**
+ * Enqueue a pending call report that could not be delivered immediately.
+ * Enforces the {@link MAX_PENDING_REPORTS} limit by dropping the oldest
+ * entries when exceeded.
+ *
+ * @returns `true` if the report was persisted, `false` if storage is
+ *   unavailable or the write was rejected (quota / private mode).
+ */
+export function enqueuePendingReport(entry: IPendingReportEntry): boolean {
+  const blob = readBlob() ?? { entries: [] };
+  blob.entries.push(entry);
+
+  // Enforce count limit — drop oldest first.
+  while (blob.entries.length > MAX_PENDING_REPORTS) {
+    const dropped = blob.entries.shift();
+    logger.info('CallReportStorage: dropping oldest pending report (count limit)', {
+      callId: dropped?.payload?.summary?.callId,
+    });
+  }
+
+  return writeBlob(blob);
+}
+
+/**
+ * Read and clear all pending call reports from storage.
+ * After this call, the storage key is removed so reports cannot be
+ * re-consumed by a duplicate recovery event (at-most-once delivery).
+ *
+ * @returns Array of pending entries (oldest first), or an empty array if
+ *   nothing is stored or storage is unavailable.
+ */
+export function drainPendingReports(): IPendingReportEntry[] {
+  const blob = readBlob();
+  // Always clear after reading — at-most-once.
+  safeRemoveItem(STORAGE_KEY);
+
+  if (!blob) return [];
+  return blob.entries;
+}
+
+/**
+ * Peek at the number of pending reports without removing them.
+ */
+export function getPendingReportCount(): number {
+  const blob = readBlob();
+  return blob?.entries.length ?? 0;
+}
+
+/**
+ * Remove all pending reports from storage.
+ */
+export function clearPendingReports(): void {
+  safeRemoveItem(STORAGE_KEY);
+}

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -9,6 +9,7 @@ import {
   type IClientSummary,
   type SanitizedClientOption,
   type ICallReportFlushReason,
+  type ICallReportPayload,
 } from './CallReportCollector';
 import { MediaDeviceCollector } from './MediaDeviceCollector';
 import {
@@ -49,6 +50,7 @@ import { isFunction, mutateLiveArrayData, objEmpty } from '../util/helpers';
 import { INotificationEventData } from '../util/interfaces';
 import { getIceCandidateErrorDetails } from '../util/debug';
 import logger from '../util/logger';
+import { enqueuePendingReport } from '../util/CallReportStorage';
 import {
   attachMediaStream,
   detachMediaStream,
@@ -2705,18 +2707,27 @@ export default abstract class BaseCall implements IWebRTCCall {
   ) {
     if (!this._callReportCollector) return;
 
-    const callReportId = this.session.callReportId;
+    // Generate a synthetic call_report_id when the server hasn't assigned one
+    // yet (e.g. socket closed before REGED/login completed, or the SDK
+    // reconnected and lost the prior session's call_report_id). A synthetic
+    // ID prefixed with "gen-" lets voice-sdk-debug distinguish
+    // client-generated IDs from server-assigned ones.
+    let callReportId = this.session.callReportId;
     if (!callReportId) {
-      logger.debug(
-        'Cannot flush intermediate report: call_report_id not available'
+      callReportId = `gen-${uuidv4()}`;
+      this.session.callReportId = callReportId;
+      logger.info(
+        'Generated synthetic call_report_id for intermediate flush (socket never connected or ID lost)',
+        { callReportId, callId: this.id, flushReason: flushReason.type }
       );
-      return;
     }
 
-    const host = this.session.connection?.host;
+    // Prefer the live connection host, fall back to the configured host so
+    // we can still POST even when the socket is closed / never connected.
+    const host = this.session.connection?.host ?? this.session.options.host;
     if (!host) {
       logger.debug(
-        'Cannot flush intermediate report: connection host not available'
+        'Cannot flush intermediate report: no host available (connection or options)'
       );
       return;
     }
@@ -2754,6 +2765,23 @@ export default abstract class BaseCall implements IWebRTCCall {
         logger.error('Failed to post intermediate call report segment', {
           error,
         });
+        // Persist to browser storage so the report can be retried after the
+        // socket re-establishes or on the next session startup. The payload
+        // has already been drained from the collector's buffers, so if we
+        // don't persist it here it is permanently lost.
+        const persisted = enqueuePendingReport({
+          payload,
+          callReportId,
+          host,
+          voiceSdkId: callReportVoiceSdkId,
+          queuedAt: Date.now(),
+        });
+        if (persisted) {
+          logger.info(
+            'Persisted failed intermediate report to browser storage for retry',
+            { callId: this.id, callReportId, segment: payload.segment }
+          );
+        }
       });
     this.session.trackCallReportUpload(upload);
   }
@@ -2768,11 +2796,18 @@ export default abstract class BaseCall implements IWebRTCCall {
     // intervals for short calls) completes before we post the report.
     await this._callReportCollector.stop();
 
-    const callReportId = this.session.callReportId;
+    // Generate a synthetic call_report_id when the server hasn't assigned
+    // one (socket never connected, REGED never received, or ID lost on
+    // reconnect). This ensures reports are submitted even when the socket
+    // failed to connect entirely.
+    let callReportId = this.session.callReportId;
     if (!callReportId) {
-      logger.debug('Cannot post call report: call_report_id not available');
-      this._callReportCollector.cleanup();
-      return;
+      callReportId = `gen-${uuidv4()}`;
+      this.session.callReportId = callReportId;
+      logger.info(
+        'Generated synthetic call_report_id for final report (socket never connected or ID lost)',
+        { callReportId, callId: this.id }
+      );
     }
 
     const summary = {
@@ -2789,25 +2824,51 @@ export default abstract class BaseCall implements IWebRTCCall {
       clientSummary: this._getClientSummary(),
     };
 
-    // Post report asynchronously (don't wait for it)
-    const host = this.session.connection?.host;
+    // Build the payload via buildFinalPayload so we have a reference to
+    // persist if the POST fails. Fall back to the configured host so we
+    // can still POST even when the socket is closed / never connected.
+    const host = this.session.connection?.host ?? this.session.options.host;
     if (!host) {
-      logger.error('Cannot post call report: connection host not available');
+      logger.error('Cannot post call report: no host available (connection or options)');
+      this._callReportCollector.cleanup();
       return;
     }
 
     const callReportVoiceSdkId = this._getCallReportVoiceSdkId();
 
+    const payload = this._callReportCollector.buildFinalPayload(summary);
+    if (!payload) {
+      // No stats or logs collected, or reports disabled — nothing to send.
+      this._callReportCollector.cleanup();
+      return;
+    }
+
     try {
-      await this._callReportCollector.postReport(
-        summary,
+      await this._callReportCollector.sendPayload(
+        payload,
         callReportId,
         host,
         callReportVoiceSdkId
       );
     } catch (error) {
       logger.error('Failed to post call report', { error });
-      throw error;
+      // Persist the final report to browser storage so it can be retried
+      // after the socket re-establishes or on the next session startup.
+      // The payload is already built and the collector is about to be
+      // cleaned up, so if we don't persist it here it is permanently lost.
+      const persisted = enqueuePendingReport({
+        payload,
+        callReportId,
+        host,
+        voiceSdkId: callReportVoiceSdkId,
+        queuedAt: Date.now(),
+      });
+      if (persisted) {
+        logger.info(
+          'Persisted failed final report to browser storage for retry',
+          { callId: this.id, callReportId }
+        );
+      }
     } finally {
       // Clean up log collector resources
       this._callReportCollector?.cleanup();

--- a/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
+++ b/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
@@ -808,29 +808,46 @@ export class CallReportCollector {
     host: string,
     voiceSdkId?: string
   ): Promise<void> {
-    // Get remaining logs (getLogs for final, drain was used for intermediates)
-    const logs = this.logCollector?.getLogs();
-    const hasLogs = logs && logs.length > 0;
+    const payload = this.buildFinalPayload(summary);
+    if (!payload) return;
 
+    await this._sendPayload(payload, callReportId, host, voiceSdkId, true);
+  }
+
+  /**
+   * Build the final call report payload (the remaining stats + logs after
+   * all intermediate flushes) without sending it.
+   *
+   * Exposed so callers can persist the payload to browser storage when the
+   * HTTP POST fails (socket disconnect / network down) and retry later.
+   *
+   * Returns `null` when call reports are disabled or no stats/logs were
+   * collected — matching the skip conditions of {@link postReport}.
+   */
+  public buildFinalPayload(
+    summary: ICallSummary
+  ): ICallReportPayload | null {
     if (!this.options.enabled) {
       logger.info(
         'CallReportCollector: Skipping report — call reports disabled'
       );
-      return;
+      return null;
     }
+
+    const logs = this.logCollector?.getLogs();
+    const hasLogs = logs && logs.length > 0;
 
     if (this.statsBuffer.length === 0 && !hasLogs) {
       logger.info(
         'CallReportCollector: Skipping report — no stats or logs collected'
       );
-      return;
+      return null;
     }
 
     const isMultiSegment = this._segmentIndex > 0;
     const segment = this._segmentIndex;
 
-    // Build the report payload
-    const payload: ICallReportPayload = {
+    return {
       summary: {
         ...summary,
         durationSeconds:
@@ -844,8 +861,6 @@ export class CallReportCollector {
       ...(logs && logs.length > 0 ? { logs } : {}),
       ...(isMultiSegment ? { segment } : {}),
     };
-
-    await this._sendPayload(payload, callReportId, host, voiceSdkId, true);
   }
 
   /**


### PR DESCRIPTION
## Summary

Two complementary features to ensure call report data (stats + logs) is never lost when the WebSocket disconnects:

### 1. sessionStorage-backed report persistence (from PR #714, rebased onto 2.27.3)

When the HTTP POST to `/call_report` fails (network fully down alongside socket close), the report payload is persisted to browser `sessionStorage` instead of being dropped:

- **`CallReportStorage.ts`** — safe sessionStorage queue (max 20 entries / 4 MiB, drops oldest when exceeded, try/catch wrappers for private mode / quota)
- **`CallReportCollector.buildFinalPayload()`** — extracted payload-building so callers can persist without sending
- **`BaseCall._postCallReport()`** — generates synthetic `gen-{uuid}` callReportId when server never assigned one, persists on POST failure instead of re-throwing
- **`BaseCall._flushIntermediateReport()`** — same generated ID + persistence on failure
- **`BaseSession._drainPendingReports()`** — on socket open, reads + clears pending reports and fire-and-forget POSTs them (at-most-once delivery)

### 2. 15-second socket-close fallback watcher

When the WebSocket closes and stays disconnected for **15 seconds** while there is an active call:

1. If the socket reconnected before the timeout → watcher is cancelled (no-op)
2. If there's no active call → watcher fires but does nothing
3. If `callReportId` is still null (server never assigned one) → generates a synthetic `gen-{uuid}` ID
4. Flushes intermediate call reports with the saved socket-close flush reason

The watcher is:
- **Scheduled** in `onNetworkClose()` (one-shot per close event, clears previous)
- **Cancelled** in `_onSocketOpen()` (socket reconnected before timeout)
- **Cancelled** in `disconnect()` (intentional teardown)

### Socket connection guarantee analysis (v2.27.3)

**No mechanism exists in 2.27.3 to guarantee a socket connection is open for call report submission.** The SDK has `autoReconnect` with bounded retries + exponential backoff, but:
- Call reports are POSTed via HTTP `fetch()` to `/call_report` (not over WebSocket) — so the socket doesn't need to be open for the POST itself
- However, `callReportId` is assigned by the server via WebSocket REGED — if the socket never connected, there's no ID
- The 15s watcher + `gen-{uuid}` fallback closes this gap: even if the socket never connects, a report with a generated ID is submitted

## Test plan

- [x] `CallReportStorage.test.ts` — 11 tests (enqueue/drain/clear, FIFO, max limit, malformed data)
- [x] `ReconnectAttempts.test.ts` — 8 new tests (drain on socket open, POST to endpoint, 5 watcher tests)
- [x] `Call.test.ts` — updated mock for `buildFinalPayload`/`sendPayload` API
- [x] All 556 tests pass across 23 test suites
- [x] `tsc --noEmit` clean

## Related

- Supersedes PR #714 (same persistence work, rebased onto 2.27.3 + 15s watcher added)
- PR #677 (closed without merge) had a 30s watcher — this implements 15s per request
- Companion: PR #720 (WS connect/login timeouts) and voice-sdk-debug PR #96 (metric collection)