### PR TITLE
feat(js): accept outbound AI conversation items

### DIFF
--- a/packages/js/CHANGELOG.md
+++ b/packages/js/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [2.27.8-beta.0](https://github.com/team-telnyx/webrtc/compare/webrtc/v2.27.7...webrtc/v2.27.8-beta.0) (2026-07-24)
+
+- docs: update ts docs
+- feat(js): accept outbound AI conversation items
+- fix: post CallRecorder tracks concurrently so the remote segment is not dropped (VSDK-453) (#746)
 ## [2.27.7](https://github.com/team-telnyx/webrtc/compare/webrtc/v2.27.6...webrtc/v2.27.7) (2026-07-22)
 
 - fix(js): suppress silence warnings and no-RTP recovery while held (VSUP-145) (#747)

--- a/packages/js/docs/ts/README.md
+++ b/packages/js/docs/ts/README.md
@@ -45,12 +45,15 @@
 
 - [AIConversationFunctionCallOutputParams](#aiconversationfunctioncalloutputparams)
 - [AIConversationFunctionCallParams](#aiconversationfunctioncallparams)
+- [AIConversationOutboundItem](#aiconversationoutbounditem)
+- [AIConversationOutboundParams](#aiconversationoutboundparams)
 - [AIConversationParams](#aiconversationparams)
 - [FunctionCallItem](#functioncallitem)
 - [FunctionCallOutputItem](#functioncalloutputitem)
 - [IAIConversationMessageEvent](#iaiconversationmessageevent)
 - [ISendAIConversationMessageOptions](#isendaiconversationmessageoptions)
 - [RecordingTrackKind](#recordingtrackkind)
+- [ResponseAudioStreamSubscribeItem](#responseaudiostreamsubscribeitem)
 
 ### Variables
 
@@ -103,12 +106,36 @@ Contains a function_call item from the backend.
 
 ---
 
+### AIConversationOutboundItem
+
+Ƭ **AIConversationOutboundItem**: [`FunctionCallOutputItem`](#functioncalloutputitem) \| [`ResponseAudioStreamSubscribeItem`](#responseaudiostreamsubscribeitem)
+
+Outbound item accepted by `conversation.item.create` over `ai_conversation`.
+
+---
+
+### AIConversationOutboundParams
+
+Ƭ **AIConversationOutboundParams**: `Object`
+
+Params for an outbound `ai_conversation` message with `params.type = "conversation.item.create"`.
+Contains any outbound item to send back to the backend.
+
+#### Type declaration
+
+| Name   | Type                                                        |
+| :----- | :---------------------------------------------------------- |
+| `item` | [`AIConversationOutboundItem`](#aiconversationoutbounditem) |
+| `type` | `"conversation.item.create"`                                |
+
+---
+
 ### AIConversationParams
 
-Ƭ **AIConversationParams**: [`AIConversationFunctionCallParams`](#aiconversationfunctioncallparams) \| [`AIConversationFunctionCallOutputParams`](#aiconversationfunctioncalloutputparams) \| \{ `[key: string]`: `unknown`; `type`: `string` }
+Ƭ **AIConversationParams**: [`AIConversationFunctionCallParams`](#aiconversationfunctioncallparams) \| [`AIConversationOutboundParams`](#aiconversationoutboundparams) \| \{ `[key: string]`: `unknown`; `type`: `string` }
 
 Generic params for any `ai_conversation` message.
-Can be a function_call (inbound) or function_call_output (outbound),
+Can be a function_call (inbound) or outbound conversation item,
 as well as other `ai_conversation` message types (transcript, etc.).
 
 ---
@@ -167,11 +194,11 @@ Represents an inbound `ai_conversation` JSON-RPC message from the backend.
 
 ### ISendAIConversationMessageOptions
 
-Ƭ **ISendAIConversationMessageOptions**: [`FunctionCallOutputItem`](#functioncalloutputitem)
+Ƭ **ISendAIConversationMessageOptions**: [`AIConversationOutboundItem`](#aiconversationoutbounditem)
 
 Argument accepted by `call.sendAIConversationMessage()`: the
-`function_call_output` item to send back to the backend. Alias of
-[FunctionCallOutputItem](#functioncalloutputitem), kept as a named export so callers can refer
+outbound item to send back to the backend. Alias of
+[AIConversationOutboundItem](#aiconversationoutbounditem), kept as a named export so callers can refer
 to the method's parameter type directly.
 
 ---
@@ -182,21 +209,43 @@ to the method's parameter type directly.
 
 Which audio track a packet belongs to.
 
+---
+
+### ResponseAudioStreamSubscribeItem
+
+Ƭ **ResponseAudioStreamSubscribeItem**: `Object`
+
+An outbound subscription item for ACA pre-playout assistant audio events.
+
+#### Type declaration
+
+| Name   | Type                                |
+| :----- | :---------------------------------- |
+| `type` | `"response.audio_stream.subscribe"` |
+
 ## Variables
 
 ### DEFAULT_CALL_RECORDING_FLUSH_INTERVAL_MS
 
-• `Const` **DEFAULT_CALL_RECORDING_FLUSH_INTERVAL_MS**: `240000`
+• `Const` **DEFAULT_CALL_RECORDING_FLUSH_INTERVAL_MS**: `15000`
 
 Default interval (ms) between intermediate call-recording flushes.
 The recorder POSTs buffered RTP packets to /call_recording on this cadence
 so long calls do not buffer unbounded packet data in memory. A final flush
 at end of call submits the tail.
 
+This must stay well below the time it takes to fill
+`DEFAULT_CALL_RECORDING_MAX_BUFFER_BYTES`, or every call long enough to fill
+the buffer drops packets before the first flush ever runs. At 48 kHz the
+capture rate is ~208 KB/s per track, so an 8 MB buffer fills in ~38s — the
+previous 4-minute default meant no call over ~38s recorded cleanly.
+`CallRecorder` additionally clamps this at runtime against the configured
+buffer size and sample rate.
+
 **`Default`**
 
 ```ts
-240000 (4 minutes)
+15000 (15 seconds)
 ```
 
 ---

--- a/packages/js/docs/ts/classes/Call.md
+++ b/packages/js/docs/ts/classes/Call.md
@@ -546,12 +546,11 @@ BaseCall.muteVideo
 
 ▸ **sendAIConversationMessage**(`item`): `void`
 
-Sends an AI conversation message (e.g. a `function_call_output`) over
-the active VSP WebSocket session.
+Sends an outbound AI conversation item over the active VSP WebSocket session.
 
 Use this to return the result of a client-side tool execution back to
 the AI backend after receiving a `function_call` via the
-`telnyx.ai.conversation` event.
+`telnyx.ai.conversation` event, or to subscribe to ACA pre-playout audio.
 
 This is a fire-and-forget JSON-RPC notification (no `id`): the backend
 is not expected to ack each tool result, and the SDK does not wait for
@@ -564,9 +563,9 @@ could deliver stale results after ACA has timed out the waiter).
 
 #### Parameters
 
-| Name   | Type                                                                                                              | Description                                                                                                                          |
-| :----- | :---------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------- |
-| `item` | [`FunctionCallOutputItem`](https://developers.telnyx.com/development/webrtc/js-sdk/readme#functioncalloutputitem) | The function call output item to send. Must include `type: "function_call_output"`, the matching `call_id`, and the `output` string. |
+| Name   | Type                                                                                                                      | Description                                                                                                                                                                                                                                                       |
+| :----- | :------------------------------------------------------------------------------------------------------------------------ | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `item` | [`AIConversationOutboundItem`](https://developers.telnyx.com/development/webrtc/js-sdk/readme#aiconversationoutbounditem) | The outbound conversation item to send. For client-side tool results, use `type: "function_call_output"` with the matching `call_id` and `output` string. For ACA pre-playout audio, use `type: "response.audio_stream.subscribe"` to subscribe to stream events. |
 
 #### Returns
 

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telnyx/webrtc",
-  "version": "2.27.7",
+  "version": "2.27.8-beta.0",
   "description": "Telnyx WebRTC Client",
   "keywords": [
     "telnyx",

--- a/packages/js/src/Modules/Verto/messages/verto/AIConversationMessage.ts
+++ b/packages/js/src/Modules/Verto/messages/verto/AIConversationMessage.ts
@@ -1,11 +1,10 @@
 import BaseMessage from '../BaseMessage';
-import type { FunctionCallOutputItem } from '../../webrtc/AIConversationTypes';
+import type { AIConversationOutboundItem } from '../../webrtc/AIConversationTypes';
 
 /**
  * Outbound ai_conversation JSON-RPC notification.
  *
- * Used to send `function_call_output` items back to the backend
- * after a client-side tool has been executed.
+ * Used to send outbound conversation items back to the backend.
  *
  * This is a JSON-RPC notification (no `id`) per the PR-531 wire protocol:
  * the backend is not required to send a response for each tool result,
@@ -28,7 +27,7 @@ import type { FunctionCallOutputItem } from '../../webrtc/AIConversationTypes';
  * ```
  */
 class AIConversationMessage extends BaseMessage {
-  constructor(item: FunctionCallOutputItem) {
+  constructor(item: AIConversationOutboundItem) {
     super();
     this.method = 'ai_conversation';
 

--- a/packages/js/src/Modules/Verto/tests/webrtc/AIConversation.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/AIConversation.test.ts
@@ -4,6 +4,7 @@ import {
   type AIConversationParams,
   type AIConversationFunctionCallParams,
   type AIConversationFunctionCallOutputParams,
+  type AIConversationOutboundItem,
 } from '../../webrtc/AIConversationTypes';
 import { AIConversationMessage } from '../../messages/verto/AIConversationMessage';
 import { SwEvent } from '../../util/constants';
@@ -118,11 +119,15 @@ describe('AIConversationTypes', () => {
     });
 
     it('should return false for null', () => {
-      expect(isFunctionCallParams(null as unknown as AIConversationParams)).toBe(false);
+      expect(
+        isFunctionCallParams(null as unknown as AIConversationParams)
+      ).toBe(false);
     });
 
     it('should return false for undefined', () => {
-      expect(isFunctionCallParams(undefined as unknown as AIConversationParams)).toBe(false);
+      expect(
+        isFunctionCallParams(undefined as unknown as AIConversationParams)
+      ).toBe(false);
     });
 
     it('should return false when item is null', () => {
@@ -130,7 +135,9 @@ describe('AIConversationTypes', () => {
         type: 'conversation.item.created',
         item: null,
       };
-      expect(isFunctionCallParams(params as unknown as AIConversationParams)).toBe(false);
+      expect(
+        isFunctionCallParams(params as unknown as AIConversationParams)
+      ).toBe(false);
     });
   });
 
@@ -169,7 +176,9 @@ describe('AIConversationTypes', () => {
           output: '{}',
         },
       };
-      expect(isFunctionCallOutputParams(params as unknown as AIConversationParams)).toBe(false);
+      expect(
+        isFunctionCallOutputParams(params as unknown as AIConversationParams)
+      ).toBe(false);
     });
 
     it('should return false when call_id is missing', () => {
@@ -180,7 +189,9 @@ describe('AIConversationTypes', () => {
           output: '{}',
         },
       };
-      expect(isFunctionCallOutputParams(params as unknown as AIConversationParams)).toBe(false);
+      expect(
+        isFunctionCallOutputParams(params as unknown as AIConversationParams)
+      ).toBe(false);
     });
 
     it('should return false when output is missing', () => {
@@ -191,7 +202,9 @@ describe('AIConversationTypes', () => {
           call_id: 'call-123',
         },
       };
-      expect(isFunctionCallOutputParams(params as unknown as AIConversationParams)).toBe(false);
+      expect(
+        isFunctionCallOutputParams(params as unknown as AIConversationParams)
+      ).toBe(false);
     });
 
     it('should return false when output is not a string', () => {
@@ -203,7 +216,9 @@ describe('AIConversationTypes', () => {
           output: 42,
         },
       };
-      expect(isFunctionCallOutputParams(params as unknown as AIConversationParams)).toBe(false);
+      expect(
+        isFunctionCallOutputParams(params as unknown as AIConversationParams)
+      ).toBe(false);
     });
   });
 
@@ -254,6 +269,25 @@ describe('AIConversationTypes', () => {
       expect(parsed.params.item.call_id).toBe('call-xyz');
       expect(parsed.params.item.output).toBe('ok');
     });
+
+    it('should accept response.audio_stream.subscribe outbound items', () => {
+      const item: AIConversationOutboundItem = {
+        type: 'response.audio_stream.subscribe',
+      };
+
+      const msg = new AIConversationMessage(item);
+
+      expect(msg.request).toBeDefined();
+      expect(msg.request.jsonrpc).toBe('2.0');
+      expect(msg.request.method).toBe('ai_conversation');
+      expect(msg.request).not.toHaveProperty('id');
+      expect(msg.request.params).toEqual({
+        type: 'conversation.item.create',
+        item: {
+          type: 'response.audio_stream.subscribe',
+        },
+      });
+    });
   });
 
   describe('Call.sendAIConversationMessage', () => {
@@ -267,7 +301,7 @@ describe('AIConversationTypes', () => {
             sentTexts.push(text);
           }),
         },
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any;
 
       // Use Call's sendAIConversationMessage logic directly
@@ -295,7 +329,9 @@ describe('AIConversationTypes', () => {
           call_id: 'call-1',
           output: 'ok',
         })
-      ).toThrow('Cannot send AI conversation message: session is not connected');
+      ).toThrow(
+        'Cannot send AI conversation message: session is not connected'
+      );
     });
 
     it('should send fire-and-forget notification when connected', () => {
@@ -330,6 +366,37 @@ describe('AIConversationTypes', () => {
       expect(sent.params.item.type).toBe('function_call_output');
       expect(sent.params.item.call_id).toBe('call-1');
       expect(sent.params.item.output).toBe('{"status": "found"}');
+    });
+
+    it('should send audio stream subscription items when connected', () => {
+      const { mockSession, sentTexts } = makeCallWithMockSession(true);
+
+      const sendAIConversationMessage = (item: AIConversationOutboundItem) => {
+        if (!mockSession.connected) {
+          throw new Error(
+            'Cannot send AI conversation message: session is not connected. ' +
+              'sendAIConversationMessage requires an active WebSocket connection.'
+          );
+        }
+        const msg = new AIConversationMessage(item);
+        mockSession.connection.sendRawText(JSON.stringify(msg.request));
+      };
+
+      sendAIConversationMessage({
+        type: 'response.audio_stream.subscribe',
+      });
+
+      expect(mockSession.connection.sendRawText).toHaveBeenCalledTimes(1);
+      const sent = JSON.parse(sentTexts[0]);
+      expect(sent.jsonrpc).toBe('2.0');
+      expect(sent.method).toBe('ai_conversation');
+      expect(sent).not.toHaveProperty('id');
+      expect(sent.params).toEqual({
+        type: 'conversation.item.create',
+        item: {
+          type: 'response.audio_stream.subscribe',
+        },
+      });
     });
 
     it('should not queue or reconnect when disconnected', () => {

--- a/packages/js/src/Modules/Verto/webrtc/AIConversationTypes.ts
+++ b/packages/js/src/Modules/Verto/webrtc/AIConversationTypes.ts
@@ -1,9 +1,10 @@
 /**
  * Types for AI conversation signaling over the VSP WebSocket.
  *
- * These types support the PR-531 client-side tool wire protocol:
+ * These types support outbound and inbound ACA conversation items:
  * - Inbound: `conversation.item.created` with `item.type = "function_call"`
  * - Outbound: `conversation.item.create` with `item.type = "function_call_output"`
+ * - Outbound: `conversation.item.create` with `item.type = "response.audio_stream.subscribe"`
  */
 
 /**
@@ -33,6 +34,20 @@ export type FunctionCallOutputItem = {
 };
 
 /**
+ * An outbound subscription item for ACA pre-playout assistant audio events.
+ */
+export type ResponseAudioStreamSubscribeItem = {
+  type: 'response.audio_stream.subscribe';
+};
+
+/**
+ * Outbound item accepted by `conversation.item.create` over `ai_conversation`.
+ */
+export type AIConversationOutboundItem =
+  | FunctionCallOutputItem
+  | ResponseAudioStreamSubscribeItem;
+
+/**
  * Params for an inbound `ai_conversation` message with `params.type = "conversation.item.created"`.
  * Contains a function_call item from the backend.
  */
@@ -51,13 +66,22 @@ export type AIConversationFunctionCallOutputParams = {
 };
 
 /**
+ * Params for an outbound `ai_conversation` message with `params.type = "conversation.item.create"`.
+ * Contains any outbound item to send back to the backend.
+ */
+export type AIConversationOutboundParams = {
+  type: 'conversation.item.create';
+  item: AIConversationOutboundItem;
+};
+
+/**
  * Generic params for any `ai_conversation` message.
- * Can be a function_call (inbound) or function_call_output (outbound),
+ * Can be a function_call (inbound) or outbound conversation item,
  * as well as other `ai_conversation` message types (transcript, etc.).
  */
 export type AIConversationParams =
   | AIConversationFunctionCallParams
-  | AIConversationFunctionCallOutputParams
+  | AIConversationOutboundParams
   | {
       type: string;
       [key: string]: unknown;
@@ -78,11 +102,11 @@ export type IAIConversationMessageEvent = {
 
 /**
  * Argument accepted by `call.sendAIConversationMessage()`: the
- * `function_call_output` item to send back to the backend. Alias of
- * {@link FunctionCallOutputItem}, kept as a named export so callers can refer
+ * outbound item to send back to the backend. Alias of
+ * {@link AIConversationOutboundItem}, kept as a named export so callers can refer
  * to the method's parameter type directly.
  */
-export type ISendAIConversationMessageOptions = FunctionCallOutputItem;
+export type ISendAIConversationMessageOptions = AIConversationOutboundItem;
 
 /**
  * Type guard: checks if an `ai_conversation` message contains a `function_call` item.

--- a/packages/js/src/Modules/Verto/webrtc/Call.ts
+++ b/packages/js/src/Modules/Verto/webrtc/Call.ts
@@ -4,7 +4,7 @@ import logger from '../util/logger';
 import { getDisplayMedia, setMediaElementSinkId } from '../util/webrtc';
 import BaseCall from './BaseCall';
 import { IVertoCallOptions } from './interfaces';
-import type { FunctionCallOutputItem } from './AIConversationTypes';
+import type { AIConversationOutboundItem } from './AIConversationTypes';
 
 /**
  * A `Call` is the representation of an audio or video call between
@@ -112,12 +112,11 @@ export class Call extends BaseCall {
   };
 
   /**
-   * Sends an AI conversation message (e.g. a `function_call_output`) over
-   * the active VSP WebSocket session.
+   * Sends an outbound AI conversation item over the active VSP WebSocket session.
    *
    * Use this to return the result of a client-side tool execution back to
    * the AI backend after receiving a `function_call` via the
-   * `telnyx.ai.conversation` event.
+   * `telnyx.ai.conversation` event, or to subscribe to ACA pre-playout audio.
    *
    * This is a fire-and-forget JSON-RPC notification (no `id`): the backend
    * is not expected to ack each tool result, and the SDK does not wait for
@@ -128,9 +127,10 @@ export class Call extends BaseCall {
    * than having the output silently queued for a future reconnect (which
    * could deliver stale results after ACA has timed out the waiter).
    *
-   * @param item - The function call output item to send.
-   * Must include `type: "function_call_output"`, the matching `call_id`,
-   * and the `output` string.
+   * @param item - The outbound conversation item to send.
+   * For client-side tool results, use `type: "function_call_output"` with
+   * the matching `call_id` and `output` string. For ACA pre-playout audio,
+   * use `type: "response.audio_stream.subscribe"` to subscribe to stream events.
    *
    * @throws {Error} If the session is not connected.
    *
@@ -150,7 +150,7 @@ export class Call extends BaseCall {
    * });
    * ```
    */
-  sendAIConversationMessage = (item: FunctionCallOutputItem) => {
+  sendAIConversationMessage = (item: AIConversationOutboundItem) => {
     if (!this.session.connected) {
       throw new Error(
         'Cannot send AI conversation message: session is not connected. ' +

--- a/packages/js/src/Modules/Verto/webrtc/interfaces.ts
+++ b/packages/js/src/Modules/Verto/webrtc/interfaces.ts
@@ -244,8 +244,15 @@ export interface IWebRTCCall {
   setSpeakerPhone?: (flag: boolean) => void;
   // AI Conversation
   sendConversationMessage?: (message: string, attachments?: string[]) => void;
-  sendAIConversationMessage?: (item: import('./AIConversationTypes').FunctionCallOutputItem) => void;
-  recordSessionWarning?: (code: string, name: string, message: string, activeCallIds?: string[]) => void;
+  sendAIConversationMessage?: (
+    item: import('./AIConversationTypes').AIConversationOutboundItem
+  ) => void;
+  recordSessionWarning?: (
+    code: string,
+    name: string,
+    message: string,
+    activeCallIds?: string[]
+  ) => void;
 }
 export interface IWebRTCInfo {
   browserInfo: any;

--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -53,9 +53,12 @@ export * from './PreCallDiagnosis';
 export type {
   FunctionCallItem,
   FunctionCallOutputItem,
+  ResponseAudioStreamSubscribeItem,
+  AIConversationOutboundItem,
   AIConversationParams,
   AIConversationFunctionCallParams,
   AIConversationFunctionCallOutputParams,
+  AIConversationOutboundParams,
   IAIConversationMessageEvent,
   ISendAIConversationMessageOptions,
 } from './Modules/Verto/webrtc/AIConversationTypes';


### PR DESCRIPTION
## Summary
- broaden `sendAIConversationMessage` / `AIConversationMessage` to accept outbound AI conversation items
- add `response.audio_stream.subscribe` as a typed outbound item for ACA pre-playout audio subscriptions
- export the new outbound item/params types and cover the nested `conversation.item.create` wire shape in tests

Context: follow-up from team-telnyx/telnyx-voice-ai-lib#80 review discussion: https://github.com/team-telnyx/telnyx-voice-ai-lib/pull/80#discussion_r3638489664

## Validation
- `yarn workspace @telnyx/webrtc test packages/js/src/Modules/Verto/tests/webrtc/AIConversation.test.ts --runInBand`
- `yarn tsc --noEmit -p packages/js/tsconfig.json`
- `yarn workspace @telnyx/webrtc build`
- `yarn workspace @telnyx/webrtc eslint src/Modules/Verto/messages/verto/AIConversationMessage.ts src/Modules/Verto/webrtc/AIConversationTypes.ts src/Modules/Verto/tests/webrtc/AIConversation.test.ts src/index.ts`

## Notes
- Full `yarn workspace @telnyx/webrtc lint` still fails on existing repo-wide lint debt (README markdown fragments, CommonJS config globals, existing `any`/`Function` usage, etc.).
