### PR TITLE
feat: add early SDP answer client option

### DIFF
--- a/packages/js/docs/ts/interfaces/IClientOptions.md
+++ b/packages/js/docs/ts/interfaces/IClientOptions.md
@@ -15,6 +15,7 @@ IClientOptions
 - [callReportInterval](#callreportinterval)
 - [debug](#debug)
 - [debugOutput](#debugoutput)
+- [earlySdpAnswer](#earlysdpanswer)
 - [enableCallRecording](#enablecallrecording)
 - [enableCallReports](#enablecallreports)
 - [env](#env)
@@ -191,6 +192,21 @@ This will gather WebRTC debugging information.
 • `Optional` **debugOutput**: `"file"` \| `"socket"`
 
 Debug output option
+
+---
+
+### earlySdpAnswer
+
+• `Optional` **earlySdpAnswer**: `boolean`
+
+When `true`, requests early SDP answers during standard authenticated
+login. This option does not apply to anonymous login.
+
+**`Default`**
+
+```ts
+false;
+```
 
 ---
 

--- a/packages/js/src/Modules/Verto/BaseSession.ts
+++ b/packages/js/src/Modules/Verto/BaseSession.ts
@@ -746,13 +746,15 @@ export default abstract class BaseSession {
         push_when_active: pushWhenActive,
         pn_late_fanout: pushWhenActive,
       };
+      const earlySdpAnswer = this.options.earlySdpAnswer ?? false;
       msg = new Login(
         this.options.login,
         this.options.password || this.options.passwd,
         this.options.login_token,
         reconnectSessionId,
         userVariables,
-        isReconnection
+        isReconnection,
+        earlySdpAnswer
       );
     } else {
       msg = new AnonymousLogin({

--- a/packages/js/src/Modules/Verto/messages/verto/Login.ts
+++ b/packages/js/src/Modules/Verto/messages/verto/Login.ts
@@ -10,18 +10,18 @@ class Login extends BaseRequest {
     login_token: string,
     sessionid: string,
     userVariables: Record<string, any> = {},
-    reconnection: boolean
+    reconnection: boolean,
+    earlySdpAnswer: boolean = false
   ) {
     super();
 
-    // TODO: handle loginParams && userVariables
     const params: any = {
       login,
       passwd,
       login_token,
       userVariables,
       reconnection,
-      loginParams: {},
+      loginParams: { early_sdp_answer: earlySdpAnswer },
       'User-Agent': {
         sdkVersion: pkg.version,
         data: navigator.userAgent,

--- a/packages/js/src/Modules/Verto/tests/Verto.test.ts
+++ b/packages/js/src/Modules/Verto/tests/Verto.test.ts
@@ -3,6 +3,7 @@ import { isQueued } from '../services/Handler';
 import Verto, { VERTO_PROTOCOL } from '..';
 import { IVertoOptions } from '../util/interfaces';
 import { IWebRTCCall } from '../webrtc/interfaces';
+import type { IClientOptions } from '../../../utils/interfaces';
 import {
   DEFAULT_DEV_ICE_SERVERS,
   DEFAULT_PROD_ICE_SERVERS,
@@ -872,6 +873,89 @@ describe('Verto', () => {
         custom_key: 'custom-value',
       });
       expect(request.params.userVariables.pn_late_fanout).toBeUndefined();
+    });
+  });
+
+  describe('earlySdpAnswer login option', () => {
+    const loginRequestFor = async (options: IClientOptions) => {
+      const client = _buildInstance(options as IVertoOptions);
+
+      await client.login();
+
+      return Connection.mockSend.mock.calls[0][0].request;
+    };
+
+    it('sends an explicit false by default on password login', async () => {
+      const request = await loginRequestFor({
+        login: 'login',
+        password: 'password',
+      });
+
+      expect(request.params.loginParams).toEqual({ early_sdp_answer: false });
+      expect(request.params).not.toHaveProperty('early_sdp_answer');
+      expect(request.params.userVariables).not.toHaveProperty(
+        'early_sdp_answer'
+      );
+    });
+
+    it('sends false when explicitly disabled', async () => {
+      const request = await loginRequestFor({
+        login: 'login',
+        password: 'password',
+        earlySdpAnswer: false,
+      });
+
+      expect(request.params.loginParams).toEqual({ early_sdp_answer: false });
+    });
+
+    it.each([
+      ['password', { login: 'login', password: 'password' }],
+      ['login token', { login_token: 'token' }],
+    ])('sends true on %s authentication', async (_label, credentials) => {
+      const request = await loginRequestFor({
+        ...credentials,
+        earlySdpAnswer: true,
+      });
+
+      expect(request.method).toBe('login');
+      expect(request.params.loginParams).toEqual({ early_sdp_answer: true });
+    });
+
+    it('preserves the option on reconnect login payloads', async () => {
+      const client = _buildInstance({
+        login: 'login',
+        password: 'password',
+        earlySdpAnswer: true,
+      } as IVertoOptions);
+
+      await client.login();
+      setReconnectToken('voice-sdk-id');
+      await client.login();
+
+      const initialRequest = Connection.mockSend.mock.calls[0][0].request;
+      const reconnectRequest = Connection.mockSend.mock.calls[1][0].request;
+      expect(initialRequest.params.loginParams).toEqual({
+        early_sdp_answer: true,
+      });
+      expect(reconnectRequest.params.reconnection).toBe(true);
+      expect(reconnectRequest.params.loginParams).toEqual(
+        initialRequest.params.loginParams
+      );
+    });
+
+    it('does not change anonymous_login payloads', async () => {
+      const request = await loginRequestFor({
+        anonymous_login: {
+          target_type: 'ai_assistant',
+          target_id: 'assistant-id',
+        },
+        earlySdpAnswer: true,
+      });
+
+      expect(request.method).toBe('anonymous_login');
+      expect(request.params).not.toHaveProperty('early_sdp_answer');
+      expect(request.params).not.toHaveProperty('loginParams');
+      expect(request.params.userVariables?.early_sdp_answer).toBeUndefined();
     });
   });
 

--- a/packages/js/src/Modules/Verto/tests/messages.test.ts
+++ b/packages/js/src/Modules/Verto/tests/messages.test.ts
@@ -31,7 +31,7 @@ describe('Messages', function () {
           false
         ).request;
         const res = JSON.parse(
-          `{"jsonrpc":"2.0","id":"${message.id}","method":"login","params":{"User-Agent": ${userAgent},"login":"login","passwd":"password", "reconnection": false,"login_token": "dskbksdjbfkjsdf234y67234kjrwe98","loginParams":{},"userVariables":{}}}`
+          `{"jsonrpc":"2.0","id":"${message.id}","method":"login","params":{"User-Agent": ${userAgent},"login":"login","passwd":"password", "reconnection": false,"login_token": "dskbksdjbfkjsdf234y67234kjrwe98","loginParams":{"early_sdp_answer":false},"userVariables":{}}}`
         );
         expect(message).toEqual(res);
       });
@@ -46,7 +46,7 @@ describe('Messages', function () {
           false
         ).request;
         const res = JSON.parse(
-          `{"jsonrpc":"2.0","id":"${message.id}","method":"login","params":{"User-Agent": ${userAgent},"login":"login","passwd":"password","reconnection": false, "login_token": "dskbksdjbfkjsdf234y67234kjrwe98","sessid":"123456789","loginParams":{},"userVariables":{}}}`
+          `{"jsonrpc":"2.0","id":"${message.id}","method":"login","params":{"User-Agent": ${userAgent},"login":"login","passwd":"password","reconnection": false, "login_token": "dskbksdjbfkjsdf234y67234kjrwe98","sessid":"123456789","loginParams":{"early_sdp_answer":false},"userVariables":{}}}`
         );
         expect(message).toEqual(res);
       });
@@ -67,6 +67,22 @@ describe('Messages', function () {
             }),
           })
         );
+      });
+
+      it('serializes early_sdp_answer only under loginParams', () => {
+        const { params } = new Login(
+          'login',
+          'password',
+          'token',
+          'session',
+          { custom_key: 'custom-value' },
+          false,
+          true
+        ).request;
+
+        expect(params.loginParams).toEqual({ early_sdp_answer: true });
+        expect(params).not.toHaveProperty('early_sdp_answer');
+        expect(params.userVariables).not.toHaveProperty('early_sdp_answer');
       });
     });
 

