### PR TITLE
refactor(js): simplify host-only ICE diagnostics (VSDK-251)

### DIFF
--- a/packages/js/src/Modules/Verto/tests/webrtc/Call.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/Call.test.ts
@@ -12,10 +12,16 @@ Object.defineProperty(global, 'performance', {
 });
 
 import { isQueued, register, deRegister } from '../../services/Handler';
-import { PeerType, State, Direction } from '../../webrtc/constants';
+import {
+  PeerType,
+  State,
+  Direction,
+  VertoMethod,
+} from '../../webrtc/constants';
 import {
   ANSWER_WHILE_PEER_ACTIVE,
   DUPLICATE_INBOUND_ANSWER,
+  ONLY_HOST_ICE_CANDIDATES,
   SwEvent,
 } from '../../util/constants';
 import { LOW_BYTES_RECEIVED } from '../../util/constants/errorCodes';
@@ -78,6 +84,126 @@ describe('Call', () => {
       expect(isQueued('telnyx.rtc.mediaError', call.id)).toEqual(true);
       expect(call.state).toEqual('new');
       expect(session.calls).toHaveProperty(call.id);
+    });
+  });
+
+  describe('non-trickle host-only ICE diagnostics', () => {
+    const sdpPrefix = 'v=0\r\no=- 1 2 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\n';
+
+    const configurePeer = () => {
+      const startNegotiation = jest.fn();
+      const restartIce = jest.fn();
+      call.peer = {
+        iceDone: false,
+        isIceRestarting: false,
+        startNegotiation,
+        restartIce,
+        instance: { removeEventListener: jest.fn() },
+      } as unknown as Peer;
+      return { startNegotiation, restartIce };
+    };
+
+    afterEach(() => {
+      deRegister(SwEvent.Warning, undefined, session.uuid);
+      jest.restoreAllMocks();
+    });
+
+    it('warns for host-only SDP while Invite signaling continues without recovery or hangup', async () => {
+      const warningHandler = jest.fn();
+      register(SwEvent.Warning, warningHandler, session.uuid);
+      const executeSpy = jest
+        .spyOn(session, 'execute')
+        .mockResolvedValue({ node_id: null });
+      const hangupSpy = jest.spyOn(call, 'hangup').mockResolvedValue();
+      const { startNegotiation, restartIce } = configurePeer();
+      const hostOnlySdp =
+        sdpPrefix +
+        'a=candidate:1 1 UDP 2113667327 192.168.1.1 54400 typ host\r\n' +
+        'a=candidate:2 1 TCP 2113667326 192.168.1.1 9 typ host tcptype active\r\n';
+
+      (
+        call as unknown as {
+          _onIceSdp: (data: { type: PeerType; sdp: string }) => void;
+        }
+      )._onIceSdp({
+        type: PeerType.Offer,
+        sdp: hostOnlySdp,
+      });
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(warningHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          warning: expect.objectContaining({
+            code: ONLY_HOST_ICE_CANDIDATES,
+            name: 'ONLY_HOST_ICE_CANDIDATES',
+          }),
+          callId: call.id,
+        })
+      );
+      expect(executeSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          request: expect.objectContaining({ method: VertoMethod.Invite }),
+        })
+      );
+      expect(startNegotiation).not.toHaveBeenCalled();
+      expect(restartIce).not.toHaveBeenCalled();
+      expect(hangupSpy).not.toHaveBeenCalled();
+    });
+
+    it.each(['srflx', 'prflx', 'relay'])(
+      'does not warn when SDP contains a %s candidate',
+      async (candidateType) => {
+        const warningHandler = jest.fn();
+        register(SwEvent.Warning, warningHandler, session.uuid);
+        const executeSpy = jest
+          .spyOn(session, 'execute')
+          .mockResolvedValue({ node_id: null });
+        configurePeer();
+
+        (
+          call as unknown as {
+            _onIceSdp: (data: { type: PeerType; sdp: string }) => void;
+          }
+        )._onIceSdp({
+          type: PeerType.Offer,
+          sdp:
+            sdpPrefix +
+            'a=candidate:1 1 UDP 2113667327 192.168.1.1 54400 typ host\r\n' +
+            `a=candidate:2 1 UDP 1694498815 198.51.100.1 54401 typ ${candidateType}\r\n`,
+        });
+        await new Promise((resolve) => setImmediate(resolve));
+
+        expect(warningHandler).not.toHaveBeenCalled();
+        expect(executeSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            request: expect.objectContaining({ method: VertoMethod.Invite }),
+          })
+        );
+      }
+    );
+
+    it('does not classify zero-candidate SDP as host-only and still signals it', async () => {
+      const warningHandler = jest.fn();
+      register(SwEvent.Warning, warningHandler, session.uuid);
+      const executeSpy = jest
+        .spyOn(session, 'execute')
+        .mockResolvedValue({ node_id: null });
+      const { startNegotiation } = configurePeer();
+
+      (
+        call as unknown as {
+          _onIceSdp: (data: { type: PeerType; sdp: string }) => void;
+        }
+      )._onIceSdp({ type: PeerType.Offer, sdp: sdpPrefix });
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(warningHandler).not.toHaveBeenCalled();
+      expect(executeSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          request: expect.objectContaining({ method: VertoMethod.Invite }),
+        })
+      );
+      expect(startNegotiation).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/js/src/Modules/Verto/tests/webrtc/Call.trickle-ice.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/Call.trickle-ice.test.ts
@@ -2,8 +2,13 @@ import { VertoMethod, VertoModifyAction } from '../../webrtc/constants';
 import Call from '../../webrtc/Call';
 import Verto from '../..';
 import type { IVertoCallOptions } from '../../webrtc/interfaces';
