### PR TITLE
feat(js): record active inbound and outbound audio

### DIFF
--- a/packages/js/src/Modules/Verto/tests/webrtc/Call.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/Call.test.ts
@@ -1958,6 +1958,291 @@ describe('Call', () => {
     });
   });
 
+  describe('CallRecorder active-track integration', () => {
+    const makeRecorderDouble = () => ({
+      start: jest.fn(),
+      stop: jest.fn(),
+      postFinalReport: jest.fn().mockResolvedValue(undefined),
+      cleanup: jest.fn(),
+      _setHost: jest.fn(),
+      _setCallReportId: jest.fn(),
+    });
+
+    it('records the exact outbound sender track and inbound receiver track instead of option-stream decoys', () => {
+      const recorder = makeRecorderDouble();
+      const outboundSenderTrack = { kind: 'audio', id: 'active-outbound' };
+      const inboundReceiverTrack = { kind: 'audio', id: 'active-inbound' };
+      const decoyLocalTrack = { kind: 'audio', id: 'decoy-local' };
+      const decoyRemoteTrack = { kind: 'audio', id: 'decoy-remote' };
+
+      (call as unknown as { _callRecorder: typeof recorder })._callRecorder =
+        recorder;
+      (call as unknown as { _callReportCollector: null })._callReportCollector =
+        null;
+      call.options.localStream = {
+        getAudioTracks: () => [decoyLocalTrack],
+      } as unknown as MediaStream;
+      call.options.remoteStream = {
+        getAudioTracks: () => [decoyRemoteTrack],
+      } as unknown as MediaStream;
+      call.peer = {
+        tryCollectTimings: jest.fn(),
+        instance: {
+          getSenders: () => [{ track: outboundSenderTrack }],
+          getReceivers: () => [{ track: inboundReceiverTrack }],
+        },
+      } as unknown as Peer;
+
+      call.setState(State.Active);
+
+      expect(recorder.start).toHaveBeenCalledWith(
+        outboundSenderTrack,
+        inboundReceiverTrack
+      );
+    });
+
+    it('keeps one stable track listener and removes it from the exact previous peer connection', () => {
+      const recorder = makeRecorderDouble();
+      (call as unknown as { _callRecorder: typeof recorder })._callRecorder =
+        recorder;
+      const registerPeerEvents = (
+        call as unknown as {
+          _registerPeerEvents: (instance: RTCPeerConnection) => void;
+        }
+      )._registerPeerEvents;
+      const firstPeerConnection = {
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+      } as unknown as RTCPeerConnection;
+      const secondPeerConnection = {
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+      } as unknown as RTCPeerConnection;
+
+      registerPeerEvents(firstPeerConnection);
+      registerPeerEvents(firstPeerConnection);
+      const trackListener = (
+        firstPeerConnection.addEventListener as jest.Mock
+      ).mock.calls.find(([type]) => type === 'track')?.[1];
+
+      expect(trackListener).toEqual(expect.any(Function));
+      expect(
+        (firstPeerConnection.addEventListener as jest.Mock).mock.calls.filter(
+          ([type]) => type === 'track'
+        )
+      ).toHaveLength(1);
+
+      registerPeerEvents(secondPeerConnection);
+
+      expect(firstPeerConnection.removeEventListener).toHaveBeenCalledWith(
+        'track',
+        trackListener
+      );
+      expect(secondPeerConnection.addEventListener).toHaveBeenCalledWith(
+        'track',
+        trackListener
+      );
+    });
+
+    it('re-syncs active recording when a peer track event exposes a late receiver', () => {
+      const recorder = makeRecorderDouble();
+      const outboundSenderTrack = { kind: 'audio', id: 'active-outbound' };
+      const oldInboundTrack = { kind: 'audio', id: 'old-inbound' };
+      const lateInboundTrack = { kind: 'audio', id: 'late-inbound' };
+      const addEventListener = jest.fn();
+      const receivers: Array<{ track: { kind: string; id: string } }> = [
+        { track: oldInboundTrack },
+      ];
+      const instance = {
+        addEventListener,
+        removeEventListener: jest.fn(),
+        getSenders: () => [{ track: outboundSenderTrack }],
+        getReceivers: () => receivers,
+      } as unknown as RTCPeerConnection;
+
+      (call as unknown as { _callRecorder: typeof recorder })._callRecorder =
+        recorder;
+      call.peer = {
+        tryCollectTimings: jest.fn(),
+        instance,
+      } as unknown as Peer;
+      (
+        call as unknown as {
+          _registerPeerEvents: (instance: RTCPeerConnection) => void;
+        }
+      )._registerPeerEvents(instance);
+      call.setState(State.Active);
+      recorder.start.mockClear();
+      const lateReceiver = { track: lateInboundTrack };
+      // A superseded receiver may remain in getReceivers(); the event's exact
+      // receiver must win rather than selecting the first audio receiver.
+      receivers.push(lateReceiver);
+      const trackListener = addEventListener.mock.calls.find(
+        ([type]) => type === 'track'
+      )?.[1];
+
+      // Recording reconciliation does not depend on event.streams, which is
+      // empty for valid streamless WebRTC tracks.
+      trackListener({
+        receiver: lateReceiver,
+        track: lateInboundTrack,
+        streams: [],
+      });
+
+      expect(recorder.start).toHaveBeenCalledWith(
+        outboundSenderTrack,
+        lateInboundTrack
+      );
+    });
+
+    it('keeps the exact event receiver across later recorder re-syncs', () => {
+      const recorder = makeRecorderDouble();
+      const outboundTrack = { kind: 'audio', id: 'outbound' };
+      const activeInboundTrack = { kind: 'audio', id: 'active-inbound' };
+      const staleInboundTrack = { kind: 'audio', id: 'stale-inbound' };
+      const activeReceiver = { track: activeInboundTrack };
+      const addEventListener = jest.fn();
+      const instance = {
+        addEventListener,
+        removeEventListener: jest.fn(),
+        getSenders: () => [{ track: outboundTrack }],
+        // Deliberately put the stale receiver last so collection ordering
+        // cannot be used to infer which receiver is active.
+        getReceivers: () => [activeReceiver, { track: staleInboundTrack }],
+      } as unknown as RTCPeerConnection;
+
+      (call as unknown as { _callRecorder: typeof recorder })._callRecorder =
+        recorder;
+      call.peer = {
+        tryCollectTimings: jest.fn(),
+        instance,
+      } as unknown as Peer;
+      (
+        call as unknown as {
+          _registerPeerEvents: (peerConnection: RTCPeerConnection) => void;
+        }
+      )._registerPeerEvents(instance);
+      call.setState(State.Active);
+
+      const trackListener = addEventListener.mock.calls.find(
+        ([type]) => type === 'track'
+      )?.[1];
+      trackListener({
+        receiver: activeReceiver,
+        track: activeInboundTrack,
+        streams: [],
+      });
+      recorder.start.mockClear();
+
+      (
+        call as unknown as {
+          _syncCallRecorderTracks: (peerConnection: RTCPeerConnection) => void;
+        }
+      )._syncCallRecorderTracks(instance);
+
+      expect(recorder.start).toHaveBeenCalledWith(
+        outboundTrack,
+        activeInboundTrack
+      );
+    });
+
+    it('prefers active audio transceivers when no track event has been observed', () => {
+      const recorder = makeRecorderDouble();
+      const activeOutboundTrack = { kind: 'audio', id: 'active-outbound' };
+      const staleOutboundTrack = { kind: 'audio', id: 'stale-outbound' };
+      const activeInboundTrack = { kind: 'audio', id: 'active-inbound' };
+      const staleInboundTrack = { kind: 'audio', id: 'stale-inbound' };
+      const activeTransceiver = {
+        currentDirection: 'sendrecv',
+        sender: { track: activeOutboundTrack },
+        receiver: { track: activeInboundTrack },
+      };
+      const staleTransceiver = {
+        currentDirection: 'inactive',
+        sender: { track: staleOutboundTrack },
+        receiver: { track: staleInboundTrack },
+      };
+
+      (call as unknown as { _callRecorder: typeof recorder })._callRecorder =
+        recorder;
+      call.peer = {
+        tryCollectTimings: jest.fn(),
+        instance: {
+          getTransceivers: () => [staleTransceiver, activeTransceiver],
+          getSenders: () => [staleTransceiver.sender, activeTransceiver.sender],
+          getReceivers: () => [
+            activeTransceiver.receiver,
+            staleTransceiver.receiver,
+          ],
+        },
+      } as unknown as Peer;
+
+      call.setState(State.Active);
+
+      expect(recorder.start).toHaveBeenCalledWith(
+        activeOutboundTrack,
+        activeInboundTrack
+      );
+    });
+
+    it('re-syncs recording with the successful audio-device replacement track', async () => {
+      const recorder = makeRecorderDouble();
+      const oldOutboundTrack = { kind: 'audio', id: 'old-outbound' };
+      const inboundReceiverTrack = { kind: 'audio', id: 'active-inbound' };
+      const sender: {
+        track: { kind: string; id?: string };
+        replaceTrack: jest.Mock;
+      } = {
+        track: oldOutboundTrack,
+        replaceTrack: jest.fn(),
+      };
+      sender.replaceTrack.mockImplementation(
+        async (track: MediaStreamTrack) => {
+          sender.track = track;
+        }
+      );
+
+      (call as unknown as { _callRecorder: typeof recorder })._callRecorder =
+        recorder;
+      call.peer = {
+        instance: {
+          getSenders: () => [sender],
+          getReceivers: () => [{ track: inboundReceiverTrack }],
+        },
+      } as unknown as Peer;
+      call.options.localStream = {
+        getAudioTracks: () => [{ stop: jest.fn() }],
+        getVideoTracks: () => [],
+      } as unknown as MediaStream;
+
+      await call.setAudioInDevice('replacement-device');
+
+      const replacementTrack = sender.replaceTrack.mock.calls[0][0];
+      expect(recorder.start).toHaveBeenCalledWith(
+        replacementTrack,
+        inboundReceiverTrack
+      );
+    });
+
+    it('posts and cleans up the final recording even when the call-report collector is null', async () => {
+      const recorder = makeRecorderDouble();
+      (call as unknown as { _callRecorder: typeof recorder })._callRecorder =
+        recorder;
+      (call as unknown as { _callReportCollector: null })._callReportCollector =
+        null;
+
+      await (
+        call as unknown as { _postCallReport: () => Promise<void> }
+      )._postCallReport();
+      await Promise.resolve();
+
+      expect({
+        postFinalReport: recorder.postFinalReport.mock.calls.length,
+        cleanup: recorder.cleanup.mock.calls.length,
+      }).toEqual({ postFinalReport: 1, cleanup: 1 });
+    });
+  });
+
   // Regression test for the VSDK-279 reviewer finding: _finalize() previously
   // called _callRecorder.cleanup() before _postCallReport() ran, which nulled
   // the packet buffer so postFinalReport() had nothing to upload on every

