### PR TITLE
feat: send client errors to voice-sdk-proxy via telnyx_rtc.client_error

### DIFF
--- a/packages/js/src/Modules/Verto/BaseSession.ts
+++ b/packages/js/src/Modules/Verto/BaseSession.ts
@@ -55,6 +55,7 @@ import { Ping } from './messages/verto/Ping';
 import { Login } from './messages/Verto';
 import { AnonymousLogin } from './messages/verto/AnonymousLogin';
 import { ERROR_TYPE } from './webrtc/constants';
+import { ClientErrorMessage } from './messages/WebRTCStats';
 import type { ICallReportFlushReason } from './webrtc/CallReportCollector';
 import type { ITelnyxWarningEvent } from './util/constants/warnings';
 import type { RestartIceResult } from './webrtc/Peer';
@@ -290,6 +291,33 @@ export default abstract class BaseSession {
       return;
     }
     this.connection.sendRawText(text);
+  }
+
+  /**
+   * Send a client_error JSON-RPC message to the server (voice-sdk-proxy).
+   * This gives the server-side visibility into SDK errors that would
+   * otherwise only exist as client-side console logs.
+   * Fire-and-forget — errors are silently swallowed so error reporting
+   * never crashes the SDK.
+   * @param errorType  Machine-readable error type (e.g. 'call_report_id_not_captured')
+   * @param errorMessage Human-readable error message
+   * @param context     Additional context key-value pairs
+   * @ignore
+   */
+  sendClientError(
+    errorType: string,
+    errorMessage: string,
+    context?: Record<string, unknown>
+  ): void {
+    try {
+      this.execute(
+        new ClientErrorMessage(errorType, errorMessage, context)
+      ).catch(() => {
+        // Silently fail — error reporting must not crash the SDK
+      });
+    } catch {
+      // Silently fail — error reporting must not crash the SDK
+    }
   }
 
   trackCallReportUpload(upload: Promise<void>): void {

--- a/packages/js/src/Modules/Verto/messages/WebRTCStats.ts
+++ b/packages/js/src/Modules/Verto/messages/WebRTCStats.ts
@@ -1,4 +1,5 @@
 import BaseMessage from './BaseMessage';
+import { VertoMethod } from '../webrtc/constants';
 
 const DEBUG_REPORT_VERSION = 1;
 
@@ -35,6 +36,25 @@ export class DebugReportDataMessage extends BaseMessage {
       debug_report_version: DEBUG_REPORT_VERSION,
       call_id: callID,
       debug_report_data: data,
+    });
+  }
+}
+
+export class ClientErrorMessage extends BaseMessage {
+  constructor(
+    errorType: string,
+    errorMessage: string,
+    context?: Record<string, unknown>
+  ) {
+    super();
+    this.buildRequest({
+      method: VertoMethod.ClientError,
+      params: {
+        error_type: errorType,
+        error_message: errorMessage,
+        timestamp: new Date().toISOString(),
+        ...context,
+      },
     });
   }
 }

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -2886,6 +2886,14 @@ export default abstract class BaseCall implements IWebRTCCall {
     const callReportId = this.session.callReportId;
     if (!callReportId) {
       logger.debug('Cannot post call report: call_report_id not available');
+      this.session.sendClientError(
+        'call_report_id_missing',
+        'Cannot post call report: call_report_id not available',
+        {
+          call_id: this.id,
+          state: this.state,
+        }
+      );
       this._callReportCollector.cleanup();
       return;
     }
@@ -2908,6 +2916,14 @@ export default abstract class BaseCall implements IWebRTCCall {
     const host = this.session.connection?.host;
     if (!host) {
       logger.error('Cannot post call report: connection host not available');
+      this.session.sendClientError(
+        'call_report_host_unavailable',
+        'Cannot post call report: connection host not available',
+        {
+          call_id: this.id,
+          call_report_id: callReportId,
+        }
+      );
       return;
     }
 
@@ -2922,6 +2938,15 @@ export default abstract class BaseCall implements IWebRTCCall {
       );
     } catch (error) {
       logger.error('Failed to post call report', { error });
+      this.session.sendClientError(
+        'call_report_post_failed',
+        'Failed to post call report',
+        {
+          call_id: this.id,
+          call_report_id: callReportId,
+          error: error instanceof Error ? error.message : String(error),
+        }
+      );
       throw error;
     } finally {
       // Clean up log collector resources

--- a/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
+++ b/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
@@ -564,6 +564,19 @@ class VertoHandler {
                     'Captured call_report_id from REGED:',
                     callReportId
                   );
+                } else {
+                  logger.warn(
+                    'call_report_id not found in REGED response'
+                  );
+                  session.sendClientError(
+                    'call_report_id_not_captured',
+                    'call_report_id not found in REGED response',
+                    {
+                      previous_gateway_state:
+                        session.connection.previousGatewayState,
+                      has_reged_params: !!msg?.result?.params,
+                    }
+                  );
                 }
 
                 const dc = msg?.result?.params?.dc;

--- a/packages/js/src/Modules/Verto/webrtc/constants.ts
+++ b/packages/js/src/Modules/Verto/webrtc/constants.ts
@@ -31,6 +31,7 @@ export enum VertoMethod {
   GatewayState = 'telnyx_rtc.gatewayState',
   Ping = 'telnyx_rtc.ping',
   Pong = 'telnyx_rtc.pong',
+  ClientError = 'telnyx_rtc.client_error',
 }
 
 export const NOTIFICATION_TYPE = {


### PR DESCRIPTION
## Summary

When the WebRTC JS SDK encounters critical errors (e.g. `call_report_id` not captured from REGED, call report post failures), it now sends a `telnyx_rtc.client_error` JSON-RPC message to voice-sdk-proxy over the WebSocket connection.

This gives **server-side visibility** into SDK errors that would otherwise only exist as client-side `logger.debug()` / `logger.error()` console logs.

## Changes

### New message type
- Added `ClientError = 'telnyx_rtc.client_error'` to `VertoMethod` enum (`constants.ts`)
- Added `ClientErrorMessage` class (`messages/WebRTCStats.ts`) — extends `BaseMessage`, sends JSON-RPC with `method: "telnyx_rtc.client_error"` and `params: { error_type, error_message, timestamp, ...context }`

### SDK-side sending mechanism
- Added `BaseSession.sendClientError(errorType, errorMessage, context?)` — fire-and-forget, catches all errors silently so error reporting never crashes the SDK
- Returns a JSON-RPC reply is expected from the proxy (same pattern as debug report messages)

### Error paths wired
1. **REGED handler** (`VertoHandler.ts`): When `call_report_id` is not found in the REGED response params → sends `call_report_id_not_captured` with `previous_gateway_state` and `has_reged_params` context
2. **`_postCallReport`** (`BaseCall.ts`): When `callReportId` is null → sends `call_report_id_missing` with `call_id` and `state`
3. **`_postCallReport`** (`BaseCall.ts`): When `connection.host` is unavailable → sends `call_report_host_unavailable` with `call_id` and `call_report_id`
4. **`_postCallReport`** (`BaseCall.ts`): When call report POST fails → sends `call_report_post_failed` with `call_id`, `call_report_id`, and error message

## Message format

```json
{
  "jsonrpc": "2.0",
  "id": "uuid",
  "method": "telnyx_rtc.client_error",
  "params": {
    "error_type": "call_report_id_not_captured",
    "error_message": "call_report_id not found in REGED response",
    "timestamp": "2026-07-09T...",
    "previous_gateway_state": "",
    "has_reged_params": false
  }
}
```

## Related

- **voice-sdk-proxy PR**: [team-telnyx/voice-sdk-proxy#160](https://github.com/team-telnyx/voice-sdk-proxy/pull/160) — handles this message type, logs it, does NOT forward to b2bua-rtc
- Root cause investigation: user `b89ffe7d` call `70af820b` — VSP generated `call_report_id` but SDK never received it, no call report was posted, and the only signal was a client-side `logger.debug()` invisible to server-side monitoring

## Testing

- All 652 existing Verto test suite tests pass (`corepack yarn jest packages/js/src/Modules/Verto/tests --runInBand`)

