### PR TITLE
fix(js): read media-playout stats using their real RTCAudioPlayoutStats names

### DIFF
--- a/packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts
@@ -1305,13 +1305,16 @@ describe('CallReportCollector media-playout stats', () => {
       [
         'MP_audio',
         {
+          // Field names must match RTCAudioPlayoutStats as the browser emits
+          // them. A real Chrome media-playout stat looks exactly like this.
           id: 'MP_audio',
           type: 'media-playout',
           kind: 'audio',
-          synthesizedSamples: 1500,
-          synthesizedDuration: 0.03,
+          synthesizedSamplesEvents: 1500,
+          synthesizedSamplesDuration: 0.03,
           totalPlayoutDelay: 0.12,
-          totalSampleCount: 48000,
+          totalSamplesCount: 48000,
+          totalSamplesDuration: 1.0,
         },
       ],
     ]);
@@ -1330,10 +1333,11 @@ describe('CallReportCollector media-playout stats', () => {
     ).toEqual(
       expect.objectContaining({
         mediaPlayout: {
-          synthesizedSamples: 1500,
-          synthesizedDuration: 0.03,
+          synthesizedSamplesEvents: 1500,
+          synthesizedSamplesDuration: 0.03,
           totalPlayoutDelay: 0.12,
-          totalSampleCount: 48000,
+          totalSamplesCount: 48000,
+          totalSamplesDuration: 1.0,
         },
       })
     );

--- a/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
+++ b/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
@@ -148,10 +148,11 @@ interface ExtendedMediaPlayoutStats {
   type: string;
   id: string;
   kind?: string;
-  synthesizedSamples?: number;
-  synthesizedDuration?: number;
+  synthesizedSamplesEvents?: number;
+  synthesizedSamplesDuration?: number;
   totalPlayoutDelay?: number;
-  totalSampleCount?: number;
+  totalSamplesCount?: number;
+  totalSamplesDuration?: number;
 }
 
 /**
@@ -386,10 +387,11 @@ export interface IStatsInterval {
    * Reports playout delay and synthesized-sample indicators.
    */
   mediaPlayout?: {
-    synthesizedSamples?: number;
-    synthesizedDuration?: number;
+    synthesizedSamplesEvents?: number;
+    synthesizedSamplesDuration?: number;
     totalPlayoutDelay?: number;
-    totalSampleCount?: number;
+    totalSamplesCount?: number;
+    totalSamplesDuration?: number;
   };
   /**
    * Remote RTCP stats parsed from `remote-inbound-rtp` (RTCP Receiver Report
@@ -1918,10 +1920,11 @@ export class CallReportCollector {
     // Media-playout stats (audio playout delay + synthesized samples)
     if (mediaPlayout) {
       entry.mediaPlayout = this._withoutUndefined({
-        synthesizedSamples: mediaPlayout.synthesizedSamples,
-        synthesizedDuration: mediaPlayout.synthesizedDuration,
+        synthesizedSamplesEvents: mediaPlayout.synthesizedSamplesEvents,
+        synthesizedSamplesDuration: mediaPlayout.synthesizedSamplesDuration,
         totalPlayoutDelay: mediaPlayout.totalPlayoutDelay,
-        totalSampleCount: mediaPlayout.totalSampleCount,
+        totalSamplesCount: mediaPlayout.totalSamplesCount,
+        totalSamplesDuration: mediaPlayout.totalSamplesDuration,
       });
     }
 


### PR DESCRIPTION
Linear: [VSUP-195](https://linear.app/telnyx/issue/VSUP-195)

## Problem

The `media-playout` collection block reads three properties that **do not exist** on [`RTCAudioPlayoutStats`](https://www.w3.org/TR/webrtc-stats/#dom-rtcaudioplayoutstats). They were always `undefined`, and `_withoutUndefined()` stripped them before the report was assembled:

| Read by the SDK | Actual spec / Chrome name |
|---|---|
| `synthesizedSamples` | `synthesizedSamplesEvents` |
| `synthesizedDuration` | `synthesizedSamplesDuration` |
| `totalSampleCount` | `totalSamplesCount` |
| `totalPlayoutDelay` | correct |

So every production call report carries a `mediaPlayout` block with exactly **one** of its five fields.

Here is a real `media-playout` stat from a production report (SDK 2.27.9):

```json
{
  "id": "AP",
  "kind": "audio",
  "type": "media-playout",
  "synthesizedSamplesDuration": 0,
  "synthesizedSamplesEvents": 0,
  "totalPlayoutDelay": 2300511.61584,
  "totalSamplesCount": 55040640,
  "totalSamplesDuration": 1146.68
}
```

## Why it matters

`totalPlayoutDelay` is a **cumulative sum in seconds**; the per-sample average requires dividing by `totalSamplesCount`. Without the denominator, `voice-sdk-call-report-stats` has nothing to normalise against and renders the raw cumulative value — producing `Playout Delay 2367908170.6 ms` on a 39-second call.

The correct figure from the stat above is `2300511.61584 / 55040640` = **~41.8 ms**, an entirely ordinary playout delay.

This is the one component of mouth-to-ear latency that is actually tunable client-side (via `RTCRtpReceiver.jitterBufferTarget`), so it is worth being able to measure.

Also now collects `totalSamplesDuration`, which the spec provides alongside and which pairs with `totalSamplesCount`.

## Why it was not caught

The existing test constructed a fabricated stats object using **the same wrong names the code read**, so it round-tripped successfully and asserted the bug was correct behaviour. It has been updated to use the names Chrome actually emits.

Verified against `main`: with real field names the collector produces

```
"mediaPlayout": {"totalPlayoutDelay": 0.12}
```

— one field out of five, exactly matching what we see in production reports. With this change all five are collected.

Full `Modules/Verto` suite: **736 passed, 27 suites**.

## Follow-up

A companion PR in `voice-sdk-call-report-stats` normalises these cumulative counters for display and reads the corrected key (with a fallback to the old one for historical reports).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