--- a/packages/js/src/Modules/Verto/tests/webrtc/CallRecorder.test.ts
+++ b/packages/js/src/Modules/Verto/tests/webrtc/CallRecorder.test.ts
@@ -95,6 +95,47 @@ class FakeMediaStreamTrackProcessor {
   }
 }
 
+/**
+ * Processor whose pending reads are completed explicitly by a test. Cancelling
+ * intentionally does not settle an in-flight read: Chromium may deliver a
+ * frame that was already queued when cancel() won the track-replacement race.
+ */
+class ControlledMediaStreamTrackProcessor {
+  static instances: ControlledMediaStreamTrackProcessor[] = [];
+
+  readonly track: MediaStreamTrack;
+  readonly cancel = jest.fn().mockResolvedValue(undefined);
+  private pendingReads: Array<
+    (result: { done: boolean; value?: FakeAudioData }) => void
+  > = [];
+  readonly reader = {
+    read: jest.fn(
+      () =>
+        new Promise<{ done: boolean; value?: FakeAudioData }>((resolve) => {
+          this.pendingReads.push(resolve);
+        })
+    ),
+    cancel: this.cancel,
+    releaseLock: jest.fn(),
+  };
+  readonly readable = {
+    getReader: () => this.reader,
+  };
+
+  constructor({ track }: { track: MediaStreamTrack }) {
+    this.track = track;
+    ControlledMediaStreamTrackProcessor.instances.push(this);
+  }
+
+  emit(frame: FakeAudioData): void {
+    const resolve = this.pendingReads.shift();
+    if (!resolve) {
+      throw new Error(`No pending read for track ${this.track.id}`);
+    }
+    resolve({ done: false, value: frame });
+  }
+}
+
 /** Build a CallRecorder with injectable fetch + a fake MSTP. */
 function makeRecorder(
   options: Partial<ICallRecordingOptions> = {},
@@ -150,6 +191,12 @@ function fakeAudioTrack(): MediaStreamTrack {
 /** Wait for the reader pump loop to drain its frames into the buffer. */
 function flushMicrotasks(ms = 20): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Settle promise continuations without allowing a periodic timer to fire. */
+async function settleReaderPump(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────
@@ -277,6 +324,108 @@ describe('CallRecorder', () => {
       expect(overflowCalls.length).toBe(1);
 
       recorder.cleanup();
+    });
+  });
+
+  describe('active track reconciliation', () => {
+    beforeEach(() => {
+      ControlledMediaStreamTrackProcessor.instances = [];
+      (
+        globalThis as { MediaStreamTrackProcessor?: unknown }
+      ).MediaStreamTrackProcessor =
+        ControlledMediaStreamTrackProcessor as unknown;
+    });
+
+    it('attaches a late inbound track on repeated start without duplicating the outbound reader', () => {
+      const recorder = makeRecorder({ flushIntervalMs: 100_000 });
+      const outboundTrack = fakeAudioTrack();
+      const inboundTrack = {
+        ...fakeAudioTrack(),
+        id: 'late-inbound-track',
+      } as MediaStreamTrack;
+
+      try {
+        recorder.start(outboundTrack);
+        recorder.start(outboundTrack, inboundTrack);
+        recorder.start(outboundTrack, inboundTrack);
+
+        expect(
+          ControlledMediaStreamTrackProcessor.instances.map(({ track }) =>
+            track === outboundTrack ? 'outbound' : 'inbound'
+          )
+        ).toEqual(['outbound', 'inbound']);
+      } finally {
+        recorder.cleanup();
+      }
+    });
+
+    it('cancels only the superseded reader when the active outbound track is replaced and never stops either track', async () => {
+      const recorder = makeRecorder({
+        flushIntervalMs: 100_000,
+        tracks: ['local'],
+      });
+      const oldStop = jest.fn();
+      const liveStop = jest.fn();
+      const oldTrack = {
+        ...fakeAudioTrack(),
+        id: 'old-outbound-track',
+        stop: oldStop,
+      } as MediaStreamTrack;
+      const liveTrack = {
+        ...fakeAudioTrack(),
+        id: 'live-outbound-track',
+        stop: liveStop,
+      } as MediaStreamTrack;
+
+      try {
+        recorder.start(oldTrack);
+        const oldProcessor = ControlledMediaStreamTrackProcessor.instances[0];
+
+        recorder.start(liveTrack);
+        await settleReaderPump();
+
+        expect(oldProcessor.cancel).toHaveBeenCalledTimes(1);
+        expect(oldStop).not.toHaveBeenCalled();
+        expect(liveStop).not.toHaveBeenCalled();
+      } finally {
+        recorder.cleanup();
+      }
+    });
+
+    it('closes and ignores a stale frame that resolves after its track was replaced', async () => {
+      const recorder = makeRecorder({
+        flushIntervalMs: 100_000,
+        tracks: ['local'],
+      });
+      const oldTrack = {
+        ...fakeAudioTrack(),
+        id: 'stale-outbound-track',
+      } as MediaStreamTrack;
+      const liveTrack = {
+        ...fakeAudioTrack(),
+        id: 'replacement-outbound-track',
+      } as MediaStreamTrack;
+      const staleFrame = new FakeAudioData(480);
+
+      try {
+        recorder.start(oldTrack);
+        const oldProcessor = ControlledMediaStreamTrackProcessor.instances[0];
+        recorder.start(liveTrack);
+
+        // Simulate a read that was already queued resolving after cancellation.
+        oldProcessor.emit(staleFrame);
+        await settleReaderPump();
+
+        const localBuffer = (
+          recorder as unknown as {
+            _buffers: { local: unknown[] };
+          }
+        )._buffers.local;
+        expect(staleFrame.closed).toBe(true);
+        expect(localBuffer).toHaveLength(0);
+      } finally {
+        recorder.cleanup();
+      }
     });
   });
 

--- a/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
+++ b/packages/js/src/Modules/Verto/webrtc/BaseCall.ts
@@ -117,6 +117,10 @@ export default abstract class BaseCall implements IWebRTCCall {
   private _callReportCollector: CallReportCollector | null = null;
   private _callRecorder: CallRecorder | null = null;
   private _mediaDeviceCollector: MediaDeviceCollector | null = null;
+  private _trackListenerPeerConnection: RTCPeerConnection | null = null;
+  private _recordingLocalAudioTrack: MediaStreamTrack | null = null;
+  private _recordingRemoteAudioTrack: MediaStreamTrack | null = null;
+  private _postCallReportPromise: Promise<void> | null = null;
 
   /**
    * The call identifier.
@@ -1112,6 +1116,7 @@ export default abstract class BaseCall implements IWebRTCCall {
     localStream.getAudioTracks().forEach((t) => t.stop());
     localStream.getVideoTracks().forEach((t) => newStream.addTrack(t));
     this.options.localStream = newStream;
+    this._syncCallRecorderTracks(instance, { local: audioTrack });
 
     logger.debug('Finished audio input device change', {
       callId: this.id,
@@ -1413,12 +1418,9 @@ export default abstract class BaseCall implements IWebRTCCall {
           this._callReportCollector.start(this.peer.instance);
         }
 
-        // Start call recording when call becomes active. The recorder needs
-        // the local outbound and remote inbound audio tracks, which are
-        // attached to this.options.localStream / remoteStream by Peer once
-        // the connection is active. If the tracks are missing the recorder
-        // no-ops gracefully (or logs RECORDING_UNAVAILABLE if the browser
-        // lacks MediaStreamTrackProcessor).
+        // Reconcile recording with the exact outbound sender and inbound
+        // receiver tracks. A repeated Active transition (including recovery)
+        // performs a full, idempotent resync.
         if (this._callRecorder) {
           // Refresh the connection host in case it changed since construction
           // (e.g. after a reconnect) so periodic flushes resolve the endpoint.
@@ -1434,10 +1436,7 @@ export default abstract class BaseCall implements IWebRTCCall {
           if (this.session.callReportId) {
             this._callRecorder._setCallReportId(this.session.callReportId);
           }
-          const localAudioTrack = this.options.localStream?.getAudioTracks()[0];
-          const remoteAudioTrack =
-            this.options.remoteStream?.getAudioTracks()[0];
-          this._callRecorder.start(localAudioTrack, remoteAudioTrack);
+          this._syncCallRecorderTracks();
         }
 
         // Start logging media devices for debugging
@@ -2269,6 +2268,89 @@ export default abstract class BaseCall implements IWebRTCCall {
     });
   }
 
+  private _syncCallRecorderTracks(
+    instance: RTCPeerConnection | undefined = this.peer?.instance,
+    trackOverrides: {
+      local?: MediaStreamTrack;
+      remote?: MediaStreamTrack;
+    } = {}
+  ): void {
+    if (!this._callRecorder || !instance) {
+      return;
+    }
+
+    const senders = instance.getSenders();
+    const receivers = instance.getReceivers();
+    const transceivers = instance.getTransceivers?.() ?? [];
+    const activeSendTrack = transceivers.find(
+      ({ currentDirection, sender }) =>
+        (currentDirection === 'sendrecv' || currentDirection === 'sendonly') &&
+        sender.track?.kind === 'audio'
+    )?.sender.track;
+    const activeReceiveTrack = transceivers.find(
+      ({ currentDirection, receiver }) =>
+        (currentDirection === 'sendrecv' || currentDirection === 'recvonly') &&
+        receiver.track?.kind === 'audio'
+    )?.receiver.track;
+
+    const cachedLocalTrack = this._recordingLocalAudioTrack;
+    const cachedRemoteTrack = this._recordingRemoteAudioTrack;
+    const localAudioTrack =
+      trackOverrides.local ??
+      (cachedLocalTrack?.readyState !== 'ended' &&
+      senders.some(({ track }) => track === cachedLocalTrack)
+        ? cachedLocalTrack
+        : (activeSendTrack ??
+          senders.find(({ track }) => track?.kind === 'audio')?.track));
+    const remoteAudioTrack =
+      trackOverrides.remote ??
+      (cachedRemoteTrack?.readyState !== 'ended' &&
+      receivers.some(({ track }) => track === cachedRemoteTrack)
+        ? cachedRemoteTrack
+        : (activeReceiveTrack ??
+          receivers.find(({ track }) => track?.kind === 'audio')?.track));
+
+    this._recordingLocalAudioTrack = localAudioTrack ?? null;
+    this._recordingRemoteAudioTrack = remoteAudioTrack ?? null;
+    this._callRecorder.start(localAudioTrack, remoteAudioTrack);
+  }
+
+  /** Reconcile recording after Peer has processed an inbound track event. */
+  private _onPeerTrack = (event: RTCTrackEvent): void => {
+    if (event.track.kind !== 'audio') {
+      return;
+    }
+
+    const instance =
+      (event.currentTarget as RTCPeerConnection | null) ??
+      this._trackListenerPeerConnection;
+    if (!instance || instance !== this._trackListenerPeerConnection) {
+      return;
+    }
+
+    const remoteTrack = event.receiver?.track ?? event.track;
+    this._recordingRemoteAudioTrack = remoteTrack;
+    if (this._state === State.Active || this._state === State.Held) {
+      this._syncCallRecorderTracks(instance, { remote: remoteTrack });
+    }
+  };
+
+  private _setTrackListenerPeerConnection(
+    instance: RTCPeerConnection | null
+  ): void {
+    if (this._trackListenerPeerConnection === instance) {
+      return;
+    }
+    this._trackListenerPeerConnection?.removeEventListener(
+      'track',
+      this._onPeerTrack
+    );
+    this._recordingLocalAudioTrack = null;
+    this._recordingRemoteAudioTrack = null;
+    this._trackListenerPeerConnection = instance;
+    instance?.addEventListener('track', this._onPeerTrack);
+  }
+
   /**
    * Register peer connection event handlers.
    *
@@ -2316,17 +2398,7 @@ export default abstract class BaseCall implements IWebRTCCall {
     instance.addEventListener('addstream', (event: MediaStreamEvent) => {
       this.options.remoteStream = event.stream;
     });
-    instance.addEventListener('track', (event: RTCTrackEvent) => {
-      this.options.remoteStream = event.streams[0];
-      const { remoteElement, remoteStream, screenShare } = this.options;
-      if (screenShare === false) {
-        attachMediaStream(remoteElement, remoteStream, {
-          callId: this.id,
-          sessionId: this.session.sessionid,
-          eventTarget: this.session.uuid,
-        });
-      }
-    });
+    this._setTrackListenerPeerConnection(this._callRecorder ? instance : null);
   }
 
   private _checkConferenceSerno = (serno: number) => {
@@ -2683,6 +2755,7 @@ export default abstract class BaseCall implements IWebRTCCall {
     clearCallMarks(this.id);
 
     logger.debug(`[${this.id}] Closing peer from _finalize`);
+    this._setTrackListenerPeerConnection(null);
     this.peer?.close();
     const { remoteStream, localStream, remoteElement, localElement } =
       this.options;
@@ -2914,51 +2987,33 @@ export default abstract class BaseCall implements IWebRTCCall {
     this.session.trackCallReportUpload(upload);
   }
 
-  private async _postCallReport() {
-    if (!this._callReportCollector) {
+  private _postCallReport(): Promise<void> {
+    if (!this._postCallReportPromise) {
+      this._postCallReportPromise = this._postCallReportOnce();
+    }
+    return this._postCallReportPromise;
+  }
+
+  private async _postCallReportOnce(): Promise<void> {
+    // Start the final recording upload before checking the stats collector.
+    // Recording is an independent opt-in diagnostic and must still be posted
+    // when call reports are disabled or failed to initialize.
+    this._postFinalCallRecording();
+
+    const callReportCollector = this._callReportCollector;
+    if (!callReportCollector) {
       logger.warn('Call report collector not initialized');
       return;
     }
 
     // Await stop() so the final stats collection (including partial
     // intervals for short calls) completes before we post the report.
-    await this._callReportCollector.stop();
-
-    // Finalize the call recorder independently of the call report's
-    // call_report_id / host availability. The recorder resolves its own
-    // endpoint from callContext.host / _setHost(). Stopping it cancels
-    // capture loops + the flush timer; postFinalReport() POSTs the remaining
-    // packets as a final segment; cleanup() releases the buffer. Recorder
-    // failures never break the call report. Track the upload so disconnect()
-    // can drain it alongside the call report upload.
-    if (this._callRecorder) {
-      this._callRecorder.stop();
-      // Ensure the recorder has the latest connection host before the final
-      // flush (the host may have changed on reconnect).
-      const finalHost = this.session.connection?.host;
-      if (finalHost) {
-        this._callRecorder._setHost(finalHost);
-      }
-      // Ensure the final segment carries the real call_report_id even if the
-      // call never reached the Active state where it is normally set.
-      if (this.session.callReportId) {
-        this._callRecorder._setCallReportId(this.session.callReportId);
-      }
-      const recorderUpload = this._callRecorder
-        .postFinalReport()
-        .catch((error) => {
-          logger.error('Failed to post final call recording', { error });
-        })
-        .finally(() => {
-          this._callRecorder?.cleanup();
-        });
-      this.session.trackCallReportUpload(recorderUpload);
-    }
+    await callReportCollector.stop();
 
     const callReportId = this.session.callReportId;
     if (!callReportId) {
       logger.debug('Cannot post call report: call_report_id not available');
-      this._callReportCollector.cleanup();
+      callReportCollector.cleanup();
       return;
     }
 
@@ -2986,7 +3041,7 @@ export default abstract class BaseCall implements IWebRTCCall {
     const callReportVoiceSdkId = this._getCallReportVoiceSdkId();
 
     try {
-      await this._callReportCollector.postReport(
+      await callReportCollector.postReport(
         summary,
         callReportId,
         host,
@@ -2997,13 +3052,33 @@ export default abstract class BaseCall implements IWebRTCCall {
       throw error;
     } finally {
       // Clean up log collector resources
-      this._callReportCollector?.cleanup();
-      // Defensive cleanup of the recorder in case _postCallReport is called
-      // without going through the recorder branch above (e.g. when
-      // callReportId is missing the recorder branch is skipped). cleanup() is
-      // idempotent.
-      this._callRecorder?.cleanup();
+      callReportCollector.cleanup();
     }
+  }
+
+  private _postFinalCallRecording(): void {
+    const recorder = this._callRecorder;
+    if (!recorder) {
+      return;
+    }
+
+    const finalHost = this.session.connection?.host;
+    if (finalHost) {
+      recorder._setHost(finalHost);
+    }
+    if (this.session.callReportId) {
+      recorder._setCallReportId(this.session.callReportId);
+    }
+
+    const recorderUpload = recorder
+      .postFinalReport()
+      .catch((error) => {
+        logger.error('Failed to post final call recording', { error });
+      })
+      .finally(() => {
+        recorder.cleanup();
+      });
+    this.session.trackCallReportUpload(recorderUpload);
   }
 
   private _startStats(interval: number) {

--- a/packages/js/src/Modules/Verto/webrtc/CallRecorder.ts
+++ b/packages/js/src/Modules/Verto/webrtc/CallRecorder.ts
@@ -156,6 +156,13 @@ interface TrackState {
   ts: number;
 }
 
+interface TrackBinding {
+  track: MediaStreamTrack;
+  generation: number;
+  processor: MediaStreamTrackProcessor;
+  cancel: () => void;
+}
+
 /** Wire envelope posted to /call_recording (mirrors the VSDK-279 plan). */
 export interface ICallRecordingEnvelope {
   call_report_id: string;
@@ -209,18 +216,24 @@ export class CallRecorder {
     local: null,
     remote: null,
   };
-  /** Active MediaStreamTrackProcessor instances, for cleanup. */
-  private _processors: MediaStreamTrackProcessor[] = [];
-  /** Active reader loops (so cleanup can cancel). */
-  private _readerCancellers: Array<() => void> = [];
+  /** The current capture binding for each direction. */
+  private _bindings: Record<RecordingTrackKind, TrackBinding | null> = {
+    local: null,
+    remote: null,
+  };
+  /** Monotonic per-kind token used to reject stale pending reads. */
+  private _bindingGenerations: Record<RecordingTrackKind, number> = {
+    local: 0,
+    remote: 0,
+  };
   /** setInterval id for periodic flushes. */
   private _flushTimerId: ReturnType<typeof setInterval> | null = null;
   /** Whether a flush is in progress (prevents re-entrant flushes). */
   private _flushing: boolean = false;
   /** Whether stop() has been requested. */
   private _stopped: boolean = false;
-  /** Whether start() succeeded (at least one track attached). */
-  private _started: boolean = false;
+  /** Whether the unsupported-browser warning has already been emitted. */
+  private _unavailableWarned: boolean = false;
   /** Recording start timestamp. */
   private _startedAt: Date | null = null;
   /** Recording end timestamp (set on final flush). */
@@ -274,55 +287,54 @@ export class CallRecorder {
     localTrack?: MediaStreamTrack,
     remoteTrack?: MediaStreamTrack
   ): void {
-    if (!this.options.enabled || this._started) {
+    if (!this.options.enabled || this._stopped) {
       return;
     }
 
     // Capability check — Chromium-only. No fallback (see module header).
     if (typeof MediaStreamTrackProcessor !== 'function') {
-      logger.warn(
-        'CallRecorder: MediaStreamTrackProcessor unavailable — recording disabled for this call'
-      );
-      this._emitWarning(RECORDING_UNAVAILABLE);
-      // No-op: call proceeds normally, no capture, no buffer, no POST.
-      this._started = true;
+      if (!this._unavailableWarned) {
+        this._unavailableWarned = true;
+        logger.warn(
+          'CallRecorder: MediaStreamTrackProcessor unavailable — recording disabled for this call'
+        );
+        this._emitWarning(RECORDING_UNAVAILABLE);
+      }
       return;
     }
 
     const tracks = this.options.tracks || (['local', 'remote'] as const);
-    let attached = 0;
+    let attached = false;
 
-    if (tracks.includes('local') && localTrack) {
-      this._attach(localTrack, 'local');
-      attached++;
+    if (tracks.includes('local')) {
+      attached = this._reconcileTrack(localTrack, 'local') || attached;
     }
-    if (tracks.includes('remote') && remoteTrack) {
-      this._attach(remoteTrack, 'remote');
-      attached++;
+    if (tracks.includes('remote')) {
+      attached = this._reconcileTrack(remoteTrack, 'remote') || attached;
     }
 
-    if (attached === 0) {
-      // No tracks available to record — log once and no-op. Do NOT emit
-      // RECORDING_UNAVAILABLE here (that's for the API-missing case); a
-      // missing track is a call-state issue, not a browser-capability issue.
+    if (!this._startedAt && !attached) {
+      // No tracks available to record — do not treat a call-state issue as a
+      // missing browser capability. A later call reconciles late tracks.
       logger.info(
         'CallRecorder: no audio tracks available to record — recording idle for this call',
         { callId: this.callContext.callId }
       );
-      this._started = true;
       return;
     }
 
-    this._startedAt = new Date();
-    this._started = true;
+    if (!this._startedAt) {
+      this._startedAt = new Date();
+    }
     this._scheduleFlush();
 
-    logger.info('CallRecorder: started', {
-      callId: this.callContext.callId,
-      tracksAttached: attached,
-      flushIntervalMs: this._flushIntervalMs(),
-      maxBufferBytes: this._maxBufferBytes(),
-    });
+    if (attached) {
+      logger.info('CallRecorder: active tracks reconciled', {
+        callId: this.callContext.callId,
+        flushIntervalMs: this._flushIntervalMs(),
+        maxBufferBytes: this._maxBufferBytes(),
+      });
+    }
   }
 
   /**
@@ -433,6 +445,7 @@ export class CallRecorder {
    * blocks and _finalize so failed/aborted calls still release resources.
    */
   public cleanup(): void {
+    this._stopped = true;
     this._clearFlushTimer();
     this._cancelReaders();
     this._buffers = { local: [], remote: [] };
@@ -442,33 +455,52 @@ export class CallRecorder {
 
   // ── Internal: capture ──────────────────────────────────────────────
 
-  /**
-   * Attach a MediaStreamTrackProcessor to a track and pump frames into the
-   * ring buffer. Capability check is assumed to have passed in start().
-   */
-  private _attach(track: MediaStreamTrack, kind: RecordingTrackKind): void {
-    // Initialize per-track synthesis state with a random SSRC.
-    this._trackStates[kind] = {
-      ssrc: Math.floor(Math.random() * 0xffffffff) >>> 0,
-      seq: 0,
-      ts: 0,
-    };
+  private _reconcileTrack(
+    track: MediaStreamTrack | undefined,
+    kind: RecordingTrackKind
+  ): boolean {
+    const current = this._bindings[kind];
+    if (current?.track === track) {
+      return false;
+    }
+    if (current) {
+      this._cancelBinding(kind);
+    }
+    if (!track || this._stopped) {
+      this._trackStates[kind] = null;
+      return false;
+    }
+    return this._attach(track, kind);
+  }
 
+  /** Attach a processor and pump frames for one exact active track. */
+  private _attach(track: MediaStreamTrack, kind: RecordingTrackKind): boolean {
     try {
-      // MediaStreamTrackProcessor is a global constructor (Chrome 94+).
       const processor = new MediaStreamTrackProcessor({ track });
-      this._processors.push(processor);
-
       const reader = processor.readable.getReader();
       let cancelled = false;
       const cancel = () => {
+        if (cancelled) {
+          return;
+        }
         cancelled = true;
         reader
           .cancel()
           .catch(() => undefined)
           .finally(() => undefined);
       };
-      this._readerCancellers.push(cancel);
+      const binding: TrackBinding = {
+        track,
+        generation: ++this._bindingGenerations[kind],
+        processor,
+        cancel,
+      };
+      this._bindings[kind] = binding;
+      this._trackStates[kind] = {
+        ssrc: Math.floor(Math.random() * 0xffffffff) >>> 0,
+        seq: 0,
+        ts: 0,
+      };
 
       const pump = async (): Promise<void> => {
         try {
@@ -477,10 +509,24 @@ export class CallRecorder {
             if (done) {
               break;
             }
-            this._onFrame(kind, value as AudioData);
+            const frame = value as AudioData;
+            if (
+              cancelled ||
+              this._stopped ||
+              this._bindings[kind] !== binding ||
+              this._bindingGenerations[kind] !== binding.generation
+            ) {
+              frame.close();
+              break;
+            }
+            this._onFrame(kind, frame);
           }
         } catch (err) {
-          if (!this._stopped) {
+          if (
+            !cancelled &&
+            !this._stopped &&
+            this._bindings[kind] === binding
+          ) {
             logger.warn('CallRecorder: reader loop error', {
               track: kind,
               error: err,
@@ -488,16 +534,17 @@ export class CallRecorder {
           }
         }
       };
-      // Fire-and-forget; cleanup() cancels via this._readerCancellers.
+      // Fire-and-forget; cleanup() cancels the current per-kind binding.
       pump();
+      return true;
     } catch (err) {
-      // Failed to construct the processor for this track — log and continue.
-      // Don't emit RECORDING_UNAVAILABLE (the API exists; this track failed).
+      // Don't emit RECORDING_UNAVAILABLE: the API exists but this track failed.
       logger.warn('CallRecorder: failed to attach track', {
         track: kind,
         error: err,
       });
       this._trackStates[kind] = null;
+      return false;
     }
   }
 
@@ -508,15 +555,20 @@ export class CallRecorder {
   private _onFrame(kind: RecordingTrackKind, audioData: AudioData): void {
     const state = this._trackStates[kind];
     if (!state || this._stopped) {
+      audioData.close();
       return;
     }
 
-    // Pull Float32 PCM samples from the AudioData. AudioData.copyTo writes
-    // planar Float32 into the destination buffer.
-    const numberOfFrames = audioData.numberOfFrames;
-    const float32 = new Float32Array(numberOfFrames);
-    audioData.copyTo(float32, { planeIndex: 0 });
-    audioData.close?.();
+    let numberOfFrames: number;
+    let float32: Float32Array;
+    try {
+      // Pull planar Float32 PCM samples from the AudioData.
+      numberOfFrames = audioData.numberOfFrames;
+      float32 = new Float32Array(numberOfFrames);
+      audioData.copyTo(float32, { planeIndex: 0 });
+    } finally {
+      audioData.close();
+    }
 
     // Raw Float32 PCM bytes (little-endian) — the RTP payload.
     const payloadBytes = new Uint8Array(
@@ -642,15 +694,22 @@ export class CallRecorder {
   }
 
   private _cancelReaders(): void {
-    for (const cancel of this._readerCancellers) {
-      try {
-        cancel();
-      } catch {
-        // ignore — cleanup must not throw
-      }
+    this._cancelBinding('local');
+    this._cancelBinding('remote');
+  }
+
+  private _cancelBinding(kind: RecordingTrackKind): void {
+    const binding = this._bindings[kind];
+    this._bindings[kind] = null;
+    this._trackStates[kind] = null;
+    if (!binding) {
+      return;
     }
-    this._readerCancellers = [];
-    this._processors = [];
+    try {
+      binding.cancel();
+    } catch {
+      // Cleanup and reconciliation must never throw.
+    }
   }
 
   /**


### PR DESCRIPTION
## Problem

When a customer reports that an agent stopped producing audio, network-side RTP evidence only shows that audio was not sent. It does not show whether the browser microphone track was still producing audio at that time.

The existing opt-in `CallRecorder` could also remain attached to stale or placeholder tracks after late inbound media, `replaceTrack()`, or peer recovery.

## Solution

- Capture the exact active outbound sender track and inbound receiver track.
- Reconcile recorder bindings when inbound media arrives, the input device is replaced, or the peer connection changes.
- Prefer active transceivers and retain exact track-event selections rather than depending on sender/receiver collection order.
- Cancel superseded recorder readers without stopping call-owned media tracks, and ignore late frames from stale readers.
- Finalize and upload recording data independently of the normal call-report collector.
- Keep recording explicitly opt-in; the normal call path remains unchanged when disabled.

The captured PCM is represented as diagnostic RTP in the existing PCAP upload path, allowing us to distinguish "the microphone captured silence/no samples" from "audio existed locally but disappeared before or during transmission."

## Browser support

This relies on `MediaStreamTrackProcessor`, so capture is currently available in Chromium-based browsers. Unsupported browsers emit the existing `RECORDING_UNAVAILABLE` warning and continue the call normally.

## Verification

- [x] Full JS test suite: 760/760 passed
- [x] Focused recorder/call suites after commit-hook formatting: 116/116 passed
- [x] Build passed
- [x] TypeScript check passed
- [x] Scoped ESLint passed
- [x] Prettier check passed
- [x] `git diff --check` passed
- [x] Independent WebRTC lifecycle review passed
