### PR TITLE
feat(js): add switchRegion() for runtime region switching

### DIFF
--- a/packages/js/src/Modules/Verto/BaseSession.ts
+++ b/packages/js/src/Modules/Verto/BaseSession.ts
@@ -25,7 +25,9 @@ import {
   RECONNECTION_EXHAUSTED,
   RECONNECTION_FAILED_WITH_NO_AUTO_RECONNECT,
   WS_CLOSE_CODES,
+  SUPPORTED_REGIONS,
 } from './util/constants';
+import type { SupportedRegion } from './util/constants';
 import {
   createTelnyxError,
   createTelnyxWarning,
@@ -502,6 +504,96 @@ export default abstract class BaseSession {
       this.connection.connect();
     }
     logger.debug('Connect method called. Connection initiated.');
+  }
+
+  /**
+   * Switch the signaling connection to a different regional endpoint.
+   *
+   * This updates the session's `region` option, recomputes the WebSocket
+   * host to use the regional subdomain (e.g. `eu` → `wss://eu.rtc.telnyx.com`),
+   * closes the current WebSocket, and re-establishes the connection.
+   *
+   * Active calls are **not** automatically terminated — the caller is
+   * responsible for hanging up active calls before switching regions if
+   * that is desired. If there are active calls, a `telnyx.warning` event
+   * is emitted with code `36008` (`REGION_SWITCH_WITH_ACTIVE_CALLS`)
+   * but the switch proceeds.
+   *
+   * @param region - One of the supported regions: `'us-east'`, `'us-central'`,
+   *   `'us-west'`, `'ca-central'`, `'eu'`, `'apac'`.
+   *   Pass `null` to revert to the default anycast endpoint.
+   * @throws {Error} if `region` is not a supported region.
+   *
+   * @examples
+   *
+   * ```js
+   * // Pin connection to Europe
+   * client.switchRegion('eu');
+   *
+   * // Revert to default anycast routing
+   * client.switchRegion(null);
+   * ```
+   */
+  public switchRegion(region: SupportedRegion | null): void {
+    if (region !== null && !SUPPORTED_REGIONS.includes(region)) {
+      throw new Error(
+        `Unsupported region "${region}". Supported regions: ${SUPPORTED_REGIONS.join(', ')}`
+      );
+    }
+
+    logger.info(`Switching region to: ${region ?? 'default (anycast)'}`, {
+      currentRegion: this.options.region ?? 'default',
+      activeCalls: this.hasActiveCall(),
+    });
+
+    // Warn if there are active calls during the switch.
+    if (this.hasActiveCall()) {
+      const warning = createTelnyxWarning(36008);
+      trigger(
+        SwEvent.Warning,
+        {
+          warning,
+          region,
+          currentRegion: this.options.region ?? null,
+          sessionId: this.sessionid,
+        },
+        this.uuid
+      );
+    }
+
+    // Update the session option so reconnects use the new region.
+    this.options.region = region ?? undefined;
+
+    // Recompute the Connection host for the new region.
+    if (this.connection) {
+      this.connection.setRegion(region);
+    }
+
+    // Close the current WebSocket and reconnect to the new regional endpoint.
+    this._closeConnection();
+
+    // Reset reconnect state for the fresh connection.
+    this._autoReconnect = true;
+    this._reconnectAttempts = 0;
+    this._reconnectCountedGeneration = -1;
+
+    // Re-attach listeners (they were detached during _closeConnection path
+    // via onNetworkClose → deRegisterAll, but _closeConnection itself
+    // does not detach socket listeners; re-attach to be safe).
+    this._attachListeners();
+
+    // Re-create the Connection if it was null or to ensure clean state.
+    if (!this.connection) {
+      this.connection = new Connection(this);
+    }
+
+    // Initiate connection to the new region.
+    this.connection.connect();
+
+    logger.debug('Region switch initiated', {
+      newHost: this.connection.host,
+      region: region ?? 'default',
+    });
   }
 
   /**

--- a/packages/js/src/Modules/Verto/services/Connection.ts
+++ b/packages/js/src/Modules/Verto/services/Connection.ts
@@ -143,6 +143,37 @@ export default class Connection {
     return this._host;
   }
 
+  /**
+   * Recompute `_host` for a different region.
+   *
+   * If the current host is a Telnyx default (`rtc.telnyx.com` or
+   * `rtcdev.telnyx.com`), the region is applied as a subdomain prefix
+   * (e.g. `eu` → `eu.rtc.telnyx.com`). If the user supplied a custom
+   * `host` option, we update `session.options.region` but leave the
+   * custom host unchanged — the caller is responsible for their own
+   * DNS / host configuration in that case.
+   *
+   * @param region - Regional prefix (e.g. `eu`, `apac`, `us-east`).
+   *   Pass `null` to revert to the default anycast host.
+   */
+  setRegion(region: string | null): void {
+    if (region === null) {
+      // Revert to the default host (respecting env).
+      const { env } = this.session.options;
+      this._host = env === 'development' ? DEV_HOST : PROD_HOST;
+      return;
+    }
+
+    // Replace the `rtc` or `rtcdev` segment with `<region>.rtc` / `<region>.rtcdev`.
+    // Handles both the default anycast host (`wss://rtc.telnyx.com`) and a
+    // previously-switched regional host (`wss://eu.rtc.telnyx.com`) by
+    // optionally consuming an existing regional subdomain prefix.
+    this._host = this._host.replace(
+      /(https?|wss?):\/\/(?:[a-z-]+\.)?rtc(dev)?\./,
+      `$1://${region}.rtc$2.`
+    );
+  }
+
   connect() {
     logger.debug('Connection.connect() called', {
       host: this._host,

--- a/packages/js/src/Modules/Verto/services/__mocks__/Connection.ts
+++ b/packages/js/src/Modules/Verto/services/__mocks__/Connection.ts
@@ -1,29 +1,37 @@
 import { destructResponse } from '../../util/helpers';
 
-export const mockResponse = jest.fn((): { result: {}; error?: string } => ({
+export const mockResponse = jest.fn((): { result: object; error?: string } => ({
   result: { message: 'fake' },
 }));
 
-export const mockSendRawText = jest.fn((str: string) => {});
-
-export const mockSend = jest.fn((bladeObj: any) => {
-  const { request } = bladeObj;
-  return new Promise((resolve, reject) => {
-    if (!request.hasOwnProperty('result')) {
-      const response = mockResponse();
-      const { result, error } = destructResponse(response);
-      return error ? reject(error) : resolve(result);
-    } else {
-      resolve('');
-    }
-  });
-});
+export const mockSendRawText = jest.fn();
+export const mockSend = jest.fn(
+  (bladeObj: { request: Record<string, unknown> }) => {
+    const { request } = bladeObj;
+    return new Promise((resolve, reject) => {
+      if (!request.hasOwnProperty('result')) {
+        const response = mockResponse();
+        const { result, error } = destructResponse(response);
+        return error ? reject(error) : resolve(result);
+      } else {
+        resolve('');
+      }
+    });
+  }
+);
 
 export const mockClose = jest.fn();
 export const mockConnect = jest.fn();
+export const mockSetRegion = jest.fn();
 
 export const connected = jest.fn().mockReturnValue(true);
 export const isAlive = jest.fn().mockReturnValue(true);
+
+let mockHostValue = 'wss://rtc.telnyx.com';
+export const mockHost = jest.fn().mockImplementation(() => mockHostValue);
+export const setMockHost = (h: string) => {
+  mockHostValue = h;
+};
 
 const mock = jest.fn().mockImplementation(() => {
   const mocked = {
@@ -31,12 +39,20 @@ const mock = jest.fn().mockImplementation(() => {
     send: mockSend,
     close: mockClose,
     connect: mockConnect,
+    setRegion: mockSetRegion,
   };
   Object.defineProperty(mocked, 'connected', {
     get: () => connected(),
   });
   Object.defineProperty(mocked, 'isAlive', {
     get: () => isAlive(),
+  });
+  Object.defineProperty(mocked, 'host', {
+    get: () => mockHost(),
+    set: (val: string) => {
+      mockHostValue = val;
+    },
+    configurable: true,
   });
   return mocked;
 });

--- a/packages/js/src/Modules/Verto/tests/SwitchRegion.test.ts
+++ b/packages/js/src/Modules/Verto/tests/SwitchRegion.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Unit tests for switchRegion() — client method to switch the signaling
+ * connection to a different regional rtc.telnyx.com endpoint.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+jest.mock('../services/Connection');
+jest.mock('../util/logger');
+jest.mock('../util/reconnect', () => ({
+  getReconnectToken: jest.fn(() => null),
+  setReconnectToken: jest.fn(),
+  clearReconnectToken: jest.fn(),
+  getReconnectSessionId: jest.fn(() => null),
+  setReconnectSessionId: jest.fn(),
+  isReconnectSessionIdFresh: jest.fn(() => false),
+  getActiveCallsRecoveryMarker: jest.fn(() => null),
+  setActiveCallsRecoveryMarker: jest.fn(),
+  clearActiveCallsRecoveryMarker: jest.fn(),
+  RECONNECT_SESSION_ID_MAX_AGE_MS: 90000,
+}));
+
+import Verto from '..';
+import { IVertoOptions } from '../util/interfaces';
+import { SUPPORTED_REGIONS } from '../util/constants';
+import { trigger } from '../services/Handler';
+
+jest.mock('../services/Handler', () => ({
+  trigger: jest.fn(),
+  register: jest.fn(),
+  deRegister: jest.fn(),
+  deRegisterAll: jest.fn(),
+  registerOnce: jest.fn(),
+  isQueued: jest.fn(),
+}));
+
+// Access the mock via require (same pattern as Verto.test.ts)
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const Connection = require('../services/Connection');
+
+describe('switchRegion', () => {
+  const _buildInstance = (props: IVertoOptions): Verto => {
+    const instance: Verto = new Verto(props);
+    instance.connection = Connection.default();
+    return instance;
+  };
+
+  let instance: Verto;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Connection.mockClose.mockClear();
+    Connection.mockConnect.mockClear();
+    Connection.mockSetRegion.mockClear();
+    Connection.default.mockClear();
+    Connection.mockHost.mockImplementation(() => 'wss://rtc.telnyx.com');
+    instance = _buildInstance({
+      login: 'login',
+      password: 'password',
+    });
+  });
+
+  describe('validation', () => {
+    it('throws on an unsupported region string', () => {
+      expect(() => instance.switchRegion('mars' as any)).toThrow(
+        /Unsupported region "mars"/
+      );
+    });
+
+    it('does NOT throw for null (revert to anycast)', () => {
+      expect(() => instance.switchRegion(null)).not.toThrow();
+    });
+
+    it.each(SUPPORTED_REGIONS)('accepts supported region "%s"', (region) => {
+      expect(() => instance.switchRegion(region as any)).not.toThrow();
+    });
+  });
+
+  describe('option and host updates', () => {
+    it('updates session.options.region to the new region', () => {
+      instance.switchRegion('eu' as any);
+
+      expect(instance.options.region).toBe('eu');
+    });
+
+    it('clears session.options.region when null is passed', () => {
+      instance.options.region = 'eu';
+      instance.switchRegion(null);
+
+      expect(instance.options.region).toBeUndefined();
+    });
+
+    it('calls connection.setRegion with the new region', () => {
+      instance.switchRegion('apac' as any);
+
+      expect(Connection.mockSetRegion).toHaveBeenCalledWith('apac');
+    });
+
+    it('calls connection.setRegion with null when reverting', () => {
+      instance.switchRegion(null);
+
+      expect(Connection.mockSetRegion).toHaveBeenCalledWith(null);
+    });
+  });
+
+  describe('connection lifecycle', () => {
+    it('closes the current connection before reconnecting', () => {
+      instance.switchRegion('eu' as any);
+
+      // _closeConnection calls connection.close()
+      expect(Connection.mockClose).toHaveBeenCalled();
+    });
+
+    it('initiates a new connection to the new region', () => {
+      instance.switchRegion('eu' as any);
+
+      expect(Connection.mockConnect).toHaveBeenCalled();
+    });
+
+    it('resets _autoReconnect to true', () => {
+      // Disable auto-reconnect by calling disconnect
+      instance.disconnect();
+      // Now switchRegion should re-enable it
+      instance.switchRegion('eu' as any);
+
+      // After switchRegion, _autoReconnect should be true (indirectly
+      // verified by the fact that connect was called, which only
+      // proceeds when autoReconnect is reset or connection is not alive)
+      expect(Connection.mockConnect).toHaveBeenCalled();
+    });
+
+    it('resets reconnect attempts to 0', () => {
+      // Access the private field to verify
+      (instance as any)._reconnectAttempts = 5;
+
+      instance.switchRegion('eu' as any);
+
+      expect((instance as any)._reconnectAttempts).toBe(0);
+    });
+  });
+
+  describe('active calls warning', () => {
+    it('emits a telnyx.warning (36008) when active calls exist', () => {
+      // Mock hasActiveCall to return true
+      jest.spyOn(instance, 'hasActiveCall').mockReturnValue(true);
+
+      instance.switchRegion('eu' as any);
+
+      const warningCalls = (trigger as jest.Mock).mock.calls.filter(
+        (c: any[]) => c[0] === 'telnyx.warning'
+      );
+      expect(warningCalls.length).toBeGreaterThanOrEqual(1);
+
+      const payload = warningCalls[0][1];
+      expect(payload.warning.code).toBe(36008);
+      expect(payload.warning.name).toBe('REGION_SWITCH_WITH_ACTIVE_CALLS');
+      expect(payload.region).toBe('eu');
+    });
+
+    it('does NOT emit a region-switch warning when no active calls', () => {
+      jest.spyOn(instance, 'hasActiveCall').mockReturnValue(false);
+
+      instance.switchRegion('eu' as any);
+
+      const warningCalls = (trigger as jest.Mock).mock.calls.filter(
+        (c: any[]) => c[0] === 'telnyx.warning' && c[1]?.warning?.code === 36008
+      );
+      expect(warningCalls).toHaveLength(0);
+    });
+  });
+
+  describe('switching from a region to another region', () => {
+    it('can switch from eu to apac', () => {
+      instance.options.region = 'eu';
+      Connection.mockHost.mockImplementation(() => 'wss://eu.rtc.telnyx.com');
+
+      instance.switchRegion('apac' as any);
+
+      expect(instance.options.region).toBe('apac');
+      expect(Connection.mockSetRegion).toHaveBeenCalledWith('apac');
+      expect(Connection.mockConnect).toHaveBeenCalled();
+    });
+
+    it('can switch from a region back to anycast (null)', () => {
+      instance.options.region = 'us-east';
+      Connection.mockHost.mockImplementation(
+        () => 'wss://us-east.rtc.telnyx.com'
+      );
+
+      instance.switchRegion(null);
+
+      expect(instance.options.region).toBeUndefined();
+      expect(Connection.mockSetRegion).toHaveBeenCalledWith(null);
+      expect(Connection.mockConnect).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/js/src/Modules/Verto/tests/services/Connection.test.ts
+++ b/packages/js/src/Modules/Verto/tests/services/Connection.test.ts
@@ -831,3 +831,85 @@ describe('Connection - VSDK-318 WEBSOCKET_CONNECTION_FAILED teardown', () => {
     expect(mockSession._terminateActiveCallsLocally).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('Connection - setRegion()', () => {
+  let connection: Connection;
+  let mockSession: any;
+
+  beforeAll(() => {
+    setWebSocket(MockWebSocket as any);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+
+    mockSession = {
+      uuid: 'setregion-uuid',
+      sessionid: 'setregion-session',
+      callReportVoiceSdkId: null,
+      options: {
+        login: 'test-login',
+        password: 'test-password',
+      },
+    };
+
+    connection = new Connection(mockSession);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('recomputes host with the regional subdomain prefix', () => {
+    // Default host is wss://rtc.telnyx.com
+    expect(connection.host).toBe('wss://rtc.telnyx.com');
+
+    connection.setRegion('eu');
+
+    expect(connection.host).toBe('wss://eu.rtc.telnyx.com');
+  });
+
+  it('handles multi-part regions like us-east', () => {
+    connection.setRegion('us-east');
+
+    expect(connection.host).toBe('wss://us-east.rtc.telnyx.com');
+  });
+
+  it('handles apac region', () => {
+    connection.setRegion('apac');
+
+    expect(connection.host).toBe('wss://apac.rtc.telnyx.com');
+  });
+
+  it('reverts to default host when null is passed', () => {
+    // First switch to eu
+    connection.setRegion('eu');
+    expect(connection.host).toBe('wss://eu.rtc.telnyx.com');
+
+    // Revert
+    connection.setRegion(null);
+    expect(connection.host).toBe('wss://rtc.telnyx.com');
+  });
+
+  it('respects development env when reverting', () => {
+    mockSession.options.env = 'development';
+    connection = new Connection(mockSession);
+    // Dev host is wss://rtcdev.telnyx.com
+    expect(connection.host).toBe('wss://rtcdev.telnyx.com');
+
+    connection.setRegion('eu');
+    expect(connection.host).toBe('wss://eu.rtcdev.telnyx.com');
+
+    connection.setRegion(null);
+    expect(connection.host).toBe('wss://rtcdev.telnyx.com');
+  });
+
+  it('can switch from one region to another', () => {
+    connection.setRegion('eu');
+    expect(connection.host).toBe('wss://eu.rtc.telnyx.com');
+
+    connection.setRegion('apac');
+    expect(connection.host).toBe('wss://apac.rtc.telnyx.com');
+  });
+});

--- a/packages/js/src/Modules/Verto/util/constants/index.ts
+++ b/packages/js/src/Modules/Verto/util/constants/index.ts
@@ -8,6 +8,25 @@ export const PROD_HOST = 'wss://rtc.telnyx.com';
 export const DEV_HOST = 'wss://rtcdev.telnyx.com';
 
 /**
+ * Supported regional signaling endpoints for `rtc.telnyx.com`.
+ *
+ * Each value is a subdomain prefix that replaces the `rtc` segment in the
+ * host URL (e.g. `eu` → `eu.rtc.telnyx.com`).
+ *
+ * See: docs/network-connectivity-requirements.md → "Region selection"
+ */
+export const SUPPORTED_REGIONS = [
+  'us-east',
+  'us-central',
+  'us-west',
+  'ca-central',
+  'eu',
+  'apac',
+] as const;
+
+export type SupportedRegion = (typeof SUPPORTED_REGIONS)[number];
+
+/**
  * WebSocket close status codes (RFC 6455)
  * https://www.rfc-editor.org/rfc/rfc6455.html#section-7.4.1
  */

--- a/packages/js/src/Modules/Verto/util/constants/warnings.ts
+++ b/packages/js/src/Modules/Verto/util/constants/warnings.ts
@@ -470,6 +470,22 @@ export const SDK_WARNINGS = {
       'If a call should be active, start a new call manually',
     ],
   },
+
+  // ── Region switching warnings (360xx) ───────────────────────────────
+  36008: {
+    name: 'REGION_SWITCH_WITH_ACTIVE_CALLS',
+    message: 'Region switch initiated while calls are active',
+    description:
+      'switchRegion() was called while one or more calls are in an active state. The region switch proceeds, but active calls will be disconnected when the WebSocket closes. Hang up active calls before switching regions if graceful call teardown is desired.',
+    causes: [
+      'Application called switchRegion() during an active call',
+      'Application did not hang up calls before switching regions',
+    ],
+    solutions: [
+      'Hang up active calls with call.hangup() before calling switchRegion()',
+      'If intentional, monitor telnyx.notification for call state changes after the switch',
+    ],
+  },
 } as const;
 
 export type SdkWarningCode = keyof typeof SDK_WARNINGS;

--- a/packages/js/src/TelnyxRTC.ts
+++ b/packages/js/src/TelnyxRTC.ts
@@ -8,6 +8,7 @@ import {
   IWebRTCInfo,
   IWebRTCSupportedBrowser,
 } from './Modules/Verto/webrtc/interfaces';
+import type { SupportedRegion } from './Modules/Verto/util/constants';
 import logger from './Modules/Verto/util/logger';
 
 import * as pkg from '../package.json';
@@ -244,6 +245,61 @@ export class TelnyxRTC extends TelnyxRTCClient {
    */
   newCall(options: ICallOptions) {
     return super.newCall(options);
+  }
+
+  /**
+   * Switch the signaling connection to a different regional endpoint.
+   *
+   * This closes the current WebSocket and reconnects to the specified
+   * regional `rtc.telnyx.com` subdomain. Useful when anycast DNS routes
+   * the initial connection to a suboptimal datacenter, or when the
+   * application needs to pin to a specific region for compliance or
+   * latency reasons.
+   *
+   * Active calls are **not** automatically terminated — the caller should
+   * hang up active calls before switching if graceful teardown is desired.
+   * If active calls exist, a `telnyx.warning` event (code `36008`) is
+   * emitted but the switch proceeds.
+   *
+   * @param region - One of: `'us-east'`, `'us-central'`, `'us-west'`,
+   *   `'ca-central'`, `'eu'`, `'apac'`.
+   *   Pass `null` to revert to the default anycast endpoint.
+   *
+   * @throws {Error} if `region` is not a supported region.
+   *
+   * @examples
+   *
+   * Pin the connection to Europe after initial connect:
+   *
+   * ```js
+   * const client = new TelnyxRTC({ login_token });
+   * client.connect();
+   *
+   * client.on('telnyx.ready', () => {
+   *   // Once connected, switch to EU region
+   *   client.switchRegion('eu');
+   * });
+   * ```
+   *
+   * Revert to default anycast routing:
+   *
+   * ```js
+   * client.switchRegion(null);
+   * ```
+   *
+   * Available regions and their datacenters:
+   *
+   * | Region        | Endpoint                  | Datacenters                    |
+   * |--------------|---------------------------|--------------------------------|
+   * | `us-east`    | `us-east.rtc.telnyx.com`  | AT1 (Atlanta), NJ1 (New Jersey)|
+   * | `us-central` | `us-central.rtc.telnyx.com`| CH1 (Chicago)               |
+   * | `us-west`    | `us-west.rtc.telnyx.com`  | LV1 (Las Vegas)                |
+   * | `ca-central` | `ca-central.rtc.telnyx.com`| MT1 (Montreal), TR1 (Toronto) |
+   * | `eu`         | `eu.rtc.telnyx.com`       | AMS3, FR5, LD6                 |
+   * | `apac`       | `apac.rtc.telnyx.com`     | CN1 (Chennai), SY1 (Sydney)   |
+   */
+  switchRegion(region: SupportedRegion | null): void {
+    super.switchRegion(region);
   }
 
   /**


### PR DESCRIPTION
## Summary

Add a public `switchRegion()` method to the TelnyxRTC client that allows switching the signaling WebSocket connection to a different regional `rtc.telnyx.com` endpoint at runtime.

This is useful when:
- Anycast DNS routes the initial connection to a suboptimal datacenter
- The application needs to pin to a specific region for compliance or latency reasons
- The user moves geographically and wants to reconnect to a closer datacenter

## Changes

| File | Change |
|------|--------|
| `util/constants/index.ts` | Add `SUPPORTED_REGIONS` array and `SupportedRegion` union type |
| `services/Connection.ts` | Add `setRegion(region)` to recompute the WebSocket host URL |
| `BaseSession.ts` | Add `switchRegion(region)` — validates, warns on active calls, disconnects, reconnects |
| `TelnyxRTC.ts` | Expose `switchRegion()` on the public API with JSDoc |
| `util/constants/warnings.ts` | Add warning code `36008` (`REGION_SWITCH_WITH_ACTIVE_CALLS`) |
| `services/__mocks__/Connection.ts` | Add `mockSetRegion`, `host` getter/setter to mock |
| `tests/SwitchRegion.test.ts` | 20 unit tests: validation, option updates, lifecycle, warnings, region-to-region |
| `tests/services/Connection.test.ts` | 6 tests for `Connection.setRegion()` host recomputation |

## Supported Regions

| Region | Endpoint | Datacenters |
|--------|----------|-------------|
| `us-east` | `us-east.rtc.telnyx.com` | AT1 (Atlanta), NJ1 (New Jersey) |
| `us-central` | `us-central.rtc.telnyx.com` | CH1 (Chicago) |
| `us-west` | `us-west.rtc.telnyx.com` | LV1 (Las Vegas) |
| `ca-central` | `ca-central.rtc.telnyx.com` | MT1 (Montreal), TR1 (Toronto) |
| `eu` | `eu.rtc.telnyx.com` | AMS3, FR5, LD6 |
| `apac` | `apac.rtc.telnyx.com` | CN1 (Chennai), SY1 (Sydney) |

Pass `null` to revert to the default anycast endpoint.

## Usage

```js
const client = new TelnyxRTC({ login_token });
client.connect();

client.on('telnyx.ready', () => {
  // Switch to EU region after initial connect
  client.switchRegion('eu');
});
```

## Active Calls

If `switchRegion()` is called while calls are active, a `telnyx.warning` event (code `36008`) is emitted. The switch proceeds but active calls will be disconnected when the WebSocket closes. Hang up active calls first for graceful teardown.

## Testing

- ✅ 20 new tests in `SwitchRegion.test.ts`
- ✅ 6 new tests in `Connection.test.ts`
- ✅ All 717 existing tests still pass
- ✅ TypeScript compilation clean
