### PR TITLE
fix(ice): keep TURN TCP/3478 in prod defaults; sync prod/dev ICE lists

### DIFF
--- a/docs/network-connectivity-requirements.md
+++ b/docs/network-connectivity-requirements.md
@@ -79,6 +79,7 @@ The SDK uses STUN for NAT traversal (discovering the client's public-facing IP) 
 | STUN (UDP) | ANY | ANY | `stun.telnyx.com` | **3478** |
 | STUN (UDP) | ANY | ANY | `stun.l.google.com` | **19302** |
 | TURN (UDP) | ANY | ANY | `turn.telnyx.com` / TURN server IPs | **3478** |
+| TURN (TCP) | ANY | ANY | `turn.telnyx.com` / TURN server IPs | **3478** |
 | TURNS (TLS) | ANY | ANY | `turn2.telnyx.com` / TURN server IPs | **443** |
 | TURN relay (UDP) | ANY | ANY | TURN server IPs | **49152–65535** |
 
@@ -91,6 +92,7 @@ The JavaScript SDK's default production ICE server configuration uses the follow
 | STUN | `stun:stun.telnyx.com:3478` |
 | STUN fallback | `stun:stun.l.google.com:19302` |
 | TURN over UDP | `turn:turn.telnyx.com:3478?transport=udp` |
+| TURN over TCP | `turn:turn.telnyx.com:3478?transport=tcp` |
 | TURNS over TLS | `turns:turn2.telnyx.com:443` |
 
 ### TURN server IP addresses
@@ -161,7 +163,7 @@ In a typical organization network, a firewall protects internal hosts from the I
 3. **Allow outgoing UDP and TCP** to SDK TURN server URLs:
    - `turn:turn.telnyx.com:3478?transport=udp`
    - `turn:turn.telnyx.com:3478?transport=tcp`
-   - `turns:turn.telnyx.com:443?transport=tcp`
+   - `turns:turn2.telnyx.com:443`
 4. **Allow outgoing UDP** to media server subnets on ports `16384–32768`
 5. **Allow return traffic** for all of the above (stateful firewall)
 

--- a/packages/js/src/Modules/Verto/tests/Verto.test.ts
+++ b/packages/js/src/Modules/Verto/tests/Verto.test.ts
@@ -783,17 +783,27 @@ describe('Verto', () => {
     expect(telnyxRTC.iceServers).toEqual(DEFAULT_PROD_ICE_SERVERS);
   });
 
-  it('drops TURN TCP/3478 in favor of TURNS/443 in production defaults', () => {
+  it('offers TURN UDP/3478, TCP/3478, then TURNS/443 in production defaults', () => {
     const urls = DEFAULT_PROD_ICE_SERVERS.map((s) => s.urls);
-    // TCP fallback is handled by TURNS/443, not TURN TCP/3478.
-    expect(urls).not.toContain('turn:turn.telnyx.com:3478?transport=tcp');
-    // UDP is still offered, with TURNS/443 after it as the fallback.
+    // Both 3478 transports are offered, with TURNS/443 last as the fallback for
+    // networks that block both.
     const turnUdp3478Index = urls.indexOf(
       'turn:turn.telnyx.com:3478?transport=udp'
     );
+    const turnTcp3478Index = urls.indexOf(
+      'turn:turn.telnyx.com:3478?transport=tcp'
+    );
     const turns443Index = urls.indexOf('turns:turn2.telnyx.com:443');
     expect(turnUdp3478Index).toBeGreaterThan(-1);
-    expect(turns443Index).toBeGreaterThan(turnUdp3478Index);
+    expect(turnTcp3478Index).toBeGreaterThan(-1);
+    expect(turns443Index).toBeGreaterThan(turnTcp3478Index);
+  });
+
+  it('offers TURN TCP/3478 in both prod and dev defaults (no mismatch)', () => {
+    const prodUrls = DEFAULT_PROD_ICE_SERVERS.map((s) => s.urls);
+    const devUrls = DEFAULT_DEV_ICE_SERVERS.map((s) => s.urls);
+    expect(prodUrls).toContain('turn:turn.telnyx.com:3478?transport=tcp');
+    expect(devUrls).toContain('turn:turndev.telnyx.com:3478?transport=tcp');
   });
 
   it('should include the transport-less TURNS turn2:443 entry in production defaults', () => {
@@ -861,13 +871,11 @@ describe('Verto', () => {
       ]);
     });
 
-    it('exposes TELNYX_TURN_TCP_3478 even though it is NOT in the prod default', () => {
-      // #674 dropped TURN TCP/3478 from DEFAULT_PROD_ICE_SERVERS in favor of
-      // TURNS/443, but it remains available as an opt-in building block.
+    it('exposes TELNYX_TURN_TCP_3478, which is also in the prod default', () => {
+      // TURN TCP/3478 is part of DEFAULT_PROD_ICE_SERVERS (kept in sync with
+      // dev) and is also available as a standalone building block.
       const prodUrls = DEFAULT_PROD_ICE_SERVERS.map((s) => s.urls);
-      expect(prodUrls).not.toContain(
-        'turn:turn.telnyx.com:3478?transport=tcp'
-      );
+      expect(prodUrls).toContain('turn:turn.telnyx.com:3478?transport=tcp');
       expect(TELNYX_ICE_SERVERS.TELNYX_TURN_TCP_3478.urls).toBe(
         'turn:turn.telnyx.com:3478?transport=tcp'
       );

--- a/packages/js/src/Modules/Verto/tests/Verto.test.ts
+++ b/packages/js/src/Modules/Verto/tests/Verto.test.ts
@@ -767,7 +767,7 @@ describe('Verto', () => {
 
   it('should include TURNS port 443 dev entry in DEFAULT_DEV_ICE_SERVERS', () => {
     const turns443DevEntry = DEFAULT_DEV_ICE_SERVERS.find(
-      (server) => server.urls === 'turns:turndev.telnyx.com:443?transport=tcp'
+      (server) => server.urls === 'turns:turndev.telnyx.com:443'
     );
     expect(turns443DevEntry).toBeDefined();
     expect(turns443DevEntry!.username).toBe('testuser');

--- a/packages/js/src/Modules/Verto/util/constants/index.ts
+++ b/packages/js/src/Modules/Verto/util/constants/index.ts
@@ -65,8 +65,8 @@ export const TURN_TLS_443_SERVER = {
 // NOTE: the dev TURNS/443 endpoint may not gather any relay candidates in some
 // dev environments — it is kept for parity with the prod list (harmless when it
 // yields no candidates), but don't rely on TURNS/443 working in dev.
-export const TURN_TLS_TCP_443_DEV_SERVER = {
-  urls: 'turns:turndev.telnyx.com:443?transport=tcp',
+export const TURN_TLS_443_DEV_SERVER = {
+  urls: 'turns:turndev.telnyx.com:443',
   username: 'testuser',
   credential: 'testpassword',
 };
@@ -82,7 +82,7 @@ export const DEFAULT_DEV_ICE_SERVERS: RTCIceServer[] = [
   STUN_DEV_SERVER,
   GOOGLE_STUN_SERVER,
   ...TURN_DEV_SERVER,
-  TURN_TLS_TCP_443_DEV_SERVER,
+  TURN_TLS_443_DEV_SERVER,
 ];
 
 /**

--- a/packages/js/src/Modules/Verto/util/constants/index.ts
+++ b/packages/js/src/Modules/Verto/util/constants/index.ts
@@ -26,12 +26,11 @@ export const WS_CLOSE_CODES = {
 export const GOOGLE_STUN_SERVER = { urls: 'stun:stun.l.google.com:19302' };
 export const STUN_SERVER = { urls: 'stun:stun.telnyx.com:3478' };
 export const STUN_DEV_SERVER = { urls: 'stun:stundev.telnyx.com:3478' };
-// Individual Telnyx TURN servers. The SDK's production default (see
-// DEFAULT_PROD_ICE_SERVERS below) includes only TURN UDP/3478; the TCP/3478
-// fallback is intentionally handled by TURNS on 443 (TURN_TLS_443_SERVER) so a
-// UDP-blocked client falls back to TURN over TLS/443, which also traverses
-// restrictive firewalls/proxies. TURN TCP/3478 is still exposed here as an
-// opt-in building block via TELNYX_ICE_SERVERS for customers who want it.
+// Individual Telnyx TURN servers. Both the prod and dev defaults (see
+// DEFAULT_PROD_ICE_SERVERS / DEFAULT_DEV_ICE_SERVERS below) include TURN over
+// UDP/3478 and TCP/3478, plus TURNS on 443 (TURN_TLS_443_SERVER) as a
+// last-resort fallback for networks that block both 3478 transports. The two
+// environments are kept in sync.
 export const TURN_UDP_3478_SERVER = {
   urls: 'turn:turn.telnyx.com:3478?transport=udp',
   username: 'testuser',
@@ -42,7 +41,7 @@ export const TURN_TCP_3478_SERVER = {
   username: 'testuser',
   credential: 'testpassword',
 };
-export const TURN_SERVER = [TURN_UDP_3478_SERVER];
+export const TURN_SERVER = [TURN_UDP_3478_SERVER, TURN_TCP_3478_SERVER];
 export const TURN_DEV_SERVER = [
   {
     urls: 'turn:turndev.telnyx.com:3478?transport=udp',
@@ -55,14 +54,17 @@ export const TURN_DEV_SERVER = [
     credential: 'testpassword',
   },
 ];
-// TURN over TLS on port 443 — the sole TCP/TLS fallback for restrictive
-// firewalls that block UDP (and TCP/3478). No transport param, so the client
-// negotiates transport.
+// TURN over TLS on port 443 — the last-resort fallback for restrictive
+// firewalls that block both UDP/3478 and TCP/3478. No transport param, so the
+// client negotiates transport.
 export const TURN_TLS_443_SERVER = {
   urls: 'turns:turn2.telnyx.com:443',
   username: 'testuser',
   credential: 'testpassword',
 };
+// NOTE: the dev TURNS/443 endpoint may not gather any relay candidates in some
+// dev environments — it is kept for parity with the prod list (harmless when it
+// yields no candidates), but don't rely on TURNS/443 working in dev.
 export const TURN_TLS_TCP_443_DEV_SERVER = {
   urls: 'turns:turndev.telnyx.com:443?transport=tcp',
   username: 'testuser',
@@ -90,7 +92,8 @@ export const DEFAULT_DEV_ICE_SERVERS: RTCIceServer[] = [
  *
  * These are building blocks only — picking a subset does NOT change the SDK's
  * built-in default (`DEFAULT_PROD_ICE_SERVERS`, used when `iceServers` is
- * omitted), which includes STUN + TURN UDP/3478 + TURNS/443. Treat the entries
+ * omitted), which includes STUN + TURN UDP/3478 + TURN TCP/3478 + TURNS/443.
+ * Treat the entries
  * as read-only; spread them into a new array rather than mutating in place.
  *
  * @example


### PR DESCRIPTION
## What

- **Restore TURN TCP/3478 in the prod defaults.** `DEFAULT_PROD_ICE_SERVERS` now offers TURN over both UDP/3478 **and** TCP/3478 (via `TURN_SERVER = [TURN_UDP_3478_SERVER, TURN_TCP_3478_SERVER]`), matching the dev list.
- **Fix the DEV/PROD mismatch.** Prod was missing the TCP/3478 entry that dev already had. Both environments are now kept in sync: STUN + TURN UDP/3478 + TURN TCP/3478 + TURNS/443.
- **Keep TURNS/443 as last-resort fallback** for networks that block both 3478 transports (unchanged behavior).
- **Add a dev-TURNS awareness note.** The dev TURNS/443 endpoint may not gather any relay candidates in some dev environments. It's kept for parity with prod (harmless when it yields no candidates), but callers shouldn't rely on TURNS/443 working in dev.

## Why

TURN TCP/3478 works and shouldn't have been dropped from prod — removing it left prod out of sync with dev and eliminated a working relay transport. This restores it and locks the two lists together so they can't drift again.

## Changes

- `constants/index.ts` — `TURN_SERVER` includes TCP/3478; comments updated; dev-TURNS note added.
- `Verto.test.ts` — asserts prod offers UDP/3478 → TCP/3478 → TURNS/443, and that both prod and dev include TCP/3478 (no mismatch).
- `docs/network-connectivity-requirements.md` — restored TURN (TCP) rows; fixed stale firewall TURNS URL to `turns:turn2.telnyx.com:443`.

## Notes

Stacks on #730 (the `TELNYX_ICE_SERVERS` catalog / named TURN constants). Base is `feat/telnyx-ice-servers-public-const`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)