### PR TITLE
ci: remove release docs automation

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -83,14 +83,6 @@ jobs:
         env:
           CI: true
 
-      - if: github.event.inputs.package == 'webrtc'
-        name: Generate docs
-        working-directory: packages/${{ env.PACKAGE_DIR }}
-        run: |
-          yarn docs
-          git add docs
-          git commit -m "docs: update ts docs" || echo "docs: no docs changes to commit"
-
       - name: Determine next version
         id: version
         working-directory: packages/${{ env.PACKAGE_DIR }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -69,21 +69,6 @@ jobs:
         env:
           CI: true
 
-      - name: get-npm-version
-        id: package-version
-        uses: martinbeentjes/npm-get-version-action@master
-        with:
-          path: packages/js
-
-      - name: Trigger developer docs update
-        if: "!github.event.release.prerelease"
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ secrets.DOCS_DISPATCH_TOKEN }}
-          repository: team-telnyx/developer-docs-mintlify
-          event-type: update-webrtc-snippets
-          client-payload: '{"sdk": "js", "version": "${{ steps.package-version.outputs.current-version }}"}'
-
   publish-react-client:
     if: startsWith(github.event.release.tag_name, 'react-client/v')
 


### PR DESCRIPTION
## Summary
- stop the draft-release workflow from regenerating and committing `packages/js/docs`
- stop the publish-release workflow from dispatching `update-webrtc-snippets` to the developer docs repository
- remove the npm-version lookup that was only used by the docs dispatch

Documentation updates are handled separately by the docs agent. Manual TypeDoc commands and the existing GitHub Pages workflow remain unchanged.

## Verification
- [x] Both modified workflows parse as YAML
- [x] Prettier check passes for both workflow files
- [x] `git diff --check` passes
