### PR TITLE
feat(js): log STUN Binding keepalive gaps and per-call summary (VSUP-204)

### DIFF
--- a/packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/CallReportCollector.test.ts
@@ -1769,3 +1769,176 @@ describe('CallReportCollector codec identity collection', () => {
     expect(collector._getCodec(stats, 'missing')).toBeUndefined();
   });
 });
+
+describe('CallReportCollector STUN Binding keepalive logging', () => {
+  type StunTestable = {
+    _trackStunBindingActivity: (pair: {
+      id?: string;
+      requestsSent?: number;
+      responsesReceived?: number;
+    }) => void;
+    stop: () => Promise<void>;
+  };
+
+  // interval 5000 -> _collectionIntervalFor() is min(1000, 5000) = 1000, so the
+  // gap threshold is max(5000, 1000 * 4) = 5000ms.
+  const createStunCollector = () =>
+    new CallReportCollector({
+      enabled: true,
+      interval: 5000,
+    }) as unknown as StunTestable;
+
+  const pair = (requestsSent: number, responsesReceived = requestsSent) => ({
+    id: 'pair-A',
+    requestsSent,
+    responsesReceived,
+  });
+
+  let nowSpy: jest.SpyInstance<number, []>;
+  let clock = 0;
+
+  const advance = (ms: number) => {
+    clock += ms;
+  };
+
+  beforeEach(() => {
+    clock = 1_700_000_000_000;
+    nowSpy = jest.spyOn(Date, 'now').mockImplementation(() => clock);
+  });
+
+  afterEach(() => {
+    nowSpy.mockRestore();
+    jest.restoreAllMocks();
+  });
+
+  it('says nothing while sampling keeps up, so the log ring buffer is not flooded', () => {
+    // LogCollector caps at maxEntries (1000) and stats are collected ~1/s, so a
+    // per-interval line would evict setup and negotiation logs on a long call.
+    const collector = createStunCollector();
+    const infoSpy = jest.spyOn(logger, 'info').mockImplementation();
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation();
+
+    let requests = 100;
+    for (let i = 0; i < 60; i++) {
+      collector._trackStunBindingActivity(pair(requests));
+      advance(1000);
+      requests += 1;
+    }
+
+    const stunLogs = [...infoSpy.mock.calls, ...warnSpy.mock.calls].filter(
+      ([message]) => String(message).includes('STUN Binding')
+    );
+    expect(stunLogs).toHaveLength(0);
+  });
+
+  it('logs a gap that libwebrtc kept pinging through as informational', () => {
+    // The benign half of a tab freeze: our setTimeout stopped, the native ICE
+    // agent did not, so the media-path NAT mapping stayed open.
+    const collector = createStunCollector();
+    const infoSpy = jest.spyOn(logger, 'info').mockImplementation();
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation();
+
+    collector._trackStunBindingActivity(pair(100));
+    advance(40_000);
+    collector._trackStunBindingActivity(pair(116));
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    const [message, context] =
+      infoSpy.mock.calls.find(([m]) =>
+        String(m).includes('STUN Binding keepalive continued')
+      ) ?? [];
+
+    expect(message).toBeDefined();
+    expect(context).toMatchObject({
+      gapMs: 40_000,
+      requestsSentDuringGap: 16,
+      impliedIntervalMs: 2500,
+    });
+  });
+
+  it('warns when no Binding Request left the machine during a gap', () => {
+    const collector = createStunCollector();
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation();
+    jest.spyOn(logger, 'info').mockImplementation();
+
+    collector._trackStunBindingActivity(pair(100));
+    advance(40_000);
+    collector._trackStunBindingActivity(pair(100));
+
+    const [message, context] =
+      warnSpy.mock.calls.find(([m]) =>
+        String(m).includes('STUN Binding keepalive stopped')
+      ) ?? [];
+
+    expect(message).toBeDefined();
+    expect(context).toMatchObject({
+      gapMs: 40_000,
+      requestsSentDuringGap: 0,
+      impliedIntervalMs: null,
+    });
+  });
+
+  it('does not subtract across a candidate pair change', () => {
+    // requestsSent is per-pair, so B's counter is not subtractable from A's.
+    // Getting this wrong is what produced three separate merge bugs in the
+    // dashboard's Tr derivation.
+    const collector = createStunCollector();
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation();
+    jest.spyOn(logger, 'info').mockImplementation();
+
+    collector._trackStunBindingActivity({
+      id: 'pair-A',
+      requestsSent: 500,
+      responsesReceived: 500,
+    });
+    advance(40_000);
+    collector._trackStunBindingActivity({
+      id: 'pair-B',
+      requestsSent: 3,
+      responsesReceived: 3,
+    });
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('summarises longest silence at stop, which a mean interval cannot show', async () => {
+    // Bursty pinging: 10 requests in one second, then 24s of nothing. The mean
+    // interval looks healthy; the 24s silence is what would trip a NAT timer.
+    const collector = createStunCollector();
+    const infoSpy = jest.spyOn(logger, 'info').mockImplementation();
+
+    collector._trackStunBindingActivity(pair(0));
+    advance(1000);
+    collector._trackStunBindingActivity(pair(10));
+    advance(24_000);
+    collector._trackStunBindingActivity(pair(10));
+
+    await collector.stop();
+
+    const [, context] =
+      infoSpy.mock.calls.find(([m]) =>
+        String(m).includes('STUN Binding keepalive summary')
+      ) ?? [];
+
+    expect(context).toMatchObject({
+      requestsSent: 10,
+      observedMs: 25_000,
+      meanIntervalMs: 2500,
+      longestSilenceMs: 24_000,
+      observationGaps: 1,
+      longestGapMs: 24_000,
+    });
+  });
+
+  it('emits no summary when there was nothing to observe', async () => {
+    const collector = createStunCollector();
+    const infoSpy = jest.spyOn(logger, 'info').mockImplementation();
+
+    await collector.stop();
+
+    const summaries = infoSpy.mock.calls.filter(([m]) =>
+      String(m).includes('STUN Binding keepalive summary')
+    );
+    expect(summaries).toHaveLength(0);
+  });
+});

--- a/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
+++ b/packages/js/src/Modules/Verto/webrtc/CallReportCollector.ts
@@ -622,6 +622,19 @@ export class CallReportCollector {
   private _lastWarningEmitted: Record<number, number> = {};
   // Minimum interval (ms) between repeated warnings of the same code
   private static readonly WARNING_THROTTLE_MS = 15_000;
+
+  // An observation gap is a stretch where our sampling timer did not run:
+  // `_scheduleNextCollection` drives collection from setTimeout on the JS main
+  // thread, so a frozen or backgrounded tab stops producing stats intervals
+  // entirely. libwebrtc's ICE agent runs on native threads and keeps pinging
+  // regardless, so requestsSent is still cumulative across the gap and the
+  // first sample after we resume tells us what happened while we were blind.
+  //
+  // Threshold has to clear ordinary timer slack (setTimeout drifts under load,
+  // and throttled background tabs settle around 1s), hence a multiple of the
+  // collection interval with a floor well above it.
+  private static readonly STUN_OBSERVATION_GAP_FACTOR = 4;
+  private static readonly STUN_OBSERVATION_GAP_FLOOR_MS = 5_000;
   // Previous packets values for packet loss delta calculation
   private _prevPacketsReceived: number | null = null;
   private _prevPacketsLost: number | null = null;
@@ -655,6 +668,34 @@ export class CallReportCollector {
 
   /** Whether stop() has been requested (prevents timer re-scheduling). */
   private _stopped: boolean = false;
+
+  // STUN Binding keepalive tracking. requestsSent/responsesReceived are
+  // cumulative *per candidate pair*, so a delta is only meaningful while the
+  // pair id is unchanged; a pair change resets tracking rather than producing a
+  // bogus delta against another pair's counter.
+  private _lastStunSample: {
+    pairId: string;
+    at: number;
+    requestsSent: number;
+    responsesReceived: number;
+  } | null = null;
+
+  private _stunTotals: {
+    requestsSent: number;
+    responsesReceived: number;
+    observedMs: number;
+    gaps: number;
+    longestGapMs: number;
+    /** Longest stretch with no Binding Request sent, observed or not. */
+    longestSilenceMs: number;
+  } = {
+    requestsSent: 0,
+    responsesReceived: 0,
+    observedMs: 0,
+    gaps: 0,
+    longestGapMs: 0,
+    longestSilenceMs: 0,
+  };
 
   // ── Retry configuration ───────────────────────────────────────────
   private static readonly RETRY_DELAYS_MS = [500, 1000, 2000];
@@ -724,6 +765,9 @@ export class CallReportCollector {
     if (this.peerConnection && this.intervalStartTime) {
       await this._collectStats(true);
     }
+
+    // Before the log collector stops, so the summary lands in the report.
+    this._logStunBindingSummary();
 
     // Stop log collector
     const logCount = this.logCollector?.getLogCount() ?? 0;
@@ -1096,6 +1140,143 @@ export class CallReportCollector {
     this._trackBreach(LOW_BYTES_RECEIVED, false);
   }
 
+  /**
+   * Track STUN Binding keepalive activity on the selected candidate pair.
+   *
+   * libwebrtc does not implement RFC 8445 s11 Binding Indications. It pings the
+   * selected pair with Binding *Requests* on a writability timer
+   * (kStrongAndStableWritableConnectionPingInterval, 2500ms once stable; 900ms
+   * while settling), independently of whether media is flowing. Those pings are
+   * what hold the media-path NAT mapping open through silence, and
+   * `requestsSent` counts exactly them.
+   *
+   * Individual Binding Requests are not observable from JS — the browser
+   * exposes only cumulative counters on the candidate-pair stat — so this logs
+   * the counter behaviour rather than the packets.
+   *
+   * Deliberately does NOT log per interval. LogCollector is a ring buffer
+   * capped at maxEntries (1000 by default) and stats are collected roughly
+   * every second, so a per-interval line would evict the whole buffer on a
+   * ~17-minute call, taking setup and negotiation logs with it. Only gaps are
+   * logged here; the per-call summary is emitted once, from stop().
+   */
+  private _trackStunBindingActivity(pair: IICECandidatePair): void {
+    const requestsSent = pair.requestsSent;
+    const responsesReceived = pair.responsesReceived;
+
+    if (typeof requestsSent !== 'number' || !pair.id) {
+      return;
+    }
+
+    const now = Date.now();
+    const previous = this._lastStunSample;
+    const sample = {
+      pairId: pair.id,
+      at: now,
+      requestsSent,
+      responsesReceived:
+        typeof responsesReceived === 'number' ? responsesReceived : 0,
+    };
+
+    // First sample, or the path moved: nothing subtractable against it.
+    if (!previous || previous.pairId !== pair.id) {
+      this._lastStunSample = sample;
+      return;
+    }
+
+    const elapsedMs = now - previous.at;
+    const requestsDelta = this._positiveDelta(
+      requestsSent,
+      previous.requestsSent
+    );
+    const responsesDelta = this._positiveDelta(
+      sample.responsesReceived,
+      previous.responsesReceived
+    );
+
+    this._lastStunSample = sample;
+
+    if (elapsedMs <= 0) {
+      return;
+    }
+
+    this._stunTotals.requestsSent += requestsDelta;
+    this._stunTotals.responsesReceived += responsesDelta;
+    this._stunTotals.observedMs += elapsedMs;
+
+    // A stretch with no Binding Request sent extends the running silence.
+    // This is the number Tr structurally cannot produce: a mean over a run
+    // hides the single long gap that actually trips a NAT idle timer.
+    if (requestsDelta === 0) {
+      this._stunTotals.longestSilenceMs = Math.max(
+        this._stunTotals.longestSilenceMs,
+        elapsedMs
+      );
+    }
+
+    const gapThresholdMs = Math.max(
+      CallReportCollector.STUN_OBSERVATION_GAP_FLOOR_MS,
+      this._collectionIntervalFor() *
+        CallReportCollector.STUN_OBSERVATION_GAP_FACTOR
+    );
+
+    if (elapsedMs < gapThresholdMs) {
+      return;
+    }
+
+    this._stunTotals.gaps += 1;
+    this._stunTotals.longestGapMs = Math.max(
+      this._stunTotals.longestGapMs,
+      elapsedMs
+    );
+
+    const context = {
+      gapMs: elapsedMs,
+      requestsSentDuringGap: requestsDelta,
+      responsesReceivedDuringGap: responsesDelta,
+      impliedIntervalMs:
+        requestsDelta > 0 ? Math.round(elapsedMs / requestsDelta) : null,
+      pairId: pair.id,
+    };
+
+    if (requestsDelta > 0) {
+      // We stopped watching, libwebrtc did not stop pinging. The media-path
+      // mapping was held open; only the application-layer signaling keepalive
+      // was affected. This is the benign half of a tab freeze.
+      logger.info(
+        'CallReportCollector: STUN Binding keepalive continued through an observation gap',
+        context
+      );
+      return;
+    }
+
+    // No Binding Request left the machine for the whole gap, so the media-path
+    // NAT mapping was unprotected for that long and may have been dropped.
+    logger.warn(
+      'CallReportCollector: STUN Binding keepalive stopped during an observation gap',
+      context
+    );
+  }
+
+  /** One-line STUN Binding keepalive summary, emitted once from stop(). */
+  private _logStunBindingSummary(): void {
+    const totals = this._stunTotals;
+
+    if (totals.observedMs <= 0 || totals.requestsSent <= 0) {
+      return;
+    }
+
+    logger.info('CallReportCollector: STUN Binding keepalive summary', {
+      requestsSent: totals.requestsSent,
+      responsesReceived: totals.responsesReceived,
+      observedMs: totals.observedMs,
+      meanIntervalMs: Math.round(totals.observedMs / totals.requestsSent),
+      observationGaps: totals.gaps,
+      longestGapMs: totals.longestGapMs,
+      longestSilenceMs: totals.longestSilenceMs,
+    });
+  }
+
   private _scheduleNextCollection(): void {
     if (
       this._stopped ||
@@ -1351,6 +1532,7 @@ export class CallReportCollector {
           this._emitWarning(ICE_CANDIDATE_PAIR_CHANGED);
         }
         this.previousCandidatePairSnapshot = currentCandidatePairSnapshot;
+        this._trackStunBindingActivity(currentCandidatePairSnapshot);
       }
 
       let localAudioTrack: ILocalAudioTrackSnapshot | undefined;


### PR DESCRIPTION
Linear: [VSUP-204](https://linear.app/telnyx/issue/VSUP-204/voice-sdk-log-stun-binding-keepalive-activity-and-observation-gaps-so)
Related: VSUP-197 (keepalive layering), [voice-sdk-call-report-stats#73](https://github.com/team-telnyx/voice-sdk-call-report-stats/pull/73) (the Tr panel)

## What this adds

`CallReportCollector` samples stats from a `setTimeout` loop on the JS main thread, so a frozen or backgrounded tab stops producing intervals entirely.

**The evidence for that is already in the report, and this PR does not add any.** `entry.ice.requestsSent` and `entry.ice.responsesReceived` are written into every stats interval alongside `intervalStartUtc`/`intervalEndUtc`, so a freeze is already visible as two adjacent intervals whose timestamp jumps 40s while the counter jumps 16. Everything below is derivable from that series today.

What is missing is that **nothing derives it**. This PR pre-computes and flags:

- a `warn` line when keepalives stopped during a gap, so the case is greppable and alertable in voice-sdk-debug instead of needing someone to diff two intervals by hand
- `longestSilenceMs`, which nothing computes — #73's Tr is a mean and structurally will not
- a summary that survives stats truncation: voice-sdk-debug's worker truncates at `max_samples: 1200` (~20 min at 1s sampling) and the SDK flushes its buffer at `STATS_FLUSH_THRESHOLD = 300`, so the line at `stop()` lands in the final segment even when early intervals are gone. Secondary — logs have their own cap.

An earlier revision of this description claimed nothing recorded the gap at all. That was wrong; the correction is the paragraph above.

That left two very different situations indistinguishable in a call report:

| Observation | What it means | Fix |
|---|---|---|
| 40s gap, `requestsSent` up ~16 | libwebrtc held the media-path NAT mapping open at ~2.5s throughout; only the application-layer signaling keepalive (`telnyx_rtc.ping`) died | signaling-side, VSUP-197 |
| 40s gap, `requestsSent` flat | no Binding Request left the machine; the mapping was unprotected for the whole window | media-path |

libwebrtc's ICE agent runs on native network threads, not the JS main thread, so it keeps pinging while we are blind and `requestsSent` stays cumulative across the gap. The first sample after the tab resumes carries the answer — it just was never read.

## What #73 covers, and what it does not

#73 added a derived aggregate to the ICE tab: `Tr = elapsed / Δ requestsSent` over runs where a pair was selected. It answers *"on average, how often did libwebrtc ping this pair while we were watching."* It structurally cannot answer:

- **The longest silence.** Tr is a mean. Ten pings in one second then 24s of nothing has the same Tr as steady 2.5s pings — and a NAT idle timer is tripped by the longest gap, never by the mean.
- **Whether keepalives survived a freeze.** No stats interval exists for that period, so Tr reports on the surrounding samples as if nothing happened.

This PR computes the second of those at the point where the data is produced, so it lands in the report rather than needing a reader to reconstruct it. Panel work stays in the dashboard repo.

## Change

Two log points in `CallReportCollector`, both landing in the report's `logs[]` (the LogCollector captures every level, so these are visible on the call-detail page and searchable in voice-sdk-debug):

1. **Observation gap** — elapsed since the previous sample exceeds `max(5000ms, 4x collection interval)`. Logs gap duration, Binding Requests sent during it, responses, and implied interval. `info` when pinging continued, `warn` when it stopped.
2. **End-of-call summary** — one line at `stop()`: totals, observed span, mean interval, gap count, longest gap, and **longest keepalive silence**.

**Not per interval, deliberately.** `LogCollector` is a ring buffer capped at `maxEntries: 1000` and collection runs about every second, so a per-sample line would evict the entire buffer on a ~17-minute call and take the setup and negotiation logs with it. It would also inflate the searchable-text blob that [voice-sdk-debug#108](https://github.com/team-telnyx/voice-sdk-debug/pull/108) was about. Logging is O(gaps), not O(intervals), and there is a test pinning that a well-behaved 60-sample call logs nothing.

Counters are per candidate pair, so a pair change resets tracking rather than subtracting across pairs — the same constraint that produced three separate merge bugs in #73's Tr derivation, so it gets its own test here.

## Out of scope

- **Logging individual STUN Binding Requests.** Not possible from JS: the browser exposes only cumulative counters on the candidate-pair stat, and individual Binding traffic is visible solely in a packet capture. This is the constraint that pushed the original VSUP-197 plan toward a PCAP.
- **A new SDK warning code.** Customer-visible and feeds the `call_sdk_warnings` metric labels in voice-sdk-debug, so it wants its own decision — worth revisiting once we see how often the stalled case fires.
- **Surfacing longest-silence on the dashboard.** Follow-up in voice-sdk-call-report-stats once the log shape has proven out.
- **Server-side observation.** b2bua-rtc sees inbound Binding Requests and would give ground truth independent of the browser. Stronger evidence, much larger change, separate ticket.

## Verification

`packages/js`: **746 tests pass**, `tsc --noEmit` clean, prettier and eslint clean. Six new tests cover the quiet case, both gap directions, the pair change, the bursty longest-silence summary, and the no-op summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
