### PR TITLE
docs: split CN1 (Chennai) into its own South Asia region (VSDK-82)

### DIFF
--- a/docs/network-connectivity-requirements.md
+++ b/docs/network-connectivity-requirements.md
@@ -57,7 +57,7 @@ The SDK connects to Telnyx signaling infrastructure via secure WebSocket (WSS) o
 | EU | AMS3 (Amsterdam) | `185.246.41.166` |
 | EU | FR5 (Frankfurt) | `185.246.41.136` |
 | EU | LD6 (London) | `185.246.41.135` |
-| APAC | CN1 (Chennai) | `36.255.198.250` |
+| South Asia | CN1 (Chennai) | `36.255.198.250` |
 
 ### Regional signaling endpoints
 
@@ -255,7 +255,8 @@ The SDK supports regional signaling endpoints for customers who need to pin conn
 | `us-west.rtc.telnyx.com` | US West | LV1 (Las Vegas) |
 | `ca-central.rtc.telnyx.com` | Canada | MT1 (Montreal), TR1 (Toronto) |
 | `eu.rtc.telnyx.com` | Europe | AMS3 (Amsterdam), FR5 (Frankfurt), LD6 (London) |
-| `apac.rtc.telnyx.com` | Asia-Pacific | CN1 (Chennai), SY1 (Sydney) |
+| `apac.rtc.telnyx.com` | Asia-Pacific | SY1 (Sydney) |
+| `south-asia.rtc.telnyx.com` | South Asia | CN1 (Chennai) |
 
 Use regional endpoints when:
 - Your users are concentrated in a known region
@@ -292,6 +293,7 @@ new TelnyxRTC({
 | United States | CH1 (Chicago), AT1 (Atlanta), NJ1 (New Jersey), LV1 (Las Vegas), DA1 (Dallas) |
 | Canada | TR1 (Toronto), MT1 (Montreal) |
 | Europe | AMS3 (Amsterdam), FR5 (Frankfurt), LD6 (London) |
-| Asia-Pacific | CN1 (Chennai), SY1 (Sydney) |
+| Asia-Pacific | SY1 (Sydney) |
+| South Asia | CN1 (Chennai) |
 
 Customers can request a direct connection to the Telnyx network via Megaport or direct peering.


### PR DESCRIPTION
Ref: [VSDK-82](https://linear.app/telnyx/issue/VSDK-82/add-vsp-instance-in-cn1-prod), [VSDK-221](https://linear.app/telnyx/issue/VSDK-221/investigate-inconsistent-dns-responses-for-turn2telnyxcom-converted-to)

CN1 (Chennai) was moved out of the `apac` region into a new `south-asia` region ([ansible#2334](https://github.com/team-telnyx/ansible/pull/2334)). It measured **~252 ms from Australia** (vs 2–3 ms for SY1), so it did not belong in the same signalling pool as SY1 (Sydney) — exactly the mis-grouping these docs described.

## Changes to `network-connectivity-requirements.md`

| Table | Before | After |
|---|---|---|
| Signalling server IPs | `APAC · CN1 (Chennai)` | `South Asia · CN1 (Chennai)` |
| Regional endpoints | `apac.rtc.telnyx.com → CN1, SY1` | `apac.rtc.telnyx.com → SY1`; add `south-asia.rtc.telnyx.com → CN1` |
| Points of presence | `Asia-Pacific: CN1, SY1` | `Asia-Pacific: SY1`; `South Asia: CN1` |

## Scope notes

- The **media-server (TURN)** table (`APAC · CN1 / SG1 / SY1`) is left unchanged — TURN anycast grouping is a separate axis from the VSP `LOCAL_REGION`, and this split only concerns signalling.
- I did not add an SY1 row to the signalling-IP table (it lists CN1 only for that region today) — I don't have an authoritative SY1 signalling IP in the same series and didn't want to guess.

## ⚠️ `south-asia.rtc.telnyx.com` doesn't resolve yet

The doc now references it, but it is **NXDOMAIN** until (1) a CN1 VSP registers with `SERVICE_5021_REGIONAL_SUBDOMAIN=south-asia.rtc` (ansible#2334 deployed) and (2) the public CNAME is added in `infra-svc-telnyx-public-domain-records`. Worth holding merge until the endpoint is live, or marking it coming-soon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)