### PR TITLE
fix(js): reconnect to a different b2bua-rtc on a transient login rejection (VSUP-171)

### DIFF
--- a/packages/js/src/Modules/Verto/BaseSession.ts
+++ b/packages/js/src/Modules/Verto/BaseSession.ts
@@ -65,6 +65,33 @@ import type { RestartIceResult } from './webrtc/Peer';
  */
 const KEEPALIVE_INTERVAL = 35 * 1000;
 
+/**
+ * JSON-RPC error codes the gateway uses for a rejected login.
+ *
+ * Both are ambiguous on their own — the same code covers a terminal
+ * rejection (expired/revoked credential) and a transient one (the
+ * credential has not propagated to the b2bua-rtc instance yet), so the
+ * message text is what disambiguates. See TRANSIENT_LOGIN_ERROR_MESSAGES.
+ */
+const LOGIN_INCORRECT_CODE = -32001;
+const AUTHENTICATION_REQUIRED_CODE = -32000;
+
+/**
+ * Login rejections that are worth retrying on a different b2bua-rtc.
+ *
+ * These are the two messages emitted while a freshly minted credential is
+ * still propagating to the instance handling the login. Any other message
+ * carried by the same error codes (e.g. an expired credential) is terminal
+ * and must pass straight through — retrying it only delays the error the
+ * caller needs to see.
+ *
+ * Matches the message-based gating voice-sdk-proxy uses for the same race.
+ */
+const TRANSIENT_LOGIN_ERROR_MESSAGES = [
+  'login incorrect',
+  'authentication required',
+];
+
 export default abstract class BaseSession {
   public uuid: string = uuidv4();
   public sessionid: string = '';
@@ -108,8 +135,23 @@ export default abstract class BaseSession {
    *  on normal app teardown or token refresh. */
   protected _intentionalClose: boolean = false;
 
+  /**
+   * Socket reconnects already spent retrying a transient login rejection.
+   * Reset on a successful login so a later, unrelated race gets a fresh
+   * budget. See _handleLoginError.
+   */
+  private _transientLoginReconnects: number = 0;
+
   private _tokenExpiryTimeout: ReturnType<typeof setTimeout> | null = null;
   private static readonly TOKEN_EXPIRY_WARNING_SECONDS = 120;
+  /**
+   * How many times the SDK will reconnect to retry a transient login
+   * rejection before surfacing it. Deliberately small: voice-sdk-proxy
+   * already re-sends the login up to 10 times in-connection, so this only
+   * covers the case where that whole burst lost the race on one
+   * b2bua-rtc instance and a different instance is worth trying.
+   */
+  private static readonly MAX_TRANSIENT_LOGIN_RECONNECTS = 2;
   private static readonly CALL_REPORT_UPLOAD_DRAIN_TIMEOUT_MS = 10000;
   private _pendingCallReportUploads = new Set<Promise<void>>();
 
@@ -515,17 +557,98 @@ export default abstract class BaseSession {
   }
 
   /**
+   * True when a rejected login is the credential-propagation race rather
+   * than a genuinely bad credential — i.e. worth retrying elsewhere.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private static _isTransientLoginError(error: any): boolean {
+    const code = error?.code;
+    if (
+      code !== LOGIN_INCORRECT_CODE &&
+      code !== AUTHENTICATION_REQUIRED_CODE
+    ) {
+      return false;
+    }
+    const message = String(error?.message ?? '').toLowerCase();
+    return TRANSIENT_LOGIN_ERROR_MESSAGES.some((candidate) =>
+      message.includes(candidate)
+    );
+  }
+
+  /**
    * Handle login error
+   *
+   * A login rejected because the credential has not propagated yet is
+   * recoverable, but only somewhere else: the gateway has already re-sent
+   * the login on this connection and exhausted its own retries, so
+   * re-sending again here would hit the same b2bua-rtc instance and fail
+   * the same way. Recovery therefore means a new socket.
+   *
+   * Reconnecting is enough to reach a different instance — `connect()`
+   * consults `options.skipLastVoiceSdkId`, so setting it here makes the
+   * next connection exclude the instance that just rejected us. Without
+   * a reconnect the flag is never read: nothing else re-enters
+   * `connect()` on a login error, which leaves the socket open and
+   * unauthenticated until something unrelated closes it.
+   *
+   * Bounded by MAX_TRANSIENT_LOGIN_RECONNECTS so a credential that is
+   * broken everywhere still surfaces promptly instead of cycling the
+   * b2bua-rtc pool.
+   *
    * @return void
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   protected _handleLoginError(error: any) {
-    const telnyxError = createTelnyxError(LOGIN_FAILED, error);
+    const isTransient = BaseSession._isTransientLoginError(error);
+    const willRetry =
+      isTransient &&
+      this._autoReconnect &&
+      this._transientLoginReconnects <
+        BaseSession.MAX_TRANSIENT_LOGIN_RECONNECTS;
+
+    // While the SDK still has a reconnect to spend the situation is not
+    // terminal, so `fatal` stays false and the app can keep waiting.
+    const telnyxError = createTelnyxError(
+      LOGIN_FAILED,
+      error,
+      undefined,
+      !willRetry
+    );
     trigger(
       SwEvent.Error,
       { error: telnyxError, sessionId: this.sessionid },
       this.uuid
     );
+
+    if (!willRetry) {
+      if (isTransient) {
+        logger.info(
+          `Login rejected as transient but not retrying ` +
+            `(reconnects spent=${this._transientLoginReconnects}/` +
+            `${BaseSession.MAX_TRANSIENT_LOGIN_RECONNECTS}, ` +
+            `autoReconnect=${this._autoReconnect})`
+        );
+      }
+      return;
+    }
+
+    this._transientLoginReconnects += 1;
+
+    // Route the next connection away from the instance that rejected us
+    // instead of sticky-reconnecting to it.
+    this.options.skipLastVoiceSdkId = true;
+
+    logger.info(
+      `Login rejected by the gateway as transient ` +
+        `(code=${error?.code}, message=${error?.message}) — reconnecting to a ` +
+        `different b2bua-rtc instance ` +
+        `(${this._transientLoginReconnects}/${BaseSession.MAX_TRANSIENT_LOGIN_RECONNECTS})`
+    );
+
+    // Closing the socket routes into the existing reconnect path
+    // (SocketClose → onNetworkClose → connect()), which owns the backoff
+    // and the attempt ceiling. Do not call connect() directly.
+    this._closeConnection();
   }
 
   /**
@@ -772,6 +895,9 @@ export default abstract class BaseSession {
     });
 
     if (response) {
+      // A login got through, so the propagation race (if any) is over.
+      // Give a later, unrelated race a fresh retry budget.
+      this._transientLoginReconnects = 0;
       this.sessionid = response.sessid;
       if (this.sessionid) {
         setReconnectSessionId(this.sessionid);

--- a/packages/js/src/Modules/Verto/tests/TransientLoginRetry.test.ts
+++ b/packages/js/src/Modules/Verto/tests/TransientLoginRetry.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Unit tests for reconnecting on a transient login rejection (VSUP-171).
+ *
+ * A `-32001 Login Incorrect` raised while a freshly minted credential is
+ * still propagating is recoverable, but only on a different b2bua-rtc
+ * instance. The session must therefore drop the socket (so the existing
+ * reconnect path re-enters `connect()`) with `skipLastVoiceSdkId` set, and
+ * must stop doing so after a bounded number of attempts. Terminal
+ * rejections carrying the same code must pass straight through.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import BaseSession from '../BaseSession';
+import { trigger } from '../services/Handler';
+import { SwEvent, LOGIN_FAILED } from '../util/constants';
+
+jest.mock('../services/Connection');
+jest.mock('../services/Handler');
+jest.mock('../util/logger');
+jest.mock('../util/reconnect', () => ({
+  getReconnectToken: jest.fn(() => null),
+  getReconnectSessionId: jest.fn(() => ''),
+  isReconnectSessionIdFresh: jest.fn(() => false),
+  setReconnectToken: jest.fn(),
+  setReconnectSessionId: jest.fn(),
+  clearReconnectToken: jest.fn(),
+}));
+
+const mockTrigger = trigger as jest.MockedFunction<typeof trigger>;
+
+class TestSession extends BaseSession {
+  validateOptions() {
+    return true;
+  }
+}
+
+const TRANSIENT_ERROR = { code: -32001, message: 'Login Incorrect' };
+
+/** The LOGIN_FAILED payload from the most recent SwEvent.Error trigger. */
+function lastLoginFailedEvent(): any {
+  const calls = mockTrigger.mock.calls.filter(
+    ([event, payload]: any[]) =>
+      event === SwEvent.Error && payload?.error?.code === LOGIN_FAILED
+  );
+  return calls.length ? (calls[calls.length - 1][1] as any) : null;
+}
+
+describe('BaseSession - transient login rejection', () => {
+  let session: any;
+  let mockConnection: any;
+
+  beforeEach(() => {
+    mockTrigger.mockClear();
+    session = new TestSession({ login: 'testuser', password: 'testpass' });
+    mockConnection = {
+      close: jest.fn(),
+      connect: jest.fn(),
+      isAlive: true,
+      connected: true,
+      previousGatewayState: '',
+      socketGeneration: 0,
+    };
+    session.connection = mockConnection;
+    session._autoReconnect = true;
+    session._idle = false;
+  });
+
+  describe('recoverable rejections', () => {
+    it('closes the socket so the reconnect path re-enters connect()', () => {
+      session._handleLoginError(TRANSIENT_ERROR);
+
+      expect(mockConnection.close).toHaveBeenCalledTimes(1);
+    });
+
+    it('asks the next connection to skip the instance that rejected the login', () => {
+      expect(session.options.skipLastVoiceSdkId).toBeUndefined();
+
+      session._handleLoginError(TRANSIENT_ERROR);
+
+      expect(session.options.skipLastVoiceSdkId).toBe(true);
+    });
+
+    it('reports the error as non-fatal while a retry is still budgeted', () => {
+      session._handleLoginError(TRANSIENT_ERROR);
+
+      expect(lastLoginFailedEvent().error.fatal).toBe(false);
+    });
+
+    it('treats -32000 Authentication Required the same way', () => {
+      session._handleLoginError({
+        code: -32000,
+        message: 'Authentication Required',
+      });
+
+      expect(mockConnection.close).toHaveBeenCalledTimes(1);
+      expect(session.options.skipLastVoiceSdkId).toBe(true);
+    });
+
+    it('matches the gateway message case-insensitively', () => {
+      session._handleLoginError({ code: -32001, message: 'LOGIN INCORRECT' });
+
+      expect(mockConnection.close).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('retry ceiling', () => {
+    it('stops reconnecting after the bounded number of attempts', () => {
+      session._handleLoginError(TRANSIENT_ERROR);
+      session._handleLoginError(TRANSIENT_ERROR);
+      expect(mockConnection.close).toHaveBeenCalledTimes(2);
+
+      // Third rejection exceeds the ceiling — surface it instead.
+      session._handleLoginError(TRANSIENT_ERROR);
+
+      expect(mockConnection.close).toHaveBeenCalledTimes(2);
+      expect(lastLoginFailedEvent().error.fatal).toBe(true);
+    });
+
+    it('restores the budget after a login succeeds', async () => {
+      session._handleLoginError(TRANSIENT_ERROR);
+      session._handleLoginError(TRANSIENT_ERROR);
+      expect(session._transientLoginReconnects).toBe(2);
+
+      jest
+        .spyOn(session, 'execute')
+        .mockResolvedValue({ sessid: 'session-after-recovery' });
+      await session._login({ type: 'login' });
+
+      expect(session._transientLoginReconnects).toBe(0);
+
+      session._handleLoginError(TRANSIENT_ERROR);
+      expect(mockConnection.close).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('rejections that must not be retried', () => {
+    it('passes through a terminal error carrying the same code', () => {
+      session._handleLoginError({
+        code: -32001,
+        message: 'Credential expired',
+      });
+
+      expect(mockConnection.close).not.toHaveBeenCalled();
+      expect(session.options.skipLastVoiceSdkId).toBeUndefined();
+      expect(lastLoginFailedEvent().error.fatal).toBe(true);
+    });
+
+    it('passes through an unrelated error code', () => {
+      session._handleLoginError({ code: -32600, message: 'Invalid Request' });
+
+      expect(mockConnection.close).not.toHaveBeenCalled();
+    });
+
+    it('passes through an error with no code at all', () => {
+      session._handleLoginError(new Error('socket exploded'));
+
+      expect(mockConnection.close).not.toHaveBeenCalled();
+    });
+
+    it('does not reconnect when auto-reconnect is disabled', () => {
+      session._autoReconnect = false;
+
+      session._handleLoginError(TRANSIENT_ERROR);
+
+      expect(mockConnection.close).not.toHaveBeenCalled();
+      expect(lastLoginFailedEvent().error.fatal).toBe(true);
+    });
+  });
+
+  it('always emits LOGIN_FAILED, retrying or not', () => {
+    session._handleLoginError(TRANSIENT_ERROR);
+    expect(lastLoginFailedEvent()).not.toBeNull();
+
+    mockTrigger.mockClear();
+    session._handleLoginError({ code: -32001, message: 'Credential expired' });
+    expect(lastLoginFailedEvent()).not.toBeNull();
+  });
+});


### PR DESCRIPTION
Part 1 of 2 for VSUP-171. Independent of #760 — either can merge first.

## Problem

`anonymous_login` intermittently fails with `-32001 Login Incorrect` while a freshly minted credential is still propagating to the b2bua-rtc instance handling the login.

voice-sdk-proxy already re-sends the login on the same upstream connection up to 10 times (`gateway_message_handler/V1.ex`, `login_attempt_count < 10`, 250 ms apart) before forwarding the error. All 10 attempts hit the **same** instance, so by the time the SDK sees `-32001` the only useful recovery left is a different instance.

`_handleLoginError` did one thing — emit `SwEvent.Error`. Nothing re-entered `connect()`, so `options.skipLastVoiceSdkId` (the mechanism that would pick a different instance, on by default in ai-agent-lib) was **never consulted**, and the socket stayed open and unauthenticated.

From the VSUP-171 Graylog capture (peer `108.240.150.47`, VSP pod `tel-da1-kube-prod-750`):

```
19:07:07.741  Handling anonymous login race condition, attempts: 1
...                                                    (9 retries, 250ms apart)
19:07:10.168  -32001 Login Incorrect  → forwarded to client
19:07:25 / :40 / :55   gateway pings, no client activity
19:08:04.272  Terminating socket connection, reason {:remote, 1001, ""}
```

54 seconds of a live-but-logged-out socket, recovered only because the browser closed it.

## Change

On a login rejection that looks like the propagation race, set `skipLastVoiceSdkId` and close the socket. That routes into the existing `SocketClose → onNetworkClose → connect()` path, which already owns the backoff and the attempt ceiling — no parallel retry loop.

- **Bounded** to 2 reconnects (`MAX_TRANSIENT_LOGIN_RECONNECTS`), reset on a successful login, so a credential that is broken everywhere still surfaces promptly instead of cycling the b2bua-rtc pool.
- **Gated on the message**, not just the code: `-32001`/`-32000` carrying `Login Incorrect` or `Authentication Required` retry; anything else on the same codes (e.g. an expired credential) is terminal and passes straight through. Same gating voice-sdk-proxy uses for this race.
- `LOGIN_FAILED` is still emitted every time. `fatal` is `false` while a retry is budgeted and `true` once it is not, so existing consumers see no change in event shape.
- Skipped entirely when `autoReconnect` is disabled.

## Not in this PR

`skip_last_voice_sdk_id` excludes the instance encoded in the last `voice_sdk_id` the client *received* (`Connection.ts` `setReconnectToken` in `ws.onmessage`), not the one it just attempted. When the client cannot process the error response at all, that token goes stale and the next reconnect can land right back on the instance that just failed — observed twice in the same capture. Not a problem on this path (handling the error implies the message was processed), so it is left for a separate change.

## Test plan

- 12 new unit tests in `TransientLoginRetry.test.ts`: socket closed, flag set, non-fatal while budgeted, `-32000` handled, case-insensitive match, ceiling enforced, budget restored after success, terminal/unrelated/codeless errors pass through, auto-reconnect off respected.
- Full package suite green (723 tests), `tsc --noEmit` clean, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)