### PR TITLE
fix(js): disable ICE candidate prefetching by default

### DIFF
--- a/packages/js/docs/ts/classes/TelnyxRTC.md
+++ b/packages/js/docs/ts/classes/TelnyxRTC.md
@@ -1155,16 +1155,14 @@ client.newCall({
 
 ### ICE Candidate Prefetching
 
-ICE candidate prefetching is enabled by default. This pre-gathers ICE candidates when the
-`RTCPeerConnection` is created, before `setLocalDescription` is called, improving call setup
-performance and reducing DTLS handshake issues caused by late-arriving candidates.
-
-To disable prefetching, pass `prefetchIceCandidates: false` to the `newCall` method:
+ICE candidate prefetching is disabled by default. To opt in, pass
+`prefetchIceCandidates: true` to `newCall`. This pre-gathers one ICE candidate set when the
+`RTCPeerConnection` is created, before `setLocalDescription` is called.
 
 ```js
 client.newCall({
   destinationNumber: 'xxx',
-  prefetchIceCandidates: false,
+  prefetchIceCandidates: true,
 });
 ```
 

--- a/packages/js/docs/ts/interfaces/ICallOptions.md
+++ b/packages/js/docs/ts/interfaces/ICallOptions.md
@@ -205,7 +205,7 @@ Preferred codecs for the call.
 
 • `Optional` **prefetchIceCandidates**: `boolean`
 
-Enable or disable prefetching ICE candidates. Defaults to true.
+Enable or disable prefetching ICE candidates. Defaults to false.
 
 Sets `iceCandidatePoolSize` to 1 when on and 0 when off. A deeper pool gains
 nothing — BUNDLE negotiates the call down to a single transport, so only one

--- a/packages/js/docs/ts/interfaces/IClientOptions.md
+++ b/packages/js/docs/ts/interfaces/IClientOptions.md
@@ -431,7 +431,7 @@ The `password` to authenticate with your SIP Connection.
 
 • `Optional` **prefetchIceCandidates**: `boolean`
 
-Enable or disable prefetching ICE candidates. Defaults to true.
+Enable or disable prefetching ICE candidates. Defaults to false.
 
 Sets `iceCandidatePoolSize` to 1 when on and 0 when off. A deeper pool gains
 nothing — BUNDLE negotiates the call down to a single transport, so only one

--- a/packages/js/src/Modules/Verto/tests/webrtc/Call.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/Call.test.ts
@@ -99,10 +99,8 @@ describe('Call', () => {
       return s;
     };
 
-    it('defaults to true when the client did not set it', () => {
-      // Regression: DEFAULT_CALL_OPTIONS.prefetchIceCandidates was being
-      // clobbered with `undefined`, leaving iceCandidatePoolSize at 0.
-      expect(call.options.prefetchIceCandidates).toBe(true);
+    it('defaults to false when the client did not set it', () => {
+      expect(call.options.prefetchIceCandidates).toBe(false);
     });
 
     it('honours an explicit client-level false', async () => {
@@ -119,12 +117,12 @@ describe('Call', () => {
       );
     });
 
-    it('lets a per-call option override the client default', () => {
+    it('lets a per-call option enable prefetching over the client default', () => {
       const c = new Call(session, {
         ...defaultParams,
-        prefetchIceCandidates: false,
+        prefetchIceCandidates: true,
       });
-      expect(c.options.prefetchIceCandidates).toBe(false);
+      expect(c.options.prefetchIceCandidates).toBe(true);
     });
   });
 

--- a/packages/js/src/Modules/Verto/tests/webrtc/VertoHandler.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/VertoHandler.test.ts
@@ -98,6 +98,18 @@ describe('VertoHandler', () => {
       expect(instance.calls[callId].direction).toEqual('inbound');
     });
 
+    it('should disable candidate prefetching by default for inbound calls', async () => {
+      await instance.connect();
+      const callId = 'cd35e65f-a507-4bd2-8d21-80f36d134a2e';
+      const msg = JSON.parse(
+        `{"jsonrpc":"2.0","id":4402,"method":"telnyx_rtc.invite","params":{"callID":"${callId}","sdp":"SDP","caller_id_name":"Extension 1004","caller_id_number":"1004","callee_id_name":"Outbound Call","callee_id_number":"1003","display_direction":"outbound"}}`
+      );
+
+      handler.handleMessage(msg);
+
+      expect(instance.calls[callId].options.prefetchIceCandidates).toBe(false);
+    });
+
     it('should store passed call options', async () => {
       await instance.connect();
       const callId = 'cd35e65f-a507-4bd2-8d21-80f36d134a2e';

--- a/packages/js/src/Modules/Verto/util/interfaces.ts
+++ b/packages/js/src/Modules/Verto/util/interfaces.ts
@@ -28,7 +28,7 @@ export interface IVertoOptions {
 
   debug?: boolean;
   debugOutput?: 'socket' | 'file';
-  /** Enable or disable prefetching ICE candidates. Defaults to true. */
+  /** Enable or disable prefetching ICE candidates. Defaults to false. */
   prefetchIceCandidates?: boolean;
   forceRelayCandidate?: boolean;
   trickleIce?: boolean;

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -319,8 +319,8 @@ export default abstract class BaseCall implements IWebRTCCall {
         debugOutput: options.debugOutput,
         trickleIce: options.trickleIce,
         // `Object.assign` copies keys whose value is `undefined`, so reading
-        // `options.prefetchIceCandidates` directly would overwrite the `true`
-        // from DEFAULT_CALL_OPTIONS whenever the client did not set it.
+        // `options.prefetchIceCandidates` directly would overwrite the default
+        // whenever the client did not set it.
         prefetchIceCandidates:
           options.prefetchIceCandidates ??
           DEFAULT_CALL_OPTIONS.prefetchIceCandidates,
@@ -2750,7 +2750,7 @@ export default abstract class BaseCall implements IWebRTCCall {
         audio: this._sanitizeClientOption(this.options.audio),
         video: this._sanitizeClientOption(this.options.video),
         mutedMicOnStart: this.options.mutedMicOnStart ?? false,
-        prefetchIceCandidates: this.options.prefetchIceCandidates ?? true,
+        prefetchIceCandidates: this.options.prefetchIceCandidates ?? false,
         forceRelayCandidate: this.options.forceRelayCandidate ?? false,
         trickleIce: this.options.trickleIce ?? false,
         iceServers: this._sanitizeIceServers(this.options.iceServers),

--- a/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
+++ b/packages/js/src/Modules/Verto/webrtc/VertoHandler.ts
@@ -258,7 +258,7 @@ class VertoHandler {
         debug: session.options.debug ?? false,
         debugOutput: session.options.debugOutput ?? 'socket',
         trickleIce: session.options.trickleIce ?? false,
-        prefetchIceCandidates: session.options.prefetchIceCandidates ?? true,
+        prefetchIceCandidates: session.options.prefetchIceCandidates ?? false,
         // An evaluated recovery value takes precedence over the session default.
         forceRelayCandidate:
           typeof forceRelayCandidateForRecovery === 'boolean'

--- a/packages/js/src/Modules/Verto/webrtc/constants.ts
+++ b/packages/js/src/Modules/Verto/webrtc/constants.ts
@@ -98,7 +98,7 @@ export const DEFAULT_CALL_OPTIONS: IVertoCallOptions = {
   userVariables: {},
   mediaSettings: { useSdpASBandwidthKbps: false, sdpASBandwidthKbps: 0 },
   mutedMicOnStart: false,
-  prefetchIceCandidates: true,
+  prefetchIceCandidates: false,
 };
 
 export enum State {

--- a/packages/js/src/Modules/Verto/webrtc/interfaces.ts
+++ b/packages/js/src/Modules/Verto/webrtc/interfaces.ts
@@ -80,7 +80,7 @@ export interface IVertoCallOptions {
    * Defaults to false.
    */
   receiveOnlyAudio?: boolean;
-  /** Enable or disable prefetching ICE candidates. Defaults to true. */
+  /** Enable or disable prefetching ICE candidates. Defaults to false. */
   prefetchIceCandidates?: boolean;
   forceRelayCandidate?: boolean;
   trickleIce?: boolean;

--- a/packages/js/src/TelnyxRTC.ts
+++ b/packages/js/src/TelnyxRTC.ts
@@ -285,15 +285,14 @@ export class TelnyxRTC extends TelnyxRTCClient {
    * 
    * ### ICE Candidate Prefetching
    * 
-   * ICE candidate prefetching is enabled by default. This pre-gathers ICE candidates when the
-   * `RTCPeerConnection` is created, before `setLocalDescription` is called, improving call setup
-   * performance and reducing DTLS handshake issues caused by late-arriving candidates.
-   * 
-   * To disable prefetching, pass `prefetchIceCandidates: false` to the `newCall` method:
+   * ICE candidate prefetching is disabled by default. To opt in, pass
+   * `prefetchIceCandidates: true` to `newCall`. This pre-gathers one ICE candidate set when the
+   * `RTCPeerConnection` is created, before `setLocalDescription` is called.
+   *
    * ```js
    * client.newCall({
    *  destinationNumber: 'xxx',
-   *  prefetchIceCandidates: false,
+   *  prefetchIceCandidates: true,
    * });
    * ```
    * 

--- a/packages/js/src/utils/interfaces.ts
+++ b/packages/js/src/utils/interfaces.ts
@@ -119,7 +119,7 @@ export interface IClientOptions {
   debugOutput?: 'socket' | 'file';
 
   /**
-   * Enable or disable prefetching ICE candidates. Defaults to true.
+   * Enable or disable prefetching ICE candidates. Defaults to false.
    *
    * Sets `iceCandidatePoolSize` to 1 when on and 0 when off. A deeper pool gains
    * nothing — BUNDLE negotiates the call down to a single transport, so only one
@@ -542,7 +542,7 @@ export interface ICallOptions {
   preferred_codecs?: RTCRtpCodecCapability[];
 
   /**
-   * Enable or disable prefetching ICE candidates. Defaults to true.
+   * Enable or disable prefetching ICE candidates. Defaults to false.
    *
    * Sets `iceCandidatePoolSize` to 1 when on and 0 when off. A deeper pool gains
    * nothing — BUNDLE negotiates the call down to a single transport, so only one


### PR DESCRIPTION
## Summary
- disable `prefetchIceCandidates` by default for outbound and inbound calls
- preserve explicit client-level and per-call opt-in (`true` keeps `iceCandidatePoolSize: 1`)
- align call-report metadata, public option docs, and generated TypeDoc output with the new default

## Verification
- `yarn test --runInBand` — 27 suites / 750 tests passed
- `../../node_modules/.bin/tsc --noEmit --project tsconfig.json`
- `yarn build`
- `yarn docs` — generated successfully with existing TypeDoc warnings
- scoped ESLint passed for changed implementation and test files
- `git diff --check`

## Lint note
The repository commit hook still reports pre-existing `any` / `Function` lint errors in the three touched interface files. Those unrelated interface-wide issues are unchanged and intentionally out of scope.
