### PR TITLE
feat(js): support explicit canary routing toggle

### DIFF
--- a/packages/js/docs/ts/interfaces/IClientOptions.md
+++ b/packages/js/docs/ts/interfaces/IClientOptions.md
@@ -533,4 +533,6 @@ Enable or disable Trickle ICE.
 
 • `Optional` **useCanaryRtcServer**: `boolean`
 
-Use Telnyx's Canary RTC server
+Override VSP RTC routing for this connection. `true` forces the Canary RTC
+server, `false` forces the stable RTC server, and omission leaves routing to
+VSP's default load-based behavior.

--- a/packages/js/src/Modules/Verto/BaseSession.ts
+++ b/packages/js/src/Modules/Verto/BaseSession.ts
@@ -47,6 +47,7 @@ import logger, { setConsoleLoggerMinLevel } from './util/logger';
 import {
   getReconnectSessionId,
   getReconnectToken,
+  getReconnectTokenCanaryRtcServer,
   clearReconnectToken,
   isReconnectSessionIdFresh,
   setReconnectSessionId,
@@ -81,6 +82,11 @@ export default abstract class BaseSession {
   public callReportId: string | null = null;
   /** voice_sdk_id used when posting call report payloads for this session. */
   public callReportVoiceSdkId: string | null = null;
+  /** Persisted voice_sdk_id whose routing association is owned by this session. */
+  public reconnectTokenVoiceSdkId: string | null = getReconnectToken();
+  /** Canary routing override associated with the persisted voice_sdk_id. */
+  public reconnectTokenCanaryRtcServer: boolean | undefined =
+    getReconnectTokenCanaryRtcServer();
   public dc: string | null = null;
   public region: string | null = null;
 
@@ -535,6 +541,8 @@ export default abstract class BaseSession {
    */
   public clearReconnectToken(): void {
     clearReconnectToken();
+    this.reconnectTokenVoiceSdkId = null;
+    this.reconnectTokenCanaryRtcServer = undefined;
   }
 
   /**

--- a/packages/js/src/Modules/Verto/services/Connection.ts
+++ b/packages/js/src/Modules/Verto/services/Connection.ts
@@ -20,7 +20,11 @@ import {
   safeParseJson,
 } from '../util/helpers';
 import logger from '../util/logger';
-import { getReconnectToken, setReconnectToken } from '../util/reconnect';
+import {
+  getReconnectToken,
+  getReconnectTokenCanaryRtcServer,
+  setReconnectToken,
+} from '../util/reconnect';
 import { GatewayStateType } from '../webrtc/constants';
 import { deRegister, registerOnce, trigger } from './Handler';
 
@@ -57,8 +61,6 @@ export default class Connection {
   private _wsClient: WebSocket | null = null;
   private _host: string = PROD_HOST;
   private _timers: { [id: string]: ReturnType<typeof setTimeout> } = {};
-  /** Canary override associated with the currently stored reconnect token. */
-  private _reconnectTokenCanaryRtcServer: boolean | undefined;
 
   private _safetyTimeoutId: ReturnType<typeof setTimeout> | null = null;
 
@@ -147,7 +149,13 @@ export default class Connection {
     });
 
     const websocketUrl = new URL(this._host);
-    let reconnectToken = getReconnectToken();
+    const storedReconnectToken = getReconnectToken();
+    if (storedReconnectToken !== this.session.reconnectTokenVoiceSdkId) {
+      this.session.reconnectTokenVoiceSdkId = storedReconnectToken;
+      this.session.reconnectTokenCanaryRtcServer =
+        getReconnectTokenCanaryRtcServer();
+    }
+    let reconnectToken = this.session.reconnectTokenVoiceSdkId;
     let canaryRtcServerForConnection: boolean | undefined;
 
     if (this.session.options.rtcIp && this.session.options.rtcPort) {
@@ -175,11 +183,12 @@ export default class Connection {
 
       if (
         reconnectToken &&
-        canaryRtcServerForConnection !== this._reconnectTokenCanaryRtcServer
+        canaryRtcServerForConnection !==
+          this.session.reconnectTokenCanaryRtcServer
       ) {
         websocketUrl.searchParams.delete('voice_sdk_id');
         logger.debug('Canary routing changed. Refreshing voice_sdk_id', {
-          previous: this._reconnectTokenCanaryRtcServer,
+          previous: this.session.reconnectTokenCanaryRtcServer,
           current: canaryRtcServerForConnection,
         });
       }
@@ -219,10 +228,7 @@ export default class Connection {
       });
       this.lastInboundAt = 0;
       this._cleanupPendingRequests();
-      this._registerSocketEvents(
-        this._wsClient,
-        canaryRtcServerForConnection
-      );
+      this._registerSocketEvents(this._wsClient, canaryRtcServerForConnection);
     } catch (error) {
       logger.error('WebSocket connection failed:', error);
       const telnyxError = createTelnyxError(WEBSOCKET_CONNECTION_FAILED, error);
@@ -454,10 +460,16 @@ export default class Connection {
         return;
       }
 
-      if (msg.voice_sdk_id) {
+      const isCurrentSocket =
+        ws === this._wsClient &&
+        registeredGeneration === this.socketGeneration &&
+        this.session.connection === this;
+      if (msg.voice_sdk_id && isCurrentSocket) {
         this.session.callReportVoiceSdkId = msg.voice_sdk_id;
-        setReconnectToken(msg.voice_sdk_id);
-        this._reconnectTokenCanaryRtcServer = canaryRtcServerForConnection;
+        this.session.reconnectTokenVoiceSdkId = msg.voice_sdk_id;
+        this.session.reconnectTokenCanaryRtcServer =
+          canaryRtcServerForConnection;
+        setReconnectToken(msg.voice_sdk_id, canaryRtcServerForConnection);
       }
       this._unsetTimer(msg.id);
       logger.debug('RECV: \n', JSON.stringify(msg, null, 2), '\n');

--- a/packages/js/src/Modules/Verto/services/Connection.ts
+++ b/packages/js/src/Modules/Verto/services/Connection.ts
@@ -57,8 +57,8 @@ export default class Connection {
   private _wsClient: WebSocket | null = null;
   private _host: string = PROD_HOST;
   private _timers: { [id: string]: ReturnType<typeof setTimeout> } = {};
-  private _useCanaryRtcServer: boolean = false;
-  private _hasCanaryBeenUsed: boolean = false;
+  /** Canary override associated with the currently stored reconnect token. */
+  private _reconnectTokenCanaryRtcServer: boolean | undefined;
 
   private _safetyTimeoutId: ReturnType<typeof setTimeout> | null = null;
 
@@ -107,10 +107,6 @@ export default class Connection {
     if (region) {
       this._host = this._host.replace(/rtc(dev)?/, `${region}.rtc$1`);
     }
-
-    if (useCanaryRtcServer) {
-      this._useCanaryRtcServer = true;
-    }
   }
 
   get connected(): boolean {
@@ -152,10 +148,10 @@ export default class Connection {
 
     const websocketUrl = new URL(this._host);
     let reconnectToken = getReconnectToken();
+    let canaryRtcServerForConnection: boolean | undefined;
 
     if (this.session.options.rtcIp && this.session.options.rtcPort) {
       reconnectToken = null;
-      this._useCanaryRtcServer = false;
       websocketUrl.searchParams.set('rtc_ip', this.session.options.rtcIp);
       websocketUrl.searchParams.set(
         'rtc_port',
@@ -167,15 +163,26 @@ export default class Connection {
       websocketUrl.searchParams.set('voice_sdk_id', reconnectToken);
     }
 
-    if (this._useCanaryRtcServer) {
-      websocketUrl.searchParams.set('canary', 'true');
+    if (
+      !(this.session.options.rtcIp && this.session.options.rtcPort) &&
+      typeof this.session.options.useCanaryRtcServer === 'boolean'
+    ) {
+      canaryRtcServerForConnection = this.session.options.useCanaryRtcServer;
+      websocketUrl.searchParams.set(
+        'canary',
+        String(canaryRtcServerForConnection)
+      );
 
-      if (reconnectToken && !this._hasCanaryBeenUsed) {
+      if (
+        reconnectToken &&
+        canaryRtcServerForConnection !== this._reconnectTokenCanaryRtcServer
+      ) {
         websocketUrl.searchParams.delete('voice_sdk_id');
-        logger.debug('first canary connection. Refreshing voice_sdk_id');
+        logger.debug('Canary routing changed. Refreshing voice_sdk_id', {
+          previous: this._reconnectTokenCanaryRtcServer,
+          current: canaryRtcServerForConnection,
+        });
       }
-
-      this._hasCanaryBeenUsed = true;
     }
 
     // Snapshot the owning session's voice_sdk_id for call report uploads.
@@ -212,7 +219,10 @@ export default class Connection {
       });
       this.lastInboundAt = 0;
       this._cleanupPendingRequests();
-      this._registerSocketEvents(this._wsClient);
+      this._registerSocketEvents(
+        this._wsClient,
+        canaryRtcServerForConnection
+      );
     } catch (error) {
       logger.error('WebSocket connection failed:', error);
       const telnyxError = createTelnyxError(WEBSOCKET_CONNECTION_FAILED, error);
@@ -344,7 +354,10 @@ export default class Connection {
     );
   }
 
-  private _registerSocketEvents(ws: WebSocket): void {
+  private _registerSocketEvents(
+    ws: WebSocket,
+    canaryRtcServerForConnection: boolean | undefined
+  ): void {
     // Capture the generation at registration time — when this socket's
     // event handlers are being attached — not at event-dispatch time.
     // If a reconnect creates a new socket (incrementing socketGeneration)
@@ -444,6 +457,7 @@ export default class Connection {
       if (msg.voice_sdk_id) {
         this.session.callReportVoiceSdkId = msg.voice_sdk_id;
         setReconnectToken(msg.voice_sdk_id);
+        this._reconnectTokenCanaryRtcServer = canaryRtcServerForConnection;
       }
       this._unsetTimer(msg.id);
       logger.debug('RECV: \n', JSON.stringify(msg, null, 2), '\n');

--- a/packages/js/src/Modules/Verto/services/Connection.ts
+++ b/packages/js/src/Modules/Verto/services/Connection.ts
@@ -171,15 +171,15 @@ export default class Connection {
       websocketUrl.searchParams.set('voice_sdk_id', reconnectToken);
     }
 
-    if (
-      !(this.session.options.rtcIp && this.session.options.rtcPort) &&
-      typeof this.session.options.useCanaryRtcServer === 'boolean'
-    ) {
+    if (!(this.session.options.rtcIp && this.session.options.rtcPort)) {
       canaryRtcServerForConnection = this.session.options.useCanaryRtcServer;
-      websocketUrl.searchParams.set(
-        'canary',
-        String(canaryRtcServerForConnection)
-      );
+
+      if (typeof canaryRtcServerForConnection === 'boolean') {
+        websocketUrl.searchParams.set(
+          'canary',
+          String(canaryRtcServerForConnection)
+        );
+      }
 
       if (
         reconnectToken &&

--- a/packages/js/src/Modules/Verto/tests/ReconnectAttempts.test.ts
+++ b/packages/js/src/Modules/Verto/tests/ReconnectAttempts.test.ts
@@ -19,6 +19,7 @@ jest.mock('../services/Handler');
 jest.mock('../util/logger');
 jest.mock('../util/reconnect', () => ({
   getReconnectToken: jest.fn(() => null),
+  getReconnectTokenCanaryRtcServer: jest.fn(() => undefined),
   setReconnectToken: jest.fn(),
   clearReconnectToken: jest.fn(),
 }));

--- a/packages/js/src/Modules/Verto/tests/reconnect.test.ts
+++ b/packages/js/src/Modules/Verto/tests/reconnect.test.ts
@@ -2,6 +2,7 @@ import {
   clearReconnectToken,
   getReconnectSessionId,
   getReconnectToken,
+  getReconnectTokenCanaryRtcServer,
   RECONNECT_SESSION_ID_MAX_AGE_MS,
   setReconnectSessionId,
   setReconnectToken,
@@ -11,6 +12,7 @@ import {
   RECOVERY_MARKER_MAX_AGE_MS,
   type IStoredActiveCall,
 } from '../util/reconnect';
+import Verto from '..';
 
 const ACTIVE_CALLS_KEY = 'telnyx-voice-sdk-active-calls';
 
@@ -42,6 +44,62 @@ describe('reconnect token storage', () => {
 
     expect(getReconnectToken()).toBeNull();
     expect(getReconnectSessionId()).toBeNull();
+  });
+
+  it.each([true, false])(
+    'keeps the canary=%s routing association with voice_sdk_id across a page refresh',
+    (useCanaryRtcServer) => {
+      setReconnectToken('voice-sdk-id', useCanaryRtcServer);
+
+      window.dispatchEvent(new Event('beforeunload'));
+
+      expect(getReconnectToken()).toBe('voice-sdk-id');
+      expect(getReconnectTokenCanaryRtcServer()).toBe(useCanaryRtcServer);
+
+      clearReconnectToken();
+    }
+  );
+
+  it.each([true, false])(
+    'restores the canary=%s routing association on a new session after page refresh',
+    (useCanaryRtcServer) => {
+      setReconnectToken('voice-sdk-id', useCanaryRtcServer);
+
+      const refreshedSession = new Verto({
+        host: 'example.telnyx.com',
+        login: 'login',
+        password: 'password',
+        useCanaryRtcServer,
+      });
+
+      expect(refreshedSession.reconnectTokenCanaryRtcServer).toBe(
+        useCanaryRtcServer
+      );
+      clearReconnectToken();
+    }
+  );
+
+  it('clears the session-level canary routing association with voice_sdk_id', () => {
+    setReconnectToken('voice-sdk-id', true);
+    const session = new Verto({
+      host: 'example.telnyx.com',
+      login: 'login',
+      password: 'password',
+      useCanaryRtcServer: true,
+    });
+
+    session.clearReconnectToken();
+
+    expect(session.reconnectTokenCanaryRtcServer).toBeUndefined();
+    expect(getReconnectTokenCanaryRtcServer()).toBeUndefined();
+  });
+
+  it('clears the persisted canary routing association with voice_sdk_id', () => {
+    setReconnectToken('voice-sdk-id', true);
+
+    clearReconnectToken();
+
+    expect(getReconnectTokenCanaryRtcServer()).toBeUndefined();
   });
 
   it('expires the previous sessid after 90 seconds', () => {
@@ -173,7 +231,11 @@ describe('active-calls recovery marker storage', () => {
   it('returns null and clears storage when calls is not an array', () => {
     sessionStorage.setItem(
       ACTIVE_CALLS_KEY,
-      JSON.stringify({ sessionId: 's', calls: 'not-an-array', storedAt: Date.now() })
+      JSON.stringify({
+        sessionId: 's',
+        calls: 'not-an-array',
+        storedAt: Date.now(),
+      })
     );
 
     const result = getActiveCallsRecoveryMarker();

--- a/packages/js/src/Modules/Verto/tests/services/Connection.test.ts
+++ b/packages/js/src/Modules/Verto/tests/services/Connection.test.ts
@@ -223,6 +223,161 @@ describe('Connection - Safety Timeout', () => {
       );
       expect(wsUrl.searchParams.has('skip_last_voice_sdk_id')).toBe(false);
     });
+
+    describe('canary routing toggle', () => {
+      const currentWebSocketUrl = (): URL => {
+        const ws = (connection as any)._wsClient as MockWebSocket;
+        expect(ws).not.toBeNull();
+        return new URL(ws.url);
+      };
+
+      beforeEach(() => {
+        (getReconnectToken as jest.Mock).mockReturnValue('stored-voice-sdk-id');
+      });
+
+      it.each([
+        { value: true, expected: 'true' },
+        { value: false, expected: 'false' },
+      ])(
+        'sends canary=$expected for explicit $value',
+        ({ value, expected }) => {
+          mockSession.options.useCanaryRtcServer = value;
+
+          connection.connect();
+
+          expect(currentWebSocketUrl().searchParams.get('canary')).toBe(
+            expected
+          );
+        }
+      );
+
+      it('omits canary when useCanaryRtcServer is omitted', () => {
+        connection.connect();
+
+        expect(currentWebSocketUrl().searchParams.has('canary')).toBe(false);
+      });
+
+      it('treats a token received without an override as default-routed', () => {
+        mockSession.options.useCanaryRtcServer = true;
+        connection.connect();
+        let ws = (connection as any)._wsClient as MockWebSocket;
+        ws.simulateMessage({ voice_sdk_id: 'canary-voice-sdk-id' });
+        (getReconnectToken as jest.Mock).mockReturnValue('canary-voice-sdk-id');
+
+        delete mockSession.options.useCanaryRtcServer;
+        connection.connect();
+        let url = currentWebSocketUrl();
+        expect(url.searchParams.has('canary')).toBe(false);
+        expect(url.searchParams.get('voice_sdk_id')).toBe(
+          'canary-voice-sdk-id'
+        );
+        ws = (connection as any)._wsClient as MockWebSocket;
+        ws.simulateMessage({ voice_sdk_id: 'default-voice-sdk-id' });
+        (getReconnectToken as jest.Mock).mockReturnValue('default-voice-sdk-id');
+
+        mockSession.options.useCanaryRtcServer = true;
+        connection.connect();
+        url = currentWebSocketUrl();
+        expect(url.searchParams.has('voice_sdk_id')).toBe(false);
+      });
+
+      it.each([true, false])(
+        'omits a stored voice_sdk_id on the first explicit %s connection, then reuses the replacement while unchanged',
+        (value) => {
+          mockSession.options.useCanaryRtcServer = value;
+
+          connection.connect();
+          expect(currentWebSocketUrl().searchParams.has('voice_sdk_id')).toBe(
+            false
+          );
+
+          const ws = (connection as any)._wsClient as MockWebSocket;
+          ws.simulateMessage({ voice_sdk_id: 'replacement-voice-sdk-id' });
+          (getReconnectToken as jest.Mock).mockReturnValue(
+            'replacement-voice-sdk-id'
+          );
+
+          connection.connect();
+          expect(currentWebSocketUrl().searchParams.get('voice_sdk_id')).toBe(
+            'replacement-voice-sdk-id'
+          );
+        }
+      );
+
+      it('keeps omitting the old voice_sdk_id after a canary switch until the new route returns a replacement', () => {
+        mockSession.options.useCanaryRtcServer = true;
+        connection.connect();
+        const initialWs = (connection as any)._wsClient as MockWebSocket;
+        initialWs.simulateMessage({ voice_sdk_id: 'canary-voice-sdk-id' });
+        (getReconnectToken as jest.Mock).mockReturnValue('canary-voice-sdk-id');
+
+        mockSession.options.useCanaryRtcServer = false;
+        connection.connect();
+        const switchedWs = (connection as any)._wsClient as MockWebSocket;
+        expect(currentWebSocketUrl().searchParams.has('voice_sdk_id')).toBe(
+          false
+        );
+
+        switchedWs.simulateError({ type: 'error' });
+        connection.connect();
+
+        expect(currentWebSocketUrl().searchParams.get('canary')).toBe('false');
+        expect(currentWebSocketUrl().searchParams.has('voice_sdk_id')).toBe(
+          false
+        );
+      });
+
+      it.each([
+        { previous: true, next: false },
+        { previous: false, next: true },
+      ])(
+        'omits a stored voice_sdk_id when canary changes from $previous to $next',
+        ({ previous, next }) => {
+          mockSession.options.useCanaryRtcServer = previous;
+          connection.connect();
+          const ws = (connection as any)._wsClient as MockWebSocket;
+          ws.simulateMessage({ voice_sdk_id: 'previous-voice-sdk-id' });
+          (getReconnectToken as jest.Mock).mockReturnValue(
+            'previous-voice-sdk-id'
+          );
+
+          mockSession.options.useCanaryRtcServer = next;
+          connection.connect();
+
+          const url = currentWebSocketUrl();
+          expect(url.searchParams.get('canary')).toBe(String(next));
+          expect(url.searchParams.has('voice_sdk_id')).toBe(false);
+        }
+      );
+
+      it('does not add skip_last_voice_sdk_id when a canary change removes voice_sdk_id', () => {
+        mockSession.options.skipLastVoiceSdkId = true;
+        mockSession.options.useCanaryRtcServer = true;
+        connection.connect();
+
+        mockSession.options.useCanaryRtcServer = false;
+        connection.connect();
+
+        const url = currentWebSocketUrl();
+        expect(url.searchParams.has('voice_sdk_id')).toBe(false);
+        expect(url.searchParams.has('skip_last_voice_sdk_id')).toBe(false);
+      });
+
+      it('preserves skip_last_voice_sdk_id when canary is unchanged and voice_sdk_id is reused', () => {
+        mockSession.options.skipLastVoiceSdkId = true;
+        mockSession.options.useCanaryRtcServer = true;
+        connection.connect();
+        const ws = (connection as any)._wsClient as MockWebSocket;
+        ws.simulateMessage({ voice_sdk_id: 'stored-voice-sdk-id' });
+        connection.connect();
+
+        const url = currentWebSocketUrl();
+        expect(url.searchParams.get('voice_sdk_id')).toBe(
+          'stored-voice-sdk-id'
+        );
+        expect(url.searchParams.get('skip_last_voice_sdk_id')).toBe('true');
+      });
+    });
   });
 
   describe('close() method', () => {
@@ -736,8 +891,6 @@ describe('Connection - Safety Timeout', () => {
       mockSession.options.skipTrailing = true;
       mockSession.options.useCanaryRtcServer = true;
 
-      // Re-create connection since useCanaryRtcServer is read in constructor
-      connection = new Connection(mockSession);
       connection.connect();
 
       const ws = (connection as any)._wsClient as MockWebSocket;

--- a/packages/js/src/Modules/Verto/tests/services/Connection.test.ts
+++ b/packages/js/src/Modules/Verto/tests/services/Connection.test.ts
@@ -266,31 +266,37 @@ describe('Connection - Safety Timeout', () => {
         expect(currentWebSocketUrl().searchParams.has('canary')).toBe(false);
       });
 
-      it('treats a token received without an override as default-routed', () => {
-        mockSession.options.useCanaryRtcServer = true;
-        connection.connect();
-        let ws = (connection as any)._wsClient as MockWebSocket;
-        ws.simulateMessage({ voice_sdk_id: 'canary-voice-sdk-id' });
-        (getReconnectToken as jest.Mock).mockReturnValue('canary-voice-sdk-id');
+      it.each([true, false])(
+        'omits an explicit %s route token when switching to unset, then reuses the default-route replacement',
+        (previousRoute) => {
+          mockSession.options.useCanaryRtcServer = previousRoute;
+          connection.connect();
+          let ws = (connection as any)._wsClient as MockWebSocket;
+          ws.simulateMessage({ voice_sdk_id: 'explicit-route-voice-sdk-id' });
+          (getReconnectToken as jest.Mock).mockReturnValue(
+            'explicit-route-voice-sdk-id'
+          );
 
-        delete mockSession.options.useCanaryRtcServer;
-        connection.connect();
-        let url = currentWebSocketUrl();
-        expect(url.searchParams.has('canary')).toBe(false);
-        expect(url.searchParams.get('voice_sdk_id')).toBe(
-          'canary-voice-sdk-id'
-        );
-        ws = (connection as any)._wsClient as MockWebSocket;
-        ws.simulateMessage({ voice_sdk_id: 'default-voice-sdk-id' });
-        (getReconnectToken as jest.Mock).mockReturnValue(
-          'default-voice-sdk-id'
-        );
+          delete mockSession.options.useCanaryRtcServer;
+          connection.connect();
+          let url = currentWebSocketUrl();
+          expect(url.searchParams.has('canary')).toBe(false);
+          expect(url.searchParams.has('voice_sdk_id')).toBe(false);
 
-        mockSession.options.useCanaryRtcServer = true;
-        connection.connect();
-        url = currentWebSocketUrl();
-        expect(url.searchParams.has('voice_sdk_id')).toBe(false);
-      });
+          ws = (connection as any)._wsClient as MockWebSocket;
+          ws.simulateMessage({ voice_sdk_id: 'default-voice-sdk-id' });
+          (getReconnectToken as jest.Mock).mockReturnValue(
+            'default-voice-sdk-id'
+          );
+
+          connection.connect();
+          url = currentWebSocketUrl();
+          expect(url.searchParams.has('canary')).toBe(false);
+          expect(url.searchParams.get('voice_sdk_id')).toBe(
+            'default-voice-sdk-id'
+          );
+        }
+      );
 
       it.each([true, false])(
         'omits a stored voice_sdk_id on the first explicit %s connection, then reuses the replacement while unchanged',

--- a/packages/js/src/Modules/Verto/tests/services/Connection.test.ts
+++ b/packages/js/src/Modules/Verto/tests/services/Connection.test.ts
@@ -13,12 +13,17 @@ import { trigger } from '../../services/Handler';
 import { SwEvent } from '../../util/constants';
 import { Region } from '../../../../index';
 import logger from '../../util/logger';
-import { getReconnectToken, setReconnectToken } from '../../util/reconnect';
+import {
+  getReconnectToken,
+  getReconnectTokenCanaryRtcServer,
+  setReconnectToken,
+} from '../../util/reconnect';
 
 jest.mock('../../services/Handler');
 jest.mock('../../util/logger');
 jest.mock('../../util/reconnect', () => ({
   getReconnectToken: jest.fn(() => null),
+  getReconnectTokenCanaryRtcServer: jest.fn(() => undefined),
   setReconnectToken: jest.fn(),
 }));
 
@@ -115,9 +120,9 @@ describe('Connection - region selection', () => {
 
   it('preserves default, custom-host, and unknown-region behavior', () => {
     expect(hostFor()).toBe('wss://rtc.telnyx.com');
-    expect(
-      hostFor({ host: 'wss://rtc.example.com', region: Region.EU })
-    ).toBe('wss://eu.rtc.example.com');
+    expect(hostFor({ host: 'wss://rtc.example.com', region: Region.EU })).toBe(
+      'wss://eu.rtc.example.com'
+    );
     expect(hostFor({ region: 'future-region' })).toBe(
       'wss://future-region.rtc.telnyx.com'
     );
@@ -149,6 +154,7 @@ describe('Connection - Safety Timeout', () => {
     };
 
     connection = new Connection(mockSession);
+    mockSession.connection = connection;
   });
 
   afterEach(() => {
@@ -233,6 +239,9 @@ describe('Connection - Safety Timeout', () => {
 
       beforeEach(() => {
         (getReconnectToken as jest.Mock).mockReturnValue('stored-voice-sdk-id');
+        (getReconnectTokenCanaryRtcServer as jest.Mock).mockReturnValue(
+          undefined
+        );
       });
 
       it.each([
@@ -273,7 +282,9 @@ describe('Connection - Safety Timeout', () => {
         );
         ws = (connection as any)._wsClient as MockWebSocket;
         ws.simulateMessage({ voice_sdk_id: 'default-voice-sdk-id' });
-        (getReconnectToken as jest.Mock).mockReturnValue('default-voice-sdk-id');
+        (getReconnectToken as jest.Mock).mockReturnValue(
+          'default-voice-sdk-id'
+        );
 
         mockSession.options.useCanaryRtcServer = true;
         connection.connect();
@@ -303,6 +314,95 @@ describe('Connection - Safety Timeout', () => {
           );
         }
       );
+
+      it('uses the persisted canary association for the current stored voice_sdk_id instead of stale session state', () => {
+        mockSession.reconnectTokenCanaryRtcServer = true;
+        mockSession.options.useCanaryRtcServer = false;
+        (getReconnectTokenCanaryRtcServer as jest.Mock).mockReturnValue(false);
+
+        connection.connect();
+
+        expect(currentWebSocketUrl().searchParams.get('voice_sdk_id')).toBe(
+          'stored-voice-sdk-id'
+        );
+      });
+
+      it('keeps the replacement voice_sdk_id when Connection is recreated within the same session', () => {
+        mockSession.options.useCanaryRtcServer = true;
+        connection.connect();
+        const ws = (connection as any)._wsClient as MockWebSocket;
+        ws.simulateMessage({ voice_sdk_id: 'replacement-voice-sdk-id' });
+        (getReconnectToken as jest.Mock).mockReturnValue(
+          'replacement-voice-sdk-id'
+        );
+
+        connection = new Connection(mockSession);
+        mockSession.connection = connection;
+        connection.connect();
+
+        expect(currentWebSocketUrl().searchParams.get('voice_sdk_id')).toBe(
+          'replacement-voice-sdk-id'
+        );
+      });
+
+      it('stores the canary routing association on the session with the replacement voice_sdk_id', () => {
+        mockSession.options.useCanaryRtcServer = false;
+        connection.connect();
+        const ws = (connection as any)._wsClient as MockWebSocket;
+
+        ws.simulateMessage({ voice_sdk_id: 'replacement-voice-sdk-id' });
+
+        expect(mockSession.reconnectTokenCanaryRtcServer).toBe(false);
+        expect(setReconnectToken).toHaveBeenCalledWith(
+          'replacement-voice-sdk-id',
+          false
+        );
+      });
+
+      it('ignores a late voice_sdk_id response from a superseded socket route', () => {
+        mockSession.options.useCanaryRtcServer = true;
+        connection.connect();
+        const oldWs = (connection as any)._wsClient as MockWebSocket;
+
+        mockSession.options.useCanaryRtcServer = false;
+        connection.connect();
+        const currentWs = (connection as any)._wsClient as MockWebSocket;
+        currentWs.simulateMessage({ voice_sdk_id: 'current-voice-sdk-id' });
+        (setReconnectToken as jest.Mock).mockClear();
+
+        oldWs.simulateMessage({ voice_sdk_id: 'stale-voice-sdk-id' });
+
+        expect(mockSession.reconnectTokenCanaryRtcServer).toBe(false);
+        expect(setReconnectToken).not.toHaveBeenCalledWith(
+          'stale-voice-sdk-id',
+          true
+        );
+      });
+
+      it('ignores a late voice_sdk_id response from a replaced Connection', () => {
+        mockSession.options.useCanaryRtcServer = true;
+        connection.connect();
+        const replacedConnectionWs = (connection as any)
+          ._wsClient as MockWebSocket;
+
+        mockSession.options.useCanaryRtcServer = false;
+        connection = new Connection(mockSession);
+        mockSession.connection = connection;
+        connection.connect();
+        const currentWs = (connection as any)._wsClient as MockWebSocket;
+        currentWs.simulateMessage({ voice_sdk_id: 'current-voice-sdk-id' });
+        (setReconnectToken as jest.Mock).mockClear();
+
+        replacedConnectionWs.simulateMessage({
+          voice_sdk_id: 'stale-voice-sdk-id',
+        });
+
+        expect(mockSession.reconnectTokenCanaryRtcServer).toBe(false);
+        expect(setReconnectToken).not.toHaveBeenCalledWith(
+          'stale-voice-sdk-id',
+          true
+        );
+      });
 
       it('keeps omitting the old voice_sdk_id after a canary switch until the new route returns a replacement', () => {
         mockSession.options.useCanaryRtcServer = true;
@@ -660,7 +760,7 @@ describe('Connection - Safety Timeout', () => {
       ws.simulateMessage({ id: 'message-id', voice_sdk_id: 'voice-sdk-id' });
 
       expect(mockSession.callReportVoiceSdkId).toBe('voice-sdk-id');
-      expect(setReconnectToken).toHaveBeenCalledWith('voice-sdk-id');
+      expect(setReconnectToken).toHaveBeenCalledWith('voice-sdk-id', undefined);
     });
   });
 

--- a/packages/js/src/Modules/Verto/tests/signaling-health/SignalingHealth.test.ts
+++ b/packages/js/src/Modules/Verto/tests/signaling-health/SignalingHealth.test.ts
@@ -29,6 +29,7 @@ jest.mock('../../services/Handler');
 jest.mock('../../util/logger');
 jest.mock('../../util/reconnect', () => ({
   getReconnectToken: jest.fn(() => null),
+  getReconnectTokenCanaryRtcServer: jest.fn(() => undefined),
   setReconnectToken: jest.fn(),
 }));
 

--- a/packages/js/src/Modules/Verto/util/reconnect.ts
+++ b/packages/js/src/Modules/Verto/util/reconnect.ts
@@ -31,6 +31,7 @@ export interface IStoredActiveCalls {
 }
 
 const STORAGE_KEY = 'telnyx-voice-sdk-id';
+const CANARY_RTC_SERVER_STORAGE_KEY = 'telnyx-voice-sdk-id-canary-rtc-server';
 const SESSION_ID_STORAGE_KEY = 'telnyx-voice-sdk-session-id';
 const SESSION_ID_STORED_AT_STORAGE_KEY =
   'telnyx-voice-sdk-session-id-stored-at';
@@ -56,8 +57,26 @@ export function getReconnectToken(): string | null {
   return token;
 }
 
-export function setReconnectToken(token: string): void {
+export function getReconnectTokenCanaryRtcServer(): boolean | undefined {
+  const value = safeGetItem(CANARY_RTC_SERVER_STORAGE_KEY);
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  return undefined;
+}
+
+export function setReconnectToken(
+  token: string,
+  useCanaryRtcServer?: boolean
+): void {
   sessionStorage.setItem(STORAGE_KEY, token);
+  if (typeof useCanaryRtcServer === 'boolean') {
+    sessionStorage.setItem(
+      CANARY_RTC_SERVER_STORAGE_KEY,
+      String(useCanaryRtcServer)
+    );
+  } else {
+    sessionStorage.removeItem(CANARY_RTC_SERVER_STORAGE_KEY);
+  }
 }
 
 export function getReconnectSessionId(now = Date.now()): string | null {
@@ -83,6 +102,7 @@ export function setReconnectSessionId(
 
 export function clearReconnectToken(): void {
   sessionStorage.removeItem(STORAGE_KEY);
+  sessionStorage.removeItem(CANARY_RTC_SERVER_STORAGE_KEY);
   sessionStorage.removeItem(SESSION_ID_STORAGE_KEY);
   sessionStorage.removeItem(SESSION_ID_STORED_AT_STORAGE_KEY);
 }

--- a/packages/js/src/utils/interfaces.ts
+++ b/packages/js/src/utils/interfaces.ts
@@ -192,7 +192,9 @@ export interface IClientOptions {
   rtcPort?: number;
 
   /**
-   *  Use Telnyx's Canary RTC server
+   * Override VSP RTC routing for this connection. `true` forces the Canary
+   * RTC server, `false` forces the stable RTC server, and omission leaves
+   * routing to VSP's default load-based behavior.
    */
   useCanaryRtcServer?: boolean;
 


### PR DESCRIPTION
## Summary
- treats `useCanaryRtcServer` as an optional routing override
- sends `canary=true` or `canary=false` for explicit booleans and omits `canary` when unset
- drops `voice_sdk_id` when an explicit canary value differs from the routing state associated with the stored token
- keeps stale-token reuse suppressed across failed route-switch retries until the new socket returns a replacement `voice_sdk_id`
- preserves normal reconnect stickiness when the option is omitted or unchanged

## Routing behavior
| `useCanaryRtcServer` | WebSocket query |
|---|---|
| `true` | `canary=true` |
| `false` | `canary=false` |
| omitted | no `canary` parameter |

## Dependencies
- VSP routing toggle: https://github.com/team-telnyx/voice-sdk-proxy/pull/166
- Demo companion PR: https://github.com/team-telnyx/webrtc-demo-js/pull/128

## Verification
- [x] Focused Connection tests: 59 passed
- [x] Full JS package tests: 711 passed
- [x] TypeScript no-emit check
- [x] SDK build
- [x] Scoped ESLint on changed implementation and tests
- [x] `git diff --check`
- [x] Independent review passed

## Note
The repository commit hook also lints the full touched public interface file and is blocked by the pre-existing `@typescript-eslint/no-unsafe-function-type` violation at `src/utils/interfaces.ts:504`. The changed implementation/test files pass scoped ESLint, and the complete typecheck/test/build stack above is green.
