### PR TITLE
fix(js): restore prefetchIceCandidates default on outbound calls

### DIFF
--- a/packages/js/src/Modules/Verto/tests/webrtc/Call.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/Call.test.ts
@@ -87,6 +87,47 @@ describe('Call', () => {
     });
   });
 
+  describe('prefetchIceCandidates default', () => {
+    const newSession = async (opts = {}) => {
+      const s = new Verto({
+        host: 'example.fs.telnyx',
+        login: 'login',
+        passwd: 'passwd',
+        ...opts,
+      });
+      await s.connect().catch(console.error);
+      return s;
+    };
+
+    it('defaults to true when the client did not set it', () => {
+      // Regression: DEFAULT_CALL_OPTIONS.prefetchIceCandidates was being
+      // clobbered with `undefined`, leaving iceCandidatePoolSize at 0.
+      expect(call.options.prefetchIceCandidates).toBe(true);
+    });
+
+    it('honours an explicit client-level false', async () => {
+      const s = await newSession({ prefetchIceCandidates: false });
+      expect(new Call(s, defaultParams).options.prefetchIceCandidates).toBe(
+        false
+      );
+    });
+
+    it('honours an explicit client-level true', async () => {
+      const s = await newSession({ prefetchIceCandidates: true });
+      expect(new Call(s, defaultParams).options.prefetchIceCandidates).toBe(
+        true
+      );
+    });
+
+    it('lets a per-call option override the client default', () => {
+      const c = new Call(session, {
+        ...defaultParams,
+        prefetchIceCandidates: false,
+      });
+      expect(c.options.prefetchIceCandidates).toBe(false);
+    });
+  });
+
   describe('non-trickle host-only ICE diagnostics', () => {
     const sdpPrefix = 'v=0\r\no=- 1 2 IN IP4 127.0.0.1\r\ns=-\r\nt=0 0\r\n';
 

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -318,7 +318,12 @@ export default abstract class BaseCall implements IWebRTCCall {
         debug: options.debug,
         debugOutput: options.debugOutput,
         trickleIce: options.trickleIce,
-        prefetchIceCandidates: options.prefetchIceCandidates,
+        // `Object.assign` copies keys whose value is `undefined`, so reading
+        // `options.prefetchIceCandidates` directly would overwrite the `true`
+        // from DEFAULT_CALL_OPTIONS whenever the client did not set it.
+        prefetchIceCandidates:
+          options.prefetchIceCandidates ??
+          DEFAULT_CALL_OPTIONS.prefetchIceCandidates,
         forceRelayCandidate: options.forceRelayCandidate,
         keepConnectionAliveOnSocketClose:
           options.keepConnectionAliveOnSocketClose,


### PR DESCRIPTION
Linear: [VSUP-194](https://linear.app/telnyx/issue/VSUP-194)

## Problem

`DEFAULT_CALL_OPTIONS` sets `prefetchIceCandidates: true`, but the overlay object in `BaseCall`'s constructor passed `options.prefetchIceCandidates` through verbatim:

```ts
this.options = Object.assign(
  {},
  DEFAULT_CALL_OPTIONS,                                          // prefetchIceCandidates: true
  { ... prefetchIceCandidates: options.prefetchIceCandidates ... },  // undefined clobbers it
  opts
);
```

`Object.assign` copies a key even when its value is `undefined`, so whenever the integrator did not set the option at **client** level, the `true` default was overwritten with `undefined`.

`Peer._config()` then evaluates:

```ts
iceCandidatePoolSize: prefetchIceCandidates ? 10 : 0,
```

`undefined ? 10 : 0` -> **0**, so no ICE candidates were pre-gathered.

### Why it went unnoticed

The call-report builder (`BaseCall.ts:2748`) reads the same value with `??`:

```ts
prefetchIceCandidates: this.options.prefetchIceCandidates ?? true,   // -> true
```

So reports render **"Prefetch ICE Candidates: yes"** while the browser actually received `iceCandidatePoolSize: 0`. One `??`, one truthiness check, same `undefined` input.

## Scope

Outbound calls only. #523 (v2.25.19, 2026-02-23) enabled the default and fixed the **inbound** path in `VertoHandler.ts` (`?? false` -> `?? true`) but left the `BaseCall` overlay untouched. Default-on prefetching has therefore been inert for outbound calls since 2.25.19.

Confirmed against production call reports from SDK **2.27.3** and **2.27.9** - both `Direction: outbound`, both reporting `Prefetch ICE Candidates: yes` alongside `"iceCandidatePoolSize": 0` in the logged RTC config.

Impact is setup latency: the candidate pool would otherwise absorb STUN/TURN gathering before `setLocalDescription`. It is worst on `forceRelayCandidate: true` calls, where the first candidate cannot exist until a full TURN Allocate completes (~281ms observed on one such call).

## Fix

Resolve against `DEFAULT_CALL_OPTIONS` so there is a single source of truth and it cannot drift from `constants.ts`.

## Tests

Four cases added to `Call.test.ts`. Verified the first **fails on `main`** (`Expected: true, Received: undefined`) and passes with the fix; the other three pass either way as regression guards for the explicit-override paths.

Full `Modules/Verto` suite: **740 passed, 27 suites**.

## Note for reviewers

The same clobber pattern applies to the other keys in that overlay. `prefetchIceCandidates` is the only one that changes behaviour today, because it is the only one whose `DEFAULT_CALL_OPTIONS` value is truthy - `debug: false` and `mutedMicOnStart: false` clobber to `undefined` harmlessly, and `trickleIce` / `forceRelayCandidate` / `keepConnectionAliveOnSocketClose` have no default entry at all. `debugOutput: 'socket'` is also truthy and is clobbered, but downstream `|| 'socket'` fallbacks appear to mask it. Deliberately left alone here to keep the change reviewable - happy to follow up with a general `undefined`-stripping helper if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