-import { SDP_CREATE_OFFER_FAILED } from '../../util/constants';
+import {
+  ONLY_HOST_ICE_CANDIDATES,
+  SDP_CREATE_OFFER_FAILED,
+  SwEvent,
+} from '../../util/constants';
 import { createTelnyxError } from '../../util/errors';
+import { deRegister, register } from '../../services/Handler';
 
 const originalConsoleDebug = console.debug;
 const originalConsoleLog = console.log;
@@ -181,6 +186,130 @@ describe('Call Trickle ICE', () => {
   });
 
   describe('Trickle ICE message behavior', () => {
+    const sdpPrefix = 'v=0\r\no=- 1 2 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\n';
+
+    const finishIceGathering = (sdp: string) => {
+      Object.defineProperty(call.peer.instance, 'localDescription', {
+        get: () => ({ type: 'offer', sdp }),
+        configurable: true,
+      });
+      call.peer.instance.onicecandidate({
+        type: 'icecandidate',
+        candidate: null,
+        target: call.peer.instance,
+      } as unknown as RTCPeerConnectionIceEvent);
+    };
+
+    afterEach(() => {
+      deRegister(SwEvent.Warning, undefined, session.uuid);
+      jest.restoreAllMocks();
+    });
+
+    it('warns for host-only local SDP at end-of-candidates and still sends EndOfCandidates', () => {
+      const warningHandler = jest.fn();
+      register(SwEvent.Warning, warningHandler, session.uuid);
+      const executeSpy = jest.spyOn(session, 'execute').mockResolvedValue({});
+      const restartIceSpy = jest.spyOn(call.peer, 'restartIce');
+      const startNegotiationSpy = jest.spyOn(call.peer, 'startNegotiation');
+      const hangupSpy = jest.spyOn(call, 'hangup').mockResolvedValue();
+
+      finishIceGathering(
+        sdpPrefix +
+          'a=candidate:1 1 UDP 2113667327 192.168.1.1 54400 typ host\r\n'
+      );
+
+      expect(warningHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          warning: expect.objectContaining({
+            code: ONLY_HOST_ICE_CANDIDATES,
+            name: 'ONLY_HOST_ICE_CANDIDATES',
+          }),
+          callId: call.id,
+        })
+      );
+      expect(executeSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          request: expect.objectContaining({
+            method: VertoMethod.EndOfCandidates,
+          }),
+        })
+      );
+      expect(restartIceSpy).not.toHaveBeenCalled();
+      expect(startNegotiationSpy).not.toHaveBeenCalled();
+      expect(hangupSpy).not.toHaveBeenCalled();
+    });
+
+    it('waits for the null candidate before warning about host-only SDP', () => {
+      const warningHandler = jest.fn();
+      register(SwEvent.Warning, warningHandler, session.uuid);
+      const executeSpy = jest.spyOn(session, 'execute').mockResolvedValue({});
+      const hostOnlySdp =
+        sdpPrefix +
+        'a=candidate:1 1 UDP 2113667327 192.168.1.1 54400 typ host\r\n';
+
+      Object.defineProperty(call.peer.instance, 'localDescription', {
+        get: () => ({ type: 'offer', sdp: hostOnlySdp }),
+        configurable: true,
+      });
+      call.peer.instance.onicecandidate({
+        candidate: { candidate: '' } as RTCIceCandidate,
+      } as RTCPeerConnectionIceEvent);
+
+      expect(executeSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          request: expect.objectContaining({
+            method: VertoMethod.EndOfCandidates,
+          }),
+        })
+      );
+      expect(warningHandler).not.toHaveBeenCalled();
+
+      finishIceGathering(hostOnlySdp);
+
+      expect(warningHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          warning: expect.objectContaining({ code: ONLY_HOST_ICE_CANDIDATES }),
+        })
+      );
+    });
+
+    it.each([
+      ['zero-candidate', sdpPrefix],
+      [
+        'srflx',
+        sdpPrefix +
+          'a=candidate:1 1 UDP 1694498815 198.51.100.1 54400 typ srflx\r\n',
+      ],
+      [
+        'prflx',
+        sdpPrefix +
+          'a=candidate:1 1 UDP 1694498815 198.51.100.1 54400 typ prflx\r\n',
+      ],
+      [
+        'relay',
+        sdpPrefix +
+          'a=candidate:1 1 UDP 1006632447 198.51.100.1 54400 typ relay\r\n',
+      ],
+    ])(
+      'does not warn for %s SDP and still sends EndOfCandidates',
+      (_description, sdp) => {
+        const warningHandler = jest.fn();
+        register(SwEvent.Warning, warningHandler, session.uuid);
+        const executeSpy = jest.spyOn(session, 'execute').mockResolvedValue({});
+
+        finishIceGathering(sdp);
+
+        expect(warningHandler).not.toHaveBeenCalled();
+        expect(executeSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            request: expect.objectContaining({
+              method: VertoMethod.EndOfCandidates,
+            }),
+          })
+        );
+      }
+    );
+
     it('should handle ICE candidate events from peer connection', () => {
       // Mock session execute to capture outgoing messages
       const sessionExecuteSpy = jest
@@ -472,7 +601,9 @@ describe('Call Trickle ICE', () => {
       const modifyCall = sessionExecuteSpy.mock.calls.find(
         (c) => (c[0] as any)?.request?.method === VertoMethod.Modify
       );
-      expect((modifyCall?.[0] as any)?.request?.params?.trickle).toBeUndefined();
+      expect(
+        (modifyCall?.[0] as any)?.request?.params?.trickle
+      ).toBeUndefined();
     });
 
     it('reattached/recovered trickle call follows the trickle restart Modify flow', () => {

--- a/packages/js/src/Modules/Verto/util/constants/errorCodes.ts
+++ b/packages/js/src/Modules/Verto/util/constants/errorCodes.ts
@@ -145,9 +145,3 @@ export const {
   MEDIA_RECOVERY_REQUIRED,
   RECONNECTION_FAILED_WITH_NO_AUTO_RECONNECT,
 } = TELNYX_WARNING_CODES;
-/**
- * Regex to detect non-host ICE candidates (srflx, prflx, or relay) in SDP.
- * Used to check if only host candidates were gathered.
- */
-export const HAS_NON_HOST_ICE_CANDIDATE_REGEX =
-  /^a=candidate:.+typ (srflx|prflx|relay)/m;

--- a/packages/js/src/Modules/Verto/util/constants/warnings.ts
+++ b/packages/js/src/Modules/Verto/util/constants/warnings.ts
@@ -273,7 +273,7 @@ export const SDK_WARNINGS = {
     name: 'ONLY_HOST_ICE_CANDIDATES',
     message: 'Only local network candidates available',
     description:
-      'ICE gathering completed but only host (local network) candidates were collected — no server-reflexive (srflx) or relay (turn) candidates were found. This typically means the STUN/TURN servers are unreachable, which will prevent connections outside the local network.',
+      'ICE gathering completed with host (local network) candidates only. This is diagnostic evidence that no server-reflexive (srflx), peer-reflexive (prflx), or relay (TURN) candidates were found; connectivity may still succeed, but network traversal options can be limited.',
     causes: [
       'STUN/TURN servers unreachable',
       'Firewall blocking UDP traffic to STUN/TURN servers',

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -37,7 +37,6 @@ import {
   ONLY_HOST_ICE_CANDIDATES,
   ANSWER_WHILE_PEER_ACTIVE,
   DUPLICATE_INBOUND_ANSWER,
-  HAS_NON_HOST_ICE_CANDIDATE_REGEX,
   UNEXPECTED_ERROR,
   LOW_BYTES_RECEIVED,
   LOW_BYTES_SENT,
@@ -88,6 +87,7 @@ import {
   enableVideoTracks,
   getStreamTrackDebugInfo,
   getTrackDebugInfo,
+  hasOnlyHostIceCandidates,
   playAudio,
   stopAudio,
   toggleAudioTracks,
@@ -1891,24 +1891,18 @@ export default abstract class BaseCall implements IWebRTCCall {
       });
   }
 
-  private _requestAnotherLocalDescription() {
-    if (isFunction(this.peer.onSdpReadyTwice)) {
-      const telnyxError = createTelnyxError(
-        SDP_SEND_FAILED,
-        new Error('SDP without candidates for the second time!')
-      );
-      trigger(
-        SwEvent.Error,
-        { error: telnyxError, sessionId: this.session.sessionid },
-        this.session.uuid
-      );
+  private _warnIfOnlyHostIceCandidates(sdp: string | null | undefined) {
+    if (!hasOnlyHostIceCandidates(sdp)) {
       return;
     }
-    Object.defineProperty(this.peer, 'onSdpReadyTwice', {
-      value: this._onIceSdp.bind(this),
-    });
-    this.peer.iceDone = false;
-    this.peer.startNegotiation();
+
+    const warning = createTelnyxWarning(ONLY_HOST_ICE_CANDIDATES);
+    logger.warn(`[${this.id}] Warning ${warning.code}: ${warning.message}`);
+    trigger(
+      SwEvent.Warning,
+      { warning, callId: this.id, sessionId: this.session.sessionid },
+      this.session.uuid
+    );
   }
 
   private _onIceSdp(data: RTCSessionDescription | null) {
@@ -1929,24 +1923,8 @@ export default abstract class BaseCall implements IWebRTCCall {
 
     const { sdp, type } = data;
 
-    if (sdp.indexOf('candidate') === -1) {
-      logger.info('No candidate - retry \n');
-      this._requestAnotherLocalDescription();
-      return;
-    }
-
     this.peer?.instance?.removeEventListener('icecandidate', this._onIce);
-
-    // W5d: Check for host-only ICE candidates (non-trickle path)
-    if (!HAS_NON_HOST_ICE_CANDIDATE_REGEX.test(sdp)) {
-      const warning = createTelnyxWarning(ONLY_HOST_ICE_CANDIDATES);
-      logger.warn(`[${this.id}] Warning ${warning.code}: ${warning.message}`);
-      trigger(
-        SwEvent.Warning,
-        { warning, callId: this.id, sessionId: this.session.sessionid },
-        this.session.uuid
-      );
-    }
+    this._warnIfOnlyHostIceCandidates(sdp);
 
     performance.mark(callMarkName(this.id, 'ice-gathering-end'));
     let msg = null;
@@ -2165,6 +2143,11 @@ export default abstract class BaseCall implements IWebRTCCall {
       this._trackCandidateMarks(event.candidate);
       this._sendIceCandidate(event.candidate);
     } else {
+      if (event.candidate === null) {
+        this._warnIfOnlyHostIceCandidates(
+          this.peer?.instance?.localDescription?.sdp
+        );
+      }
       this._sendEndOfCandidates();
     }
   }

--- a/packages/js/src/Modules/Verto/webrtc/Peer.ts
+++ b/packages/js/src/Modules/Verto/webrtc/Peer.ts
@@ -33,7 +33,6 @@ import {
   WebRTCStatsReporter,
 } from '../util/debug';
 
-import { isFunction } from '../util/helpers';
 import logger from '../util/logger';
 import {
   attachMediaStream,
@@ -61,7 +60,6 @@ export type RestartIceResult = {
  */
 export default class Peer {
   public instance: RTCPeerConnection;
-  public onSdpReadyTwice: ((data: RTCSessionDescription) => void) | null = null;
   public statsReporter: WebRTCStatsReporter | null = null;
   public isIceRestarting: boolean = false;
   public iceDone: boolean = false;
@@ -101,7 +99,6 @@ export default class Peer {
       offerToReceiveVideo: !!options.video,
     };
 
-    this._sdpReady = this._sdpReady.bind(this);
     this.handleSignalingStateChangeEvent =
       this.handleSignalingStateChangeEvent.bind(this);
     this.handleNegotiationNeededEvent =
@@ -924,10 +921,6 @@ export default class Peer {
       performance.mark(callMarkName(this.options.id, 'set-local-description'));
       performance.mark(callMarkName(this.options.id, 'ice-gathering-started'));
 
-      if (!this._isTrickleIce()) {
-        this._sdpReady();
-      }
-
       return offer;
     } catch (error) {
       logger.error('Peer _createOffer error:', error);
@@ -1034,13 +1027,6 @@ export default class Peer {
       return transceiver.setCodecPreferences(codecs);
     }
   };
-  /** Workaround for ReactNative: first time SDP has no candidates */
-  private _sdpReady(): void {
-    if (isFunction(this.onSdpReadyTwice)) {
-      this.onSdpReadyTwice(this.instance.localDescription);
-    }
-  }
-
   private async _retrieveLocalStream() {
     if (streamIsValid(this.options.localStream)) {
       return this.options.localStream;

--- a/packages/js/src/Modules/Verto/webrtc/helpers.ts
+++ b/packages/js/src/Modules/Verto/webrtc/helpers.ts
@@ -831,6 +831,21 @@ function stopAudio(audioElement: IAudio): void {
   }
 }
 
+const hasOnlyHostIceCandidates = (sdp: string | null | undefined): boolean => {
+  if (!sdp) {
+    return false;
+  }
+
+  const candidateLines = sdp
+    .split(/\r?\n/)
+    .filter((line) => /^a=candidate:/i.test(line));
+
+  return (
+    candidateLines.length > 0 &&
+    candidateLines.every((line) => /\styp\s+host(?:\s|$)/i.test(line))
+  );
+};
+
 const getPreferredCodecs = (preferred_codecs?: RTCRtpCodecCapability[]) => {
   const audioCodecs: RTCRtpCodecCapability[] = [];
   const videoCodecs: RTCRtpCodecCapability[] = [];
@@ -883,6 +898,7 @@ export {
   getPreferredCodecs,
   getTrackDebugInfo,
   getStreamTrackDebugInfo,
+  hasOnlyHostIceCandidates,
   // Exported for testing
   isDeviceNotFoundError,
   getConstraintsWithoutDeviceId,


### PR DESCRIPTION
## Summary
- emit the existing `ONLY_HOST_ICE_CANDIDATES` warning when trickle ICE globally completes with host candidates only
- share the host-only SDP classifier across trickle and non-trickle paths without blocking signaling
- remove the legacy second-SDP negotiation/retry path
- avoid classifying zero-candidate SDP as host-only and soften the warning text to remain diagnostic

Host-only candidates do **not** trigger ICE restart, extra negotiation, hangup, or a terminal error. Trickle ICE still sends `EndOfCandidates`, and non-trickle calls still send their normal Invite/Answer/Attach/Modify request.

## Verification
- `yarn test src/Modules/Verto/tests/webrtc/Call.test.ts src/Modules/Verto/tests/webrtc/Call.trickle-ice.test.ts --runInBand` — 2 suites / 90 tests passed
- `../../node_modules/.bin/tsc --noEmit --project tsconfig.json`
- scoped ESLint on changed production files
- Prettier check on all changed files
- `yarn build`
- `git diff --check`

## Notes
- The file-wide pre-commit ESLint hook still reports 25 pre-existing `no-explicit-any` violations in `Call.trickle-ice.test.ts`; no new violation was added by this change.
- Supersedes the implementation direction in #679 with a small branch from current `main`.

Linear: [VSDK-251](https://linear.app/telnyx/issue/VSDK-251/handling-case-where-client-only-gather-host-ice-candidates)