--- a/packages/js/src/Modules/Verto/util/interfaces.ts
+++ b/packages/js/src/Modules/Verto/util/interfaces.ts
@@ -12,6 +12,7 @@ export interface IVertoOptions {
   login_token?: string;
   userVariables?: Record<string, any>;
   pushWhenActive?: boolean;
+  earlySdpAnswer?: boolean;
   ringtoneFile?: string;
   ringbackFile?: string;
   env?: Environment;

--- a/packages/js/src/utils/interfaces.ts
+++ b/packages/js/src/utils/interfaces.ts
@@ -91,6 +91,13 @@ export interface IClientOptions {
    */
   pushWhenActive?: boolean;
   /**
+   * When `true`, requests early SDP answers during standard authenticated
+   * login. This option does not apply to anonymous login.
+   *
+   * @default false
+   */
+  earlySdpAnswer?: boolean;
+  /**
    * A URL to a wav/mp3 ringtone file.
    */
   ringtoneFile?: string;


### PR DESCRIPTION
## Summary
- add public `earlySdpAnswer` client option, defaulting to `false`
- serialize the option as `params.loginParams.early_sdp_answer` on standard login
- preserve the option for password, token, and reconnect login flows while leaving anonymous login unchanged
- document the new public option

## Test plan
- [x] `jest src/Modules/Verto/tests/messages.test.ts src/Modules/Verto/tests/Verto.test.ts --runInBand` — 100 passed
- [x] full JS SDK Jest suite — 747 passed
- [x] `tsc --noEmit --project tsconfig.json`
- [x] Rollup build
- [x] Prettier check on changed files
- [x] `git diff --check`

## Notes
Scoped ESLint reports 12 existing errors on unchanged legacy lines (`any`, `Function`, and one CommonJS `require`). No new lint findings were introduced by this change.
