### PR TITLE
docs: add response.audio_stream.subscribe example to README

### DIFF
--- a/packages/js/README.md
+++ b/packages/js/README.md
@@ -371,6 +371,14 @@ client.on('telnyx.ai.conversation', (event) => {
 
 The `call_id` from the `function_call` must match the `call_id` in the `function_call_output` — this is how the backend correlates the request with the response.
 
+You can also subscribe to ACA pre-playout assistant audio events:
+
+```js
+call.sendAIConversationMessage({
+  type: 'response.audio_stream.subscribe',
+});
+```
+
 > See [Call#sendAIConversationMessage](./docs/ts/classes/Call.md#sendaiconversationmessage) for the full API reference.
 
 ---


### PR DESCRIPTION
## Summary

Adds a usage example for the `response.audio_stream.subscribe` outbound AI conversation item (introduced in #751) to the JS SDK README.

This is the last docs commit from the pre-release docs sync that didn't land in #761 (it was added after that PR was merged). It should ship with the next release so the new ACA pre-playout audio subscription feature is documented in the getting-started guide.

**Checklist:**
- [x] Documentation only — no source changes
- [x] Consistent with the `AIConversationOutboundItem` type exported in `src/index.ts`