### PR TITLE
fix(js): prevent deferred signaling after immediate hangup

### DIFF
--- a/packages/js/src/Modules/Verto/tests/webrtc/Call.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/Call.test.ts
@@ -207,6 +207,68 @@ describe('Call', () => {
     });
   });
 
+  describe('non-trickle ICE lifecycle', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.clearAllTimers();
+      jest.restoreAllMocks();
+      jest.useRealTimers();
+    });
+
+    it.each([
+      ['hangup', State.Hangup],
+      ['destroy', State.Destroy],
+      ['purge', State.Purge],
+    ])(
+      'does not schedule an ICE completion timeout for a queued event in %s state',
+      (_stateName, terminalState) => {
+        call.setState(terminalState);
+        call.peer = {
+          instance: {
+            localDescription: null,
+          },
+          incrementGatheredCandidates: jest.fn(),
+        } as unknown as Peer;
+        const privateCall = call as unknown as {
+          _iceTimeout: ReturnType<typeof setTimeout> | null;
+          _onIce: (event: RTCPeerConnectionIceEvent) => void;
+        };
+        const candidate = {
+          candidate:
+            'candidate:1 1 UDP 1694498815 198.51.100.1 54400 typ srflx',
+          sdpMLineIndex: 0,
+          sdpMid: '0',
+        } as RTCIceCandidate;
+
+        privateCall._onIce({ candidate } as RTCPeerConnectionIceEvent);
+
+        expect(privateCall._iceTimeout).toBeNull();
+      }
+    );
+
+    it('clears an existing ICE completion timeout before ignoring terminal SDP', () => {
+      const privateCall = call as unknown as {
+        _iceTimeout: ReturnType<typeof setTimeout> | null;
+        _onIceSdp: (data: RTCSessionDescriptionInit) => void;
+      };
+      const iceTimeout = setTimeout(noop, 1000);
+      const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
+      privateCall._iceTimeout = iceTimeout;
+      call.setState(State.Hangup);
+
+      privateCall._onIceSdp({
+        type: PeerType.Offer,
+        sdp: 'v=0\no=- 1 2 IN IP4 127.0.0.1\ns=-',
+      });
+
+      expect(clearTimeoutSpy).toHaveBeenCalledWith(iceTimeout);
+      expect(privateCall._iceTimeout).toBeNull();
+    });
+  });
+
   describe('specifying an ID', () => {
     it('should use the ID as callId', () => {
       call = new Call(session, { ...defaultParams, id: 'test-id-example' });
@@ -908,6 +970,11 @@ describe('Call', () => {
   });
 
   describe('outbound invite response races', () => {
+    const localOffer: RTCSessionDescriptionInit = {
+      type: PeerType.Offer,
+      sdp: 'v=0\no=- 1 2 IN IP4 127.0.0.1\ns=-',
+    };
+
     it('should not move a hung up outbound call back to trying when invite ACK arrives late', async () => {
       let resolveInvite: (response: { node_id: string }) => void;
       const inviteResponse = new Promise<{ node_id: string }>((resolve) => {
@@ -921,10 +988,7 @@ describe('Call', () => {
         ) => void
       ).bind(call);
 
-      onTrickleIceSdp({
-        type: PeerType.Offer,
-        sdp: 'v=0\no=- 1 2 IN IP4 127.0.0.1\ns=-',
-      });
+      onTrickleIceSdp(localOffer);
       expect(call.state).toEqual('requesting');
 
       call.setState(State.Hangup);
@@ -933,6 +997,69 @@ describe('Call', () => {
       await Promise.resolve();
 
       expect(call.state).toEqual('hangup');
+    });
+
+    it('does not send deferred non-trickle local SDP after destroy', () => {
+      const onIceSdp = (
+        Reflect.get(call, '_onIceSdp') as (
+          this: Call,
+          data: RTCSessionDescriptionInit
+        ) => void
+      ).bind(call);
+
+      call.setState(State.Destroy);
+      const executeSpy = jest
+        .spyOn(session, 'execute')
+        .mockImplementation(() => new Promise(() => {}));
+
+      onIceSdp(localOffer);
+
+      expect(call.state).toEqual('destroy');
+      expect(executeSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not send deferred trickle local SDP after destroy', () => {
+      const onTrickleIceSdp = (
+        Reflect.get(call, '_onTrickleIceSdp') as (
+          this: Call,
+          data: RTCSessionDescriptionInit
+        ) => void
+      ).bind(call);
+
+      call.setState(State.Destroy);
+      const executeSpy = jest
+        .spyOn(session, 'execute')
+        .mockImplementation(() => new Promise(() => {}));
+
+      onTrickleIceSdp(localOffer);
+
+      expect(call.state).toEqual('destroy');
+      expect(executeSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not signal queued trickle candidate or end-of-candidates events after destroy', () => {
+      const onTrickleIce = (
+        Reflect.get(call, '_onTrickleIce') as (
+          this: Call,
+          event: RTCPeerConnectionIceEvent
+        ) => void
+      ).bind(call);
+      const candidate = {
+        candidate: 'candidate:1 1 UDP 1694498815 198.51.100.1 54400 typ srflx',
+        sdpMLineIndex: 0,
+        sdpMid: '0',
+      } as RTCIceCandidate;
+
+      call.setState(State.Destroy);
+      const executeSpy = jest
+        .spyOn(session, 'execute')
+        .mockImplementation(() => new Promise(() => {}));
+
+      onTrickleIce({ candidate } as RTCPeerConnectionIceEvent);
+      onTrickleIce({ candidate: null } as RTCPeerConnectionIceEvent);
+
+      expect(call.state).toEqual('destroy');
+      expect(executeSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -1910,6 +1910,11 @@ export default abstract class BaseCall implements IWebRTCCall {
       clearTimeout(this._iceTimeout);
     }
     this._iceTimeout = null;
+
+    if (this._isTerminatingOrTerminated()) {
+      return;
+    }
+
     if (this.peer) {
       this.peer.iceDone = true;
     }
@@ -2016,6 +2021,10 @@ export default abstract class BaseCall implements IWebRTCCall {
   }
 
   private _onTrickleIceSdp(data: RTCSessionDescription) {
+    if (this._isTerminatingOrTerminated()) {
+      return;
+    }
+
     if (!data) {
       logger.error('No SDP data provided');
       void this.hangup({ initiator: 'sdk:missing-local-sdp' }, false);
@@ -2116,6 +2125,10 @@ export default abstract class BaseCall implements IWebRTCCall {
   }
 
   private _onIce(event: RTCPeerConnectionIceEvent) {
+    if (this._isTerminatingOrTerminated()) {
+      return;
+    }
+
     const { instance } = this.peer;
     if (this._iceTimeout === null) {
       // Use a longer timeout for attach (reconnection) to allow full ICE
@@ -2137,6 +2150,10 @@ export default abstract class BaseCall implements IWebRTCCall {
   }
 
   private _onTrickleIce(event: RTCPeerConnectionIceEvent) {
+    if (this._isTerminatingOrTerminated()) {
+      return;
+    }
+
     if (event.candidate && event.candidate.candidate) {
       logger.debug('RTCPeer Candidate:', event.candidate);
       this.peer?.incrementGatheredCandidates();


### PR DESCRIPTION
## Summary
- prevent terminal calls from sending deferred local SDP signaling after immediate hangup
- ignore queued trickle and non-trickle ICE work after `hangup`, `destroy`, or `purge`
- preserve non-trickle timeout cleanup and add deterministic race regression coverage

## Root cause
`newCall()` returns while local SDP generation is still asynchronous. If `hangup()` completes before that callback runs, the callback could move the call from `destroy` back to `requesting` and send `telnyx_rtc.invite`, leaving the callee ringing until timeout.

## Test plan
- [x] `yarn workspace @telnyx/webrtc test --runInBand --silent` (26 suites, 718 tests)
- [x] `../../node_modules/.bin/tsc --noEmit --project tsconfig.json`
- [x] scoped ESLint on `BaseCall.ts` and `Call.test.ts`
- [x] `yarn build`
- [x] `git diff --check`

Linear: [VSDK-488](https://linear.app/telnyx/issue/VSDK-488/immediate-hangup-does-not-cancel-outbound-webrtc-call)