### PR TITLE
fix: post CallRecorder tracks concurrently so the remote segment is not dropped (VSDK-453)

### DIFF
--- a/packages/js/src/Modules/Verto/tests/webrtc/CallRecorder.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/CallRecorder.test.ts
@@ -204,13 +204,11 @@ describe('CallRecorder', () => {
 
   describe('buffer accumulation + overflow', () => {
     it('accumulates packets from captured frames', async () => {
-      const fetchImpl = jest
-        .fn()
-        .mockResolvedValue({
-          ok: true,
-          status: 200,
-          text: () => Promise.resolve(''),
-        });
+      const fetchImpl = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve(''),
+      });
       const recorder = makeRecorder(
         { flushIntervalMs: 100_000 }, // no periodic flush during the test
         fetchImpl
@@ -226,16 +224,14 @@ describe('CallRecorder', () => {
       expect(fetchImpl).not.toHaveBeenCalled();
     });
 
-    it('drops oldest packets on overflow and emits RECORDING_BUFFER_OVERFLOW once per window', async () => {
+    it('drops oldest packets on overflow and emits RECORDING_BUFFER_OVERFLOW once per track per window', async () => {
       // Tiny cap so a single 480-frame Float32 packet (1920 bytes) overflows
       // after a couple of packets.
-      const fetchImpl = jest
-        .fn()
-        .mockResolvedValue({
-          ok: true,
-          status: 200,
-          text: () => Promise.resolve(''),
-        });
+      const fetchImpl = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve(''),
+      });
       const onWarning = jest.fn();
       const recorder = makeRecorder(
         {
@@ -249,27 +245,171 @@ describe('CallRecorder', () => {
       await flushMicrotasks();
       recorder.stop();
 
-      // The recorder should have warned at most once about overflow within
-      // this single flush window.
+      // Both tracks overflow, and the throttle is per-track (VSDK-453) — a
+      // shared flag let an overflow on `local` mask one on `remote`, hiding
+      // packet loss on half the recording. Two tracks => at most two warnings.
       const overflowCalls = onWarning.mock.calls.filter(
         (c) => c[0].name === 'RECORDING_BUFFER_OVERFLOW'
       );
-      expect(overflowCalls.length).toBeLessThanOrEqual(1);
+      expect(overflowCalls.length).toBeLessThanOrEqual(2);
       expect(overflowCalls.length).toBeGreaterThanOrEqual(0);
 
+      recorder.cleanup();
+    });
+
+    it('throttles the overflow warning to one per track within a window', async () => {
+      // Only `local` is recorded, so the many frames that overflow the tiny
+      // cap must still produce exactly one warning.
+      const onWarning = jest.fn();
+      const recorder = makeRecorder({
+        maxBufferBytes: 4000, // ~2 packets before overflow
+        flushIntervalMs: 100_000,
+        tracks: ['local'],
+      });
+      recorder.onWarning = onWarning;
+      recorder.start(fakeAudioTrack(), fakeAudioTrack());
+      await flushMicrotasks();
+      recorder.stop();
+
+      const overflowCalls = onWarning.mock.calls.filter(
+        (c) => c[0].name === 'RECORDING_BUFFER_OVERFLOW'
+      );
+      expect(overflowCalls.length).toBe(1);
+
+      recorder.cleanup();
+    });
+  });
+
+  describe('flush interval clamping (VSDK-453)', () => {
+    // A flush interval longer than the buffer's fill time means the oldest
+    // packets are evicted before they are ever uploaded. At 48 kHz the capture
+    // rate is ~208 KB/s per track, so an 8 MB buffer fills in ~38s.
+    const safeIntervalMs = (maxBufferBytes: number, sampleRate = 48000) =>
+      (maxBufferBytes / (sampleRate * 4 + 100 * 160)) * 500;
+
+    /** Read the clamped interval off the private method under test. */
+    const flushIntervalOf = (recorder: CallRecorder): number =>
+      (
+        recorder as unknown as { _flushIntervalMs(): number }
+      )._flushIntervalMs();
+
+    it('clamps an interval that outlives the buffer fill time', () => {
+      const recorder = makeRecorder({
+        flushIntervalMs: 240_000, // the old default
+        maxBufferBytes: 8_000_000,
+        sampleRate: 48000,
+      });
+      const interval = flushIntervalOf(recorder);
+      expect(interval).toBeCloseTo(safeIntervalMs(8_000_000), 0);
+      expect(interval).toBeLessThan(38_000);
+    });
+
+    it('leaves an already-safe interval untouched', () => {
+      const recorder = makeRecorder({
+        flushIntervalMs: 5_000,
+        maxBufferBytes: 8_000_000,
+        sampleRate: 48000,
+      });
+      expect(flushIntervalOf(recorder)).toBe(5_000);
+    });
+
+    it('passes through 0 to disable time-based flushes', () => {
+      const recorder = makeRecorder({
+        flushIntervalMs: 0,
+        maxBufferBytes: 8_000_000,
+      });
+      expect(flushIntervalOf(recorder)).toBe(0);
+    });
+  });
+
+  describe('final flush concurrency (VSDK-453)', () => {
+    it('posts every track even when the first upload is slow', async () => {
+      // Serialized posts made `remote` start only after `local` finished, so a
+      // slow first upload pushed it past BaseSession's 10s upload drain and it
+      // was never sent. Both must now be in flight together.
+      let resolveLocal: () => void = () => {};
+      const inFlight: string[] = [];
+      const fetchImpl = jest.fn().mockImplementation((_url, init) => {
+        const body = JSON.parse(init.body);
+        inFlight.push(body.track);
+        const ok = {
+          ok: true,
+          status: 202,
+          text: () => Promise.resolve(''),
+        };
+        if (body.track === 'local') {
+          // Hold the local POST open until both have been issued.
+          return new Promise((resolve) => {
+            resolveLocal = () => resolve(ok);
+          });
+        }
+        return Promise.resolve(ok);
+      });
+
+      const recorder = makeRecorder(
+        { flushIntervalMs: 100_000, maxBufferBytes: 8_000_000 },
+        fetchImpl
+      );
+      recorder.start(fakeAudioTrack(), fakeAudioTrack());
+      await flushMicrotasks();
+
+      const finalPost = recorder.postFinalReport();
+      await flushMicrotasks();
+
+      // `remote` was issued while `local` was still pending — the old
+      // sequential loop would have only issued `local` at this point.
+      expect(inFlight).toContain('local');
+      expect(inFlight).toContain('remote');
+
+      resolveLocal();
+      await finalPost;
+
+      const postedTracks = fetchImpl.mock.calls.map(
+        (c) => JSON.parse(c[1].body).track
+      );
+      expect(postedTracks.sort()).toEqual(['local', 'remote']);
+      recorder.cleanup();
+    });
+
+    it('still posts the second track when the first fails outright', async () => {
+      const fetchImpl = jest.fn().mockImplementation((_url, init) => {
+        const body = JSON.parse(init.body);
+        if (body.track === 'local') {
+          return Promise.reject(new Error('network down'));
+        }
+        return Promise.resolve({
+          ok: true,
+          status: 202,
+          text: () => Promise.resolve(''),
+        });
+      });
+
+      const recorder = makeRecorder(
+        { flushIntervalMs: 100_000, maxBufferBytes: 8_000_000 },
+        fetchImpl
+      );
+      recorder.start(fakeAudioTrack(), fakeAudioTrack());
+      await flushMicrotasks();
+
+      // The local track exhausts its retries and postFinalReport rethrows,
+      // but the remote track must have been uploaded regardless.
+      await expect(recorder.postFinalReport()).rejects.toThrow('network down');
+
+      const remotePosts = fetchImpl.mock.calls.filter(
+        (c) => JSON.parse(c[1].body).track === 'remote'
+      );
+      expect(remotePosts.length).toBe(1);
       recorder.cleanup();
     });
   });
 
   describe('periodic flush', () => {
     it('fires _periodicFlush and clears the buffer on success', async () => {
-      const fetchImpl = jest
-        .fn()
-        .mockResolvedValue({
-          ok: true,
-          status: 200,
-          text: () => Promise.resolve(''),
-        });
+      const fetchImpl = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve(''),
+      });
       const recorder = makeRecorder({ flushIntervalMs: 10 }, fetchImpl);
       recorder.start(fakeAudioTrack(), fakeAudioTrack());
       // Wait long enough for the pump + at least one 10ms flush tick.
@@ -335,13 +475,11 @@ describe('CallRecorder', () => {
     });
 
     it('throws after retry exhaustion and cleanup still runs', async () => {
-      const fetchImpl = jest
-        .fn()
-        .mockResolvedValue({
-          ok: false,
-          status: 500,
-          text: () => Promise.resolve('err'),
-        });
+      const fetchImpl = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: () => Promise.resolve('err'),
+      });
 
       const recorder = makeRecorder(
         { flushIntervalMs: 100_000, tracks: ['local'] },
@@ -362,13 +500,11 @@ describe('CallRecorder', () => {
 
     it('sets keepalive: true for final payloads below 60 KB', async () => {
       // Use a single small frame so the final payload is small.
-      const fetchImpl = jest
-        .fn()
-        .mockResolvedValue({
-          ok: true,
-          status: 200,
-          text: () => Promise.resolve(''),
-        });
+      const fetchImpl = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve(''),
+      });
 
       const recorder = makeRecorder({ flushIntervalMs: 100_000 }, fetchImpl);
       recorder.start(fakeAudioTrack(), fakeAudioTrack());
@@ -409,13 +545,11 @@ describe('CallRecorder', () => {
         globalThis as { MediaStreamTrackProcessor?: unknown }
       ).MediaStreamTrackProcessor = BigMSTP as unknown;
 
-      const fetchImpl = jest
-        .fn()
-        .mockResolvedValue({
-          ok: true,
-          status: 200,
-          text: () => Promise.resolve(''),
-        });
+      const fetchImpl = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve(''),
+      });
 
       const recorder = makeRecorder(
         {
@@ -445,13 +579,11 @@ describe('CallRecorder', () => {
       // BaseCall constructs the recorder in _init() before the server assigns
       // session.callReportId, so the context value is empty. _setCallReportId
       // is called later (at the Active state / before the final flush).
-      const fetchImpl = jest
-        .fn()
-        .mockResolvedValue({
-          ok: true,
-          status: 200,
-          text: () => Promise.resolve(''),
-        });
+      const fetchImpl = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve(''),
+      });
 
       const recorder = makeRecorder(
         { flushIntervalMs: 100_000, tracks: ['local'] },
@@ -476,13 +608,11 @@ describe('CallRecorder', () => {
     });
 
     it('ignores empty _setCallReportId and keeps the context value', async () => {
-      const fetchImpl = jest
-        .fn()
-        .mockResolvedValue({
-          ok: true,
-          status: 200,
-          text: () => Promise.resolve(''),
-        });
+      const fetchImpl = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve(''),
+      });
 
       const recorder = makeRecorder(
         { flushIntervalMs: 100_000, tracks: ['local'] },
@@ -504,13 +634,11 @@ describe('CallRecorder', () => {
 
   describe('cleanup', () => {
     it('is idempotent and clears the timer', () => {
-      const fetchImpl = jest
-        .fn()
-        .mockResolvedValue({
-          ok: true,
-          status: 200,
-          text: () => Promise.resolve(''),
-        });
+      const fetchImpl = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve(''),
+      });
       const recorder = makeRecorder({ flushIntervalMs: 10 }, fetchImpl);
       recorder.start(fakeAudioTrack(), fakeAudioTrack());
 
@@ -558,13 +686,11 @@ describe('CallRecorder', () => {
 
   describe('endpoint resolution', () => {
     it('converts ws/wss host to http/https endpoint', async () => {
-      const fetchImpl = jest
-        .fn()
-        .mockResolvedValue({
-          ok: true,
-          status: 200,
-          text: () => Promise.resolve(''),
-        });
+      const fetchImpl = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve(''),
+      });
       const recorder = makeRecorder({ flushIntervalMs: 100_000 }, fetchImpl, {
         host: 'wss://example.fs.telnyx',
       });
@@ -578,13 +704,11 @@ describe('CallRecorder', () => {
     });
 
     it('honors a custom endpoint path', async () => {
-      const fetchImpl = jest
-        .fn()
-        .mockResolvedValue({
-          ok: true,
-          status: 200,
-          text: () => Promise.resolve(''),
-        });
+      const fetchImpl = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve(''),
+      });
       const recorder = makeRecorder(
         { flushIntervalMs: 100_000, endpoint: '/custom_recording' },
         fetchImpl,

--- a/packages/js/src/Modules/Verto/tests/webrtc/CallRecorder.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/CallRecorder.test.ts
@@ -520,6 +520,64 @@ describe('CallRecorder', () => {
       recorder.cleanup();
     });
 
+    it('does not set keepalive when concurrent final payloads exceed the aggregate keepalive budget', async () => {
+      // Each track is individually below the 60KB keepalive cap, but together
+      // they exceed it. Keepalive quota is shared across in-flight requests,
+      // so concurrent final uploads must disable keepalive for this batch.
+      class MediumAudioData extends FakeAudioData {
+        constructor() {
+          super(8000);
+        }
+      }
+      class MediumReadableStream extends FakeReadableStream {
+        constructor() {
+          super([new MediumAudioData()]);
+        }
+      }
+      class MediumMSTP extends FakeMediaStreamTrackProcessor {
+        constructor() {
+          super({ track: {} as MediaStreamTrack });
+          this.readable = new MediumReadableStream();
+        }
+      }
+      (
+        globalThis as { MediaStreamTrackProcessor?: unknown }
+      ).MediaStreamTrackProcessor = MediumMSTP as unknown;
+
+      const fetchImpl = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve(''),
+      });
+
+      const recorder = makeRecorder(
+        {
+          flushIntervalMs: 100_000,
+          maxBufferBytes: 200_000,
+          tracks: ['local', 'remote'],
+        },
+        fetchImpl
+      );
+      recorder.start(fakeAudioTrack(), fakeAudioTrack());
+      await flushMicrotasks();
+      recorder.stop();
+
+      await recorder.postFinalReport();
+
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+      const calls = fetchImpl.mock.calls.map((c) => ({
+        keepalive: c[1].keepalive,
+        bodyLength: c[1].body.length,
+      }));
+      expect(calls.every((c) => c.bodyLength < 60 * 1024)).toBe(true);
+      expect(calls.reduce((sum, c) => sum + c.bodyLength, 0)).toBeGreaterThan(
+        60 * 1024
+      );
+      expect(calls.every((c) => c.keepalive === undefined)).toBe(true);
+
+      recorder.cleanup();
+    });
+
     it('does not set keepalive for large final payloads', async () => {
       // Large frames + small cap still produces a payload, but force the body
       // over 60KB by lowering nothing — instead use a cap that keeps a few

--- a/packages/js/src/Modules/Verto/webrtc/CallRecorder.ts
+++ b/packages/js/src/Modules/Verto/webrtc/CallRecorder.ts
@@ -378,28 +378,44 @@ export class CallRecorder {
       'remote',
     ]) as RecordingTrackKind[];
 
+    const startedAt = this._startedAt;
+    const endedAt = this._endedAt || new Date();
+    const finalUploads = tracks.flatMap((track) => {
+      const packets = this._drain(track);
+      if (packets.length === 0) {
+        return [];
+      }
+      const envelope = this._buildEnvelope(
+        packets,
+        track,
+        'final',
+        startedAt,
+        endedAt
+      );
+      return [{ envelope, bodyBytes: JSON.stringify(envelope).length }];
+    });
+
     // Post tracks concurrently. Serializing them made the last track (always
     // `remote`) start only after the first finished uploading — multi-MB final
     // segments regularly take longer than BaseSession's 10s upload drain, so
     // the remote segment was abandoned before its POST was ever issued.
+    //
+    // Keepalive has a browser-wide in-flight body quota (~64 KiB). Since these
+    // final uploads are concurrent, the decision must be per batch, not per
+    // request; two individually-small final segments can otherwise exceed the
+    // aggregate quota and drop one track before it is sent.
+    const finalKeepaliveBodyBytes = finalUploads.reduce(
+      (total, upload) => total + upload.bodyBytes,
+      0
+    );
+    const useFinalKeepalive =
+      finalKeepaliveBodyBytes <= CallRecorder.KEEPALIVE_BODY_LIMIT_BYTES;
+
     // allSettled (not all) so one track's failure cannot cancel the other.
-    const startedAt = this._startedAt;
-    const endedAt = this._endedAt || new Date();
     const results = await Promise.allSettled(
-      tracks.map((track) => {
-        const packets = this._drain(track);
-        if (packets.length === 0) {
-          return Promise.resolve();
-        }
-        const envelope = this._buildEnvelope(
-          packets,
-          track,
-          'final',
-          startedAt,
-          endedAt
-        );
-        return this._postRecording(endpoint, envelope, true);
-      })
+      finalUploads.map(({ envelope }) =>
+        this._postRecording(endpoint, envelope, useFinalKeepalive)
+      )
     );
 
     // Surface the first failure so BaseCall can log it, having attempted all.
@@ -803,14 +819,13 @@ export class CallRecorder {
   }
 
   /**
-   * POST a recording envelope with retry + keepalive, mirroring
-   * CallReportCollector._sendPayload. `isFinal` controls keepalive for small
-   * payloads. Throws on exhaustion.
+   * POST a recording envelope with retry + optional keepalive, mirroring
+   * CallReportCollector._sendPayload. Throws on exhaustion.
    */
   private async _postRecording(
     endpoint: string,
     envelope: ICallRecordingEnvelope,
-    isFinal: boolean
+    useKeepalive: boolean
   ): Promise<void> {
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
@@ -822,8 +837,8 @@ export class CallRecorder {
     }
 
     const body = JSON.stringify(envelope);
-    const useKeepalive =
-      isFinal && body.length <= CallRecorder.KEEPALIVE_BODY_LIMIT_BYTES;
+    const shouldUseKeepalive =
+      useKeepalive && body.length <= CallRecorder.KEEPALIVE_BODY_LIMIT_BYTES;
     const fetchImpl = this.options.fetchImpl || fetch;
 
     let lastError: unknown;
@@ -838,7 +853,7 @@ export class CallRecorder {
           method: 'POST',
           headers,
           body,
-          ...(useKeepalive ? { keepalive: true } : {}),
+          ...(shouldUseKeepalive ? { keepalive: true } : {}),
         });
         if (!response.ok) {
           const errorText = await response.text().catch(() => '');

--- a/packages/js/src/Modules/Verto/webrtc/CallRecorder.ts
+++ b/packages/js/src/Modules/Verto/webrtc/CallRecorder.ts
@@ -225,8 +225,16 @@ export class CallRecorder {
   private _startedAt: Date | null = null;
   /** Recording end timestamp (set on final flush). */
   private _endedAt: Date | null = null;
-  /** Throttle: only log RECORDING_BUFFER_OVERFLOW once per flush window. */
-  private _overflowWarnedThisWindow: boolean = false;
+  /**
+   * Throttle: only log RECORDING_BUFFER_OVERFLOW once per track per flush
+   * window. Per-track (not a single shared flag) so an overflow on `local`
+   * cannot mask a concurrent overflow on `remote` — operators need to know
+   * which tracks actually lost packets.
+   */
+  private _overflowWarnedThisWindow: Record<RecordingTrackKind, boolean> = {
+    local: false,
+    remote: false,
+  };
 
   /** Callback invoked when a quality warning should be surfaced. */
   public onWarning: ((warning: ITelnyxWarning) => void) | null = null;
@@ -236,6 +244,10 @@ export class CallRecorder {
   private static readonly KEEPALIVE_BODY_LIMIT_BYTES = 60 * 1024;
   /** Per-packet overhead estimate (envelope JSON keys ~120B + RTP header). */
   private static readonly PACKET_OVERHEAD_BYTES = 160;
+  /** Bytes per PCM sample on the wire (Float32). */
+  private static readonly BYTES_PER_SAMPLE = 4;
+  /** AudioData frames delivered per second (~10ms frames). */
+  private static readonly FRAMES_PER_SECOND = 100;
 
   constructor(
     options: ICallRecordingOptions,
@@ -366,19 +378,36 @@ export class CallRecorder {
       'remote',
     ]) as RecordingTrackKind[];
 
-    for (const track of tracks) {
-      const packets = this._drain(track);
-      if (packets.length === 0) {
-        continue;
-      }
-      const envelope = this._buildEnvelope(
-        packets,
-        track,
-        'final',
-        this._startedAt,
-        this._endedAt || new Date()
-      );
-      await this._postRecording(endpoint, envelope, true);
+    // Post tracks concurrently. Serializing them made the last track (always
+    // `remote`) start only after the first finished uploading — multi-MB final
+    // segments regularly take longer than BaseSession's 10s upload drain, so
+    // the remote segment was abandoned before its POST was ever issued.
+    // allSettled (not all) so one track's failure cannot cancel the other.
+    const startedAt = this._startedAt;
+    const endedAt = this._endedAt || new Date();
+    const results = await Promise.allSettled(
+      tracks.map((track) => {
+        const packets = this._drain(track);
+        if (packets.length === 0) {
+          return Promise.resolve();
+        }
+        const envelope = this._buildEnvelope(
+          packets,
+          track,
+          'final',
+          startedAt,
+          endedAt
+        );
+        return this._postRecording(endpoint, envelope, true);
+      })
+    );
+
+    // Surface the first failure so BaseCall can log it, having attempted all.
+    const rejected = results.find(
+      (r): r is PromiseRejectedResult => r.status === 'rejected'
+    );
+    if (rejected) {
+      throw rejected.reason;
     }
   }
 
@@ -522,8 +551,8 @@ export class CallRecorder {
             dropped.payloadBytes.length + CallRecorder.PACKET_OVERHEAD_BYTES;
         }
       }
-      if (!this._overflowWarnedThisWindow) {
-        this._overflowWarnedThisWindow = true;
+      if (!this._overflowWarnedThisWindow[track]) {
+        this._overflowWarnedThisWindow[track] = true;
         logger.warn('CallRecorder: buffer overflow — oldest packets dropped', {
           track,
         });
@@ -534,10 +563,34 @@ export class CallRecorder {
 
   // ── Internal: flush ─────────────────────────────────────────────────
 
+  /**
+   * Flush cadence, clamped so a flush always happens before the ring buffer
+   * can fill. An interval longer than the buffer's fill time means the oldest
+   * packets are evicted before they are ever uploaded, silently punching holes
+   * in the recording. 0 (or negative) disables time-based flushes entirely and
+   * is passed through untouched — that is an explicit "final flush only" opt-in.
+   */
   private _flushIntervalMs(): number {
-    return (
-      this.options.flushIntervalMs ?? DEFAULT_CALL_RECORDING_FLUSH_INTERVAL_MS
-    );
+    const configured =
+      this.options.flushIntervalMs ?? DEFAULT_CALL_RECORDING_FLUSH_INTERVAL_MS;
+    if (configured <= 0) {
+      return configured;
+    }
+    return Math.min(configured, this._maxSafeFlushIntervalMs());
+  }
+
+  /**
+   * Time (ms) to fill half the ring buffer at the current capture rate. Each
+   * ~10ms AudioData frame yields (sampleRate / 100) Float32 samples plus
+   * PACKET_OVERHEAD_BYTES, so the rate is (sampleRate * 4) + (100 * overhead)
+   * bytes/sec per track. Half, not all, to leave headroom for a flush that is
+   * still uploading when the next one is due.
+   */
+  private _maxSafeFlushIntervalMs(): number {
+    const bytesPerSecond =
+      this._sampleRate() * CallRecorder.BYTES_PER_SAMPLE +
+      CallRecorder.FRAMES_PER_SECOND * CallRecorder.PACKET_OVERHEAD_BYTES;
+    return Math.max(1000, (this._maxBufferBytes() / bytesPerSecond) * 500);
   }
 
   private _maxBufferBytes(): number {
@@ -608,22 +661,33 @@ export class CallRecorder {
       ]) as RecordingTrackKind[];
       const windowStart = this._startedAt || new Date();
       const windowEnd = new Date();
-      for (const track of tracks) {
-        const packets = this._drain(track);
-        if (packets.length === 0) {
-          continue;
-        }
-        const envelope = this._buildEnvelope(
-          packets,
-          track,
-          'intermediate',
-          windowStart,
-          windowEnd
-        );
-        await this._postRecording(endpoint, envelope, false);
-      }
-      // New flush window — allow overflow warning to fire again.
-      this._overflowWarnedThisWindow = false;
+      // Concurrent for the same reason as postFinalReport: serialized posts
+      // let one slow track delay the next flush window for every other track.
+      await Promise.allSettled(
+        tracks.map((track) => {
+          const packets = this._drain(track);
+          if (packets.length === 0) {
+            return Promise.resolve();
+          }
+          const envelope = this._buildEnvelope(
+            packets,
+            track,
+            'intermediate',
+            windowStart,
+            windowEnd
+          );
+          return this._postRecording(endpoint, envelope, false).catch((err) => {
+            // Intermediate flushes are best-effort; the packets are already
+            // drained, so log and let the recording continue with the tail.
+            logger.error('CallRecorder: intermediate flush failed', {
+              track,
+              error: err,
+            });
+          });
+        })
+      );
+      // New flush window — allow overflow warnings to fire again.
+      this._overflowWarnedThisWindow = { local: false, remote: false };
     } finally {
       this._flushing = false;
     }

--- a/packages/js/src/Modules/Verto/webrtc/constants.ts
+++ b/packages/js/src/Modules/Verto/webrtc/constants.ts
@@ -54,9 +54,17 @@ export const ERROR_TYPE = {
  * The recorder POSTs buffered RTP packets to /call_recording on this cadence
  * so long calls do not buffer unbounded packet data in memory. A final flush
  * at end of call submits the tail.
- * @default 240000 (4 minutes)
+ *
+ * This must stay well below the time it takes to fill
+ * `DEFAULT_CALL_RECORDING_MAX_BUFFER_BYTES`, or every call long enough to fill
+ * the buffer drops packets before the first flush ever runs. At 48 kHz the
+ * capture rate is ~208 KB/s per track, so an 8 MB buffer fills in ~38s — the
+ * previous 4-minute default meant no call over ~38s recorded cleanly.
+ * `CallRecorder` additionally clamps this at runtime against the configured
+ * buffer size and sample rate.
+ * @default 15000 (15 seconds)
  */
-export const DEFAULT_CALL_RECORDING_FLUSH_INTERVAL_MS = 240_000;
+export const DEFAULT_CALL_RECORDING_FLUSH_INTERVAL_MS = 15_000;
 
 /**
  * Default hard cap (bytes) on the in-memory call-recording packet buffer.


### PR DESCRIPTION
Closes VSDK-453.

## Problem

The `remote` track's final recording segment is never uploaded — every recording produced since VSDK-279 landed is effectively one-sided.

From a real call (SDK v2.27.6, call_id `6d058d33-9865-45f1-a0f0-096ee80f07e6`):

```
16:15:47.119 - CallRecorder: started {tracksAttached: 2, flushIntervalMs: 240000, maxBufferBytes: 8000000}
16:16:25.579 - CallRecorder: buffer overflow — oldest packets dropped {track: 'local'}
16:16:42.086 - CallRecorder: stopped {packetsBuffered: 7692}
16:16:54.264 - CallRecorder: posted {track: 'local', segment: 'final', attempt: 1, status: 202, packets: 3846}
```

7692 = 2 × 3846, so the `remote` buffer held a full 3846 packets that were never sent.

## Root cause

`postFinalReport()` posted tracks in a sequential `for` loop with an `await` per track, so `remote` always started only after `local` finished. That `local` POST took **12.2s** on `attempt: 1` — pure upload time, no retries — while `BaseSession._drainCallReportUploads()` caps the wait at `CALL_REPORT_UPLOAD_DRAIN_TIMEOUT_MS = 10000`. The drain window closed ~2s *before* the first track even finished, so on any real teardown the remote POST was abandoned before being issued.

`keepalive` doesn't help: it's only set when the body is ≤ 60KB, and final segments are multiple MB.

## Changes

- **`postFinalReport` / `_periodicFlush`**: post all tracks concurrently via `Promise.allSettled`, so one track can neither delay nor cancel another. `postFinalReport` still rethrows the first failure *after* attempting every track, so `BaseCall`'s error logging is unchanged — but a `local` failure no longer silently skips `remote` (it previously aborted the loop).
- **`DEFAULT_CALL_RECORDING_FLUSH_INTERVAL_MS`: 240000 → 15000.** At 48kHz the capture rate is ~208 KB/s per track, so the 8MB buffer fills in ~38s. The 4-minute default meant **no call longer than ~38s recorded cleanly** — that is exactly the `RECORDING_BUFFER_OVERFLOW` above, which fired 38.46s after start. The two defaults were mutually inconsistent.
- **`_flushIntervalMs` clamp**: bound the configured interval to half the buffer's fill time, derived from `maxBufferBytes` and `sampleRate`, so a custom `flushIntervalMs`/`maxBufferBytes` pair can't reintroduce the same silent packet loss. `0` still disables timed flushes.
- **`_overflowWarnedThisWindow` is now per-track.** It was a single shared flag, so the `local` overflow above masked a concurrent `remote` overflow — both buffers were at cap, but only one was reported.

## Verification

`packages/js` — 668 tests pass, `tsc --noEmit` and eslint clean. Six new tests:

- final flush issues `remote` while `local` is still in flight (fails against the old sequential loop)
- `remote` is still posted when `local` fails outright
- flush interval is clamped when it outlives buffer fill time / left alone when already safe / `0` passes through
- overflow warning throttles once *per track*, not globally

## Not in this PR

The payload is raw Float32 PCM base64'd into JSON (~277 KB/s/track on the wire), which is why the upload can exceed the drain window at all. Moving to Int16 (or a binary body) halves-or-better that, but it changes the wire format and needs to land with the `.pcap` writer in voice-sdk-debug — tracked separately on VSDK-453's follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)