### PR TITLE
fix(js): detect a socket that receives but no longer sends (VSUP-171)

### DIFF
--- a/packages/js/src/Modules/Verto/BaseSession.ts
+++ b/packages/js/src/Modules/Verto/BaseSession.ts
@@ -1188,6 +1188,17 @@ export default abstract class BaseSession {
   }
 
   /**
+   * Called by Connection.send() when a request we sent comes back
+   * answered. Feeds the monitor's outbound-liveness clock, which is what
+   * distinguishes a working socket from one that only still receives.
+   *
+   * Public because Connection calls it; not part of the app-facing API.
+   */
+  public onOutboundConfirmed(): void {
+    this._signalingHealthMonitor.onOutboundConfirmed();
+  }
+
+  /**
    * Returns true if there is at least one active (non-terminated) call.
    * Public so that BaseCall can check if the monitor should stop.
    */

--- a/packages/js/src/Modules/Verto/services/Connection.ts
+++ b/packages/js/src/Modules/Verto/services/Connection.ts
@@ -260,7 +260,7 @@ export default class Connection {
         // frames, which inbound activity alone does not. Recorded even
         // when the response is late or is an error — both still prove the
         // round trip completed.
-        this.session.onOutboundConfirmed?.();
+        this.session.onOutboundConfirmed();
 
         if (timedOut) {
           // Response arrived after timeout — discard silently

--- a/packages/js/src/Modules/Verto/services/Connection.ts
+++ b/packages/js/src/Modules/Verto/services/Connection.ts
@@ -255,6 +255,13 @@ export default class Connection {
         }
         this._pendingRequestIds.delete(request.id);
         this._pendingRequestRejecters.delete(request.id);
+
+        // A response to something we sent proves the socket carries our
+        // frames, which inbound activity alone does not. Recorded even
+        // when the response is late or is an error — both still prove the
+        // round trip completed.
+        this.session.onOutboundConfirmed?.();
+
         if (timedOut) {
           // Response arrived after timeout — discard silently
           return;

--- a/packages/js/src/Modules/Verto/services/SignalingHealthMonitor.ts
+++ b/packages/js/src/Modules/Verto/services/SignalingHealthMonitor.ts
@@ -32,6 +32,22 @@ const PROBE_TIMEOUT_MS = 5 * 1000; // 5s after probe → give up
 const CHECK_INTERVAL_MS = 3 * 1000;
 
 /**
+ * How long (ms) the socket may go without a single outbound request being
+ * answered before signaling health is treated as unknown and probed.
+ *
+ * Inbound bytes alone do not prove the socket works. b2bua-rtc pings every
+ * ~15s and the SDK answers each one, so a working session confirms an
+ * outbound round trip at roughly that cadence. When frames keep arriving
+ * but nothing we send is ever answered, the socket is half-open (or the
+ * page has stopped executing our handlers) — a state the inbound-only
+ * check reads as perfectly healthy, because the pings keep landing.
+ *
+ * Set to three missed ping cycles so a single slow round trip cannot
+ * trigger a probe.
+ */
+const OUTBOUND_CONFIRM_THRESHOLD_MS = 45 * 1000;
+
+/**
  * If inbound WS activity was received within this window (ms),
  * signaling is considered recently active and a triggered probe
  * is skipped.
@@ -68,6 +84,12 @@ type PendingMediaRecovery = {
 export default class SignalingHealthMonitor {
   /** Timestamp of the last inbound WS message. */
   private _lastInboundAt: number = 0;
+  /**
+   * Timestamp of the last outbound request that came back answered.
+   * Distinct from _lastInboundAt: this one proves the socket carries our
+   * frames, not just the server's. See OUTBOUND_CONFIRM_THRESHOLD_MS.
+   */
+  private _lastOutboundConfirmedAt: number = 0;
   /** Timestamp of the last health probe (Ping) sent. Reset to 0 on activity. */
   private _lastProbeSentAt: number = 0;
   /** True when a probe has been sent and we're waiting for a response. */
@@ -116,6 +138,7 @@ export default class SignalingHealthMonitor {
     }
     logger.debug('Signaling health: monitor started');
     this._lastInboundAt = Date.now();
+    this._lastOutboundConfirmedAt = Date.now();
     this._probeInFlight = false;
     this._lastProbeSentAt = 0;
 
@@ -165,6 +188,20 @@ export default class SignalingHealthMonitor {
     this._lastInboundAt = Date.now();
   }
 
+  /**
+   * Called when a request the SDK sent comes back answered — by a result
+   * or by an error, since either one proves the frame reached the server
+   * and the reply reached our handler.
+   *
+   * This is the only signal that says the socket works in both
+   * directions. onSocketActivity() cannot: it fires on server-initiated
+   * traffic too, so it stays fresh on a socket that is no longer carrying
+   * anything we send.
+   */
+  onOutboundConfirmed(): void {
+    this._lastOutboundConfirmedAt = Date.now();
+  }
+
   private _resolveProbe(): void {
     if (!this._probeInFlight) {
       return;
@@ -173,6 +210,8 @@ export default class SignalingHealthMonitor {
     this._probeInFlight = false;
     this._lastProbeSentAt = 0;
     this._lastInboundAt = Date.now();
+    // A resolved probe is itself a completed outbound round trip.
+    this._lastOutboundConfirmedAt = Date.now();
     logger.debug('Signaling health: probe resolved by matching Ping response');
 
     if (!this._pendingMediaRecovery) {
@@ -437,9 +476,18 @@ export default class SignalingHealthMonitor {
   // ── Private ─────────────────────────────────────────────────────────
 
   /**
-   * Periodic check: if no inbound WS activity during an active call for
-   * PROBE_THRESHOLD_MS, send a probe. If a probe is in-flight and
-   * PROBE_TIMEOUT_MS has elapsed, declare signaling unhealthy.
+   * Periodic check. Two independent reasons to probe:
+   *
+   * - Inbound silence for PROBE_THRESHOLD_MS — nothing is arriving.
+   * - No outbound request answered for OUTBOUND_CONFIRM_THRESHOLD_MS —
+   *   frames may still be arriving, but none of ours are getting through
+   *   (or are being processed). Inbound silence alone never catches this,
+   *   because server pings keep the inbound clock fresh.
+   *
+   * Either way the probe is the arbiter: it resolves only on its own
+   * matching response, so it settles both questions at once. If a probe
+   * is in flight and PROBE_TIMEOUT_MS has elapsed, declare signaling
+   * unhealthy.
    */
   private _check(): void {
     if (!this._session.connection?.connected) {
@@ -448,16 +496,21 @@ export default class SignalingHealthMonitor {
 
     const now = Date.now();
     const silenceMs = now - this._lastInboundAt;
+    const unconfirmedMs = now - this._lastOutboundConfirmedAt;
+    const inboundStale = silenceMs >= PROBE_THRESHOLD_MS;
+    const outboundStale = unconfirmedMs >= OUTBOUND_CONFIRM_THRESHOLD_MS;
 
-    // If we have recent activity, nothing to do
-    if (silenceMs < PROBE_THRESHOLD_MS) {
+    // If both directions look recently healthy, nothing to do
+    if (!inboundStale && !outboundStale) {
       return;
     }
 
     // If no probe is in flight, send one
     if (!this._probeInFlight) {
       logger.info(
-        `Signaling health: no inbound WS activity for ${Math.round(silenceMs / 1000)}s during active call, sending health probe`
+        inboundStale
+          ? `Signaling health: no inbound WS activity for ${Math.round(silenceMs / 1000)}s during active call, sending health probe`
+          : `Signaling health: inbound WS activity is flowing but no outbound request has been answered for ${Math.round(unconfirmedMs / 1000)}s, sending health probe`
       );
       this._sendProbe();
       return;
@@ -467,10 +520,15 @@ export default class SignalingHealthMonitor {
     const probeElapsedMs = now - this._lastProbeSentAt;
     if (probeElapsedMs >= PROBE_TIMEOUT_MS) {
       logger.warn(
-        `Signaling health: probe timed out after ${probeElapsedMs}ms with no inbound activity — declaring signaling unhealthy`
+        `Signaling health: probe timed out after ${probeElapsedMs}ms ` +
+          `(inbound silent for ${Math.round(silenceMs / 1000)}s, ` +
+          `no outbound request answered for ${Math.round(unconfirmedMs / 1000)}s) — ` +
+          `declaring signaling unhealthy`
       );
       this._triggerSignalingRecovery(
-        'Signaling health probe timed out: no inbound WS activity after probe',
+        inboundStale
+          ? 'Signaling health probe timed out: no inbound WS activity after probe'
+          : 'Signaling health probe timed out: inbound WS activity is flowing but no outbound request is being answered',
         'probe'
       );
     }

--- a/packages/js/src/Modules/Verto/tests/signaling-health/OutboundLiveness.test.ts
+++ b/packages/js/src/Modules/Verto/tests/signaling-health/OutboundLiveness.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Unit tests for outbound-liveness detection in SignalingHealthMonitor
+ * (VSUP-171).
+ *
+ * The monitor used to decide health from inbound WS activity alone. On a
+ * socket where b2bua-rtc keeps pinging every ~15s but nothing the SDK
+ * sends is ever answered, that clock stays fresh forever and the session
+ * looks healthy while being useless. These tests cover the second clock:
+ * the last outbound request that came back answered.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import SignalingHealthMonitor from '../../services/SignalingHealthMonitor';
+
+jest.mock('../../services/Handler');
+jest.mock('../../util/logger');
+jest.mock('../../util/reconnect', () => ({
+  getReconnectToken: jest.fn(() => null),
+  setReconnectToken: jest.fn(),
+}));
+
+const CHECK_INTERVAL_MS = 3_000;
+const PROBE_TIMEOUT_MS = 5_000;
+const OUTBOUND_CONFIRM_THRESHOLD_MS = 45_000;
+/** b2bua-rtc pings at this cadence; the SDK answers each one. */
+const SERVER_PING_INTERVAL_MS = 15_000;
+
+describe('SignalingHealthMonitor – outbound liveness', () => {
+  let mockSession: any;
+  let monitor: SignalingHealthMonitor;
+  /** Resolvers for probes sent via connection.send(), newest last. */
+  let pendingProbes: Array<(value?: unknown) => void>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // 'modern' so advanceTimersByTime also moves Date.now() — the monitor
+    // compares wall-clock timestamps, not timer ticks.
+    jest.useFakeTimers('modern');
+    jest.setSystemTime(new Date('2026-07-27T19:00:00.000Z'));
+
+    pendingProbes = [];
+    mockSession = {
+      uuid: 'test-uuid',
+      sessionid: 'test-session',
+      hasActiveCall: jest.fn(() => true),
+      triggerIceRestart: jest.fn(() => ({ started: true })),
+      socketDisconnect: jest.fn(),
+      connection: {
+        connected: true,
+        lastInboundAt: 0,
+        socketGeneration: 0,
+        send: jest.fn(
+          () => new Promise((resolve) => pendingProbes.push(resolve))
+        ),
+      },
+    };
+    monitor = new SignalingHealthMonitor(mockSession);
+    monitor.start();
+  });
+
+  afterEach(() => {
+    monitor.stop();
+    jest.useRealTimers();
+  });
+
+  /**
+   * Advance time in check-interval steps, keeping inbound activity fresh
+   * at the server ping cadence — i.e. exactly what a half-open socket
+   * looks like from the inbound side.
+   */
+  const advanceWithInboundPings = (totalMs: number) => {
+    for (let elapsed = 0; elapsed < totalMs; elapsed += CHECK_INTERVAL_MS) {
+      if (elapsed % SERVER_PING_INTERVAL_MS === 0) {
+        monitor.onSocketActivity();
+      }
+      jest.advanceTimersByTime(CHECK_INTERVAL_MS);
+    }
+  };
+
+  describe('a socket that only receives', () => {
+    it('stays quiet while outbound requests are still being answered', () => {
+      for (let elapsed = 0; elapsed < 120_000; elapsed += CHECK_INTERVAL_MS) {
+        if (elapsed % SERVER_PING_INTERVAL_MS === 0) {
+          monitor.onSocketActivity();
+          monitor.onOutboundConfirmed();
+        }
+        jest.advanceTimersByTime(CHECK_INTERVAL_MS);
+      }
+
+      expect(mockSession.connection.send).not.toHaveBeenCalled();
+      expect(mockSession.socketDisconnect).not.toHaveBeenCalled();
+    });
+
+    it('probes once inbound is flowing but nothing outbound is answered', () => {
+      advanceWithInboundPings(
+        OUTBOUND_CONFIRM_THRESHOLD_MS - CHECK_INTERVAL_MS
+      );
+      expect(mockSession.connection.send).not.toHaveBeenCalled();
+
+      advanceWithInboundPings(CHECK_INTERVAL_MS * 2);
+
+      expect(mockSession.connection.send).toHaveBeenCalledTimes(1);
+      expect(monitor.isProbeInFlight).toBe(true);
+    });
+
+    it('declares signaling unhealthy when that probe goes unanswered', () => {
+      advanceWithInboundPings(
+        OUTBOUND_CONFIRM_THRESHOLD_MS + CHECK_INTERVAL_MS
+      );
+      expect(mockSession.connection.send).toHaveBeenCalledTimes(1);
+      expect(mockSession.socketDisconnect).not.toHaveBeenCalled();
+
+      advanceWithInboundPings(PROBE_TIMEOUT_MS + CHECK_INTERVAL_MS);
+
+      expect(mockSession.socketDisconnect).toHaveBeenCalledTimes(1);
+    });
+
+    it('clears the alarm when the probe comes back', async () => {
+      advanceWithInboundPings(
+        OUTBOUND_CONFIRM_THRESHOLD_MS + CHECK_INTERVAL_MS
+      );
+      expect(pendingProbes).toHaveLength(1);
+
+      pendingProbes[0]();
+      await Promise.resolve();
+      expect(monitor.isProbeInFlight).toBe(false);
+
+      // The resolved probe counts as a fresh outbound round trip, so the
+      // monitor should go quiet again rather than immediately re-probing.
+      advanceWithInboundPings(
+        OUTBOUND_CONFIRM_THRESHOLD_MS - CHECK_INTERVAL_MS
+      );
+      expect(mockSession.connection.send).toHaveBeenCalledTimes(1);
+      expect(mockSession.socketDisconnect).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('interaction with the existing inbound check', () => {
+    it('still probes on inbound silence well before the outbound threshold', () => {
+      // No onSocketActivity at all — inbound silence trips first, at 20s.
+      jest.advanceTimersByTime(21_000);
+
+      expect(mockSession.connection.send).toHaveBeenCalledTimes(1);
+    });
+
+    it('does nothing while the socket is disconnected', () => {
+      mockSession.connection.connected = false;
+
+      advanceWithInboundPings(OUTBOUND_CONFIRM_THRESHOLD_MS * 2);
+
+      expect(mockSession.connection.send).not.toHaveBeenCalled();
+      expect(mockSession.socketDisconnect).not.toHaveBeenCalled();
+    });
+
+    it('starts both clocks fresh on start()', () => {
+      monitor.stop();
+      jest.advanceTimersByTime(OUTBOUND_CONFIRM_THRESHOLD_MS * 2);
+      monitor.start();
+
+      // A stale pre-start timestamp must not cause an immediate probe.
+      jest.advanceTimersByTime(CHECK_INTERVAL_MS);
+      expect(mockSession.connection.send).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
Part 2 of 2 for VSUP-171. Independent of #759 — either can merge first.

## Problem

`SignalingHealthMonitor` decides health from `_lastInboundAt`, updated on **every** inbound WS frame (`onSocketActivity`, fed from `Connection.onmessage`).

b2bua-rtc pings every ~15s. So on a socket where nothing the SDK sends is answered any more, those pings keep the inbound clock permanently fresh: `_check()` returns early, no probe is ever sent, no recovery is ever triggered, and the session is reported healthy while being useless. The b2bua registration is held until something external tears the socket down.

This is exactly what the VSUP-171 capture shows. Every affected socket:

```
19:08:07.473  anonymous_login  →  logged in, REGED     (client alive)
19:08:22.853  gateway ping   → no response
19:08:37.861  gateway ping   → no response
19:08:52.869  gateway ping   → no response
19:09:04.243  Terminating socket connection, reason {:remote, 1001, ""}
```

Inbound frames arriving on schedule the whole time. The monitor saw a healthy socket.

## Change

Track a second clock alongside `_lastInboundAt`: `_lastOutboundConfirmedAt`, the last outbound request that came back **answered**.

- `Connection.send()` reports it on every response — including errors and post-timeout arrivals, since either still proves the round trip completed.
- `_check()` gains a second probe trigger: frames arriving but nothing outbound answered for **45s** (three b2bua-rtc ping cycles). The probe is the arbiter either way — it resolves only on its own matching response, so it settles both questions at once. Unanswered within the existing 5s `PROBE_TIMEOUT_MS` → signaling unhealthy → normal reconnect path.
- A resolved probe counts as a fresh outbound round trip.
- Both clocks are seeded in `start()` so a stale pre-start timestamp cannot cause an immediate probe.

The inbound-silence trigger is unchanged and still fires first at 20s when nothing is arriving at all.

## Cost

None on a healthy session: the SDK answers server pings every ~15s, so the outbound clock stays fresh and no extra probes are sent. A genuinely outbound-silent session costs at most one extra ping per 45s before it recovers.

## Scope

This detects a socket that receives but cannot send. It does **not** rescue a page that has stopped executing JS altogether — in that case the monitor's own interval is not running either. That is the browser-lifecycle half of VSUP-171 (`{:remote, 1001, ""}` on a per-client 60s clock), tracked separately under ENGDESK-51102.

## Test plan

- 7 new unit tests in `signaling-health/OutboundLiveness.test.ts`: quiet while outbound is confirmed; probes at the threshold when only inbound flows; recovery when that probe is unanswered; alarm cleared when it comes back; inbound-silence trigger still fires first; no-op while disconnected; clocks reseeded on `start()`.
- Full package suite green (718 tests), `tsc --noEmit` clean, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)